### PR TITLE
add isMainThread function to hs.crash

### DIFF
--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -3,6 +3,7 @@
 #import "MJUserNotificationManager.h"
 #import "MJConfigUtils.h"
 #import "variables.h"
+#import <pthread.h>
 
 static lua_State* MJLuaState;
 static int evalfn;
@@ -10,6 +11,8 @@ static int evalfn;
 /// === hs ===
 ///
 /// Core Hammerspoon functionality.
+
+pthread_t mainthreadid;
 
 static void(^loghandler)(NSString* str);
 void MJLuaSetupLogHandler(void(^blk)(NSString* str)) {
@@ -80,6 +83,7 @@ static luaL_Reg corelib[] = {
 };
 
 void MJLuaSetup(void) {
+    mainthreadid = pthread_self();
     if (MJLuaState)
         lua_close(MJLuaState);
     

--- a/extensions/crash/internal.m
+++ b/extensions/crash/internal.m
@@ -24,6 +24,27 @@ static int burnTheWorld(lua_State *L __unused) {
 
 extern pthread_t mainthreadid;
 
+/// hs.crash.isMainThread() -> bool
+/// Method
+/// Tells you whether you are executing Lua on the main thread.
+///
+/// Notes:
+/// * This is for testing purposes only, you are extremely unlikely to need this in normal Hammerspoon usage
+/// * When developing a new extension, especially one that involves handlers for outside events, this function
+///   can be used to make sure your event handling happens on the main thread. You can use this Lua code
+///   to make Hammerspoon abort if anything happens on a different thread:
+///   ```lua
+///   local function crashifnotmain(reason)
+///     print("crashifnotmain called with reason", reason) -- may want to remove this, very verbose otherwise
+///     if not hs.crash.isMainThread() then
+///       print("not in main thread, crashing")
+///       hs.crash.crash()
+///     end
+///   end
+///
+///   debug.sethook(crashifnotmain, 'c')
+///   ```
+
 static int isMainThread(lua_State *L)
 {
     pthread_t id = pthread_self();

--- a/extensions/crash/internal.m
+++ b/extensions/crash/internal.m
@@ -1,6 +1,7 @@
 #import <Cocoa/Cocoa.h>
 #import <Carbon/Carbon.h>
 #import <lauxlib.h>
+#import <pthread.h>
 
 // ----------------------- API Implementation ---------------------
 
@@ -21,10 +22,21 @@ static int burnTheWorld(lua_State *L __unused) {
     return 0;
 }
 
+extern pthread_t mainthreadid;
+
+static int isMainThread(lua_State *L)
+{
+    pthread_t id = pthread_self();
+
+    lua_pushboolean(L, pthread_equal(mainthreadid, id));
+    return 1;
+}
+
 // ----------------------- Lua/hs glue GAR ---------------------
 
 static const luaL_Reg crashlib[] = {
     {"crash", burnTheWorld},
+    {"isMainThread", isMainThread},
 
     {}
 };


### PR DESCRIPTION
With this new function, you can add this to init.lua:

```lua
local function crashifnotmain(reason)
  print("crashifnotmain called with reason", reason) -- may want to remove this, very verbose otherwise
  if not hs.crash.isMainThread() then
    print("not in main thread, crashing")
    hs.crash.crash()
  end
end

debug.sethook(crashifnotmain, 'c')
```

allowing you to abort (causing backtraces in XCode, a Crashlytics report, etc.) when something is not happening on the main thread.

Pre 5d9130325f4635c7b66c72e0b5bec9257f04c447, this Lua code triggers it: `function mywifiwatcher() hs.alert.show(hs.wifi.currentNetwork()) end wifiwatcher = hs.wifi.watcher.new(mywifiwatcher) wifiwatcher:start()`
