### PR TITLE
Implement vimperator-style hints

### DIFF
--- a/extensions/hints/init.lua
+++ b/extensions/hints/init.lua
@@ -12,9 +12,13 @@ local modal_hotkey = hotkey.modal
 --- Variable
 --- This controls the set of characters that will be used for window hints. They must be characters found in hs.keycodes.map
 --- The default is the letters A-Z, the numbers 0-9, and the punctuation characters: -=[];'\\,./\`
-hints.hintChars = {"A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z",
-                   "1","2","3","4","5","6","7","8","9","0",
-                   "-","=","[","]",";","'","\\",",",".","/","`"}
+hints.hintChars = {"A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z"}
+
+--- hs.hints.style
+--- Variable
+--- If this is set to "vimperator", every window hint starts with the first character
+--- of the parent application's title
+hints.style = "vimperator"
 
 local openHints = {}
 local takenPositions = {}
@@ -23,22 +27,75 @@ local modalKey = nil
 
 local bumpThresh = 40^2
 local bumpMove = 80
+
 function hints.bumpPos(x,y)
   for i, pos in ipairs(takenPositions) do
     if ((pos.x-x)^2 + (pos.y-y)^2) < bumpThresh then
       return hints.bumpPos(x,y+bumpMove)
     end
   end
-
   return {x = x,y = y}
 end
 
-function hints.createHandler(char)
-  return function()
-    local win = hintDict[char]
-    if win then win:focus() end
+function hints.addWindow(dict, win)
+  local n = dict['count']
+  if n == nil then
+    dict['count'] = 0
+    n = 0
+  end
+  local m = (n % #hints.hintChars) + 1
+  local char = hints.hintChars[m]
+  if n < #hints.hintChars then
+    dict[char] = win
+  else
+    if type(dict[char]) == "userdata" then
+      -- dict[m] is already occupied by another window
+      -- which me must convert into a new dictionary
+      local otherWindow = dict[char]
+      dict[char] = {}
+      hints.addWindow(dict, otherWindow)
+    end
+    hints.addWindow(dict[char], win)
+  end
+  dict['count'] = dict['count'] + 1
+end
+
+function hints.displayHintsForDict(dict, prefixstring)
+  for key, val in pairs(dict) do
+    if type(val) == "userdata" then -- this is a window
+      local win = val
+      local app = win:application()
+      local fr = win:frame()
+      local sfr = win:screen():frame()
+      if app and win:title() ~= "" and win:isStandard() then
+        local c = {x = fr.x + (fr.w/2) - sfr.x, y = fr.y + (fr.h/2) - sfr.y}
+        c = hints.bumpPos(c.x, c.y)
+        if c.y < 0 then
+          print("hs.hints: Skipping offscreen window: "..win:title())
+        else
+          -- print(win:title().." x:"..c.x.." y:"..c.y) -- debugging
+          local hint = hints.new(c.x, c.y, prefixstring .. key, app:bundleID(), win:screen())
+          table.insert(takenPositions, c)
+          table.insert(openHints, hint)
+        end
+      end
+    elseif type(val) == "table" then -- this is another window dict
+      hints.displayHintsForDict(val, prefixstring .. key)
+    end
+  end
+end
+
+function hints.processChar(char)
+  if hintDict[char] ~= nil then
     hints.closeHints()
-    modalKey:exit()
+    if type(hintDict[char]) == "userdata" then
+      if hintDict[char] then hintDict[char]:focus() end
+      modalKey:exit()
+    elseif type(hintDict[char]) == "table" then
+      hintDict = hintDict[char]
+      takenPositions = {}
+      hints.displayHintsForDict(hintDict, "")
+    end
   end
 end
 
@@ -46,8 +103,8 @@ function hints.setupModal()
   k = modal_hotkey.new(nil, nil)
   k:bind({}, 'escape', function() hints.closeHints(); k:exit() end)
 
-  for i,c in ipairs(hints.hintChars) do
-    k:bind({}, c, hints.createHandler(c))
+  for _, c in ipairs(hints.hintChars) do
+    k:bind({}, c, function() hints.processChar(c) end)
   end
   return k
 end
@@ -63,54 +120,41 @@ end
 ---  * None
 ---
 --- Notes:
----  * If there are more windows open than there are characters available in hs.hints.hintChars, not all windows will receive a hint, and an error will be logged to the Hammerspoon Console
+---  * If there are more windows open than there are characters available in hs.hints.hintChars,
+---    we resort to multi-character hints
+---  * If hints.style is set to "vimperator", every window hint is prefixed with the first
+---    character of the parent application's name
 function hints.windowHints()
   if (modalKey == nil) then
     modalKey = hints.setupModal()
   end
   hints.closeHints()
-
-  local numHints = 0
-  for i,_ in ipairs(hints.hintChars) do
-      numHints = numHints + 1
-  end
-
-  for i,win in ipairs(window.allWindows()) do
+  hintDict = {}
+  for i, win in ipairs(window.allWindows()) do
     local app = win:application()
-    local fr = win:frame()
-    local sfr = win:screen():frame()
-    if app and win:title() ~= "" and win:isStandard() then
-      local c = {x = fr.x + (fr.w/2) - sfr.x, y = fr.y + (fr.h/2) - sfr.y}
-      c = hints.bumpPos(c.x, c.y)
-      if c.y < 0 then
-          print("hs.hints: Skipping offscreen window: "..win:title())
-      else
-        --print(win:title().." x:"..c.x.." y:"..c.y) -- debugging
-        -- Check there are actually hint keys available
-        local numOpenHints = 0
-        for x,_ in ipairs(openHints) do
-            numOpenHints = numOpenHints + 1
+    if hints.style == "vimperator" then
+      if app and win:title() ~= "" and win:isStandard() then
+        local appchar = string.upper(string.sub(app:title(), 1, 1))
+        modalKey:bind({}, appchar, function() hints.processChar(appchar) end)
+        if hintDict[appchar] == nil then
+          hintDict[appchar] = {}
         end
-        if numOpenHints < numHints then
-          local hint = hints.new(c.x,c.y,hints.hintChars[numOpenHints+1],app:bundleID(),win:screen())
-          hintDict[hints.hintChars[numOpenHints+1]] = win
-          table.insert(takenPositions, c)
-          table.insert(openHints, hint)
-        else
-          print("hs.hints: Error: more windows than we have hint keys defined. See docs for hs.hints.hintChars")
-        end
+        hints.addWindow(hintDict[appchar], win)
       end
+    else
+      hints.addWindow(hintDict, win)
     end
   end
+  takenPositions = {}
+  hints.displayHintsForDict(hintDict, "")
   modalKey:enter()
 end
 
 function hints.closeHints()
-  for i, hint in ipairs(openHints) do
+  for _, hint in ipairs(openHints) do
     hint:close()
   end
   openHints = {}
-  hintDict = {}
   takenPositions = {}
 end
 


### PR DESCRIPTION
Add hs.hints.style variable to control hinting style:

hs.hints.style = "vimperator" creates multi-character hints, with the
first character of each hint corresponding to the first character of the
parent application's title

hs.hints.style = "default" (or anything else) creates the usual
single-character hints, unless the available hintChars are exhausted. In
that case, Hammerspoon switches to multi-char hints (but without
application title prefixes)
