### PR TITLE
rename win:toggleFullscreen to win:toggleFullScreen

### DIFF
--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -132,10 +132,10 @@ function window:maximize()
   self:setFrame(screenrect)
 end
 
---- hs.window:toggleFullscreen()
+--- hs.window:toggleFullScreen()
 --- Method
 --- Toggle the fullscreen state of this window.
-function window:toggleFullscreen()
+function window:toggleFullScreen()
     self:setFullScreen(not self:isFullScreen())
 end
 


### PR DESCRIPTION
The change preserves consistency in spelling of `FullScreen` (note the capital S).
Only in `win:toggleFullscreen` the `s` is not capital as opposed to `win:setFullScreen` and `win:isFullScreen`.

This is a breaking change but Hammerspoon is still < 1.0 so this should be ok. 
