### PR TITLE
Changing how app list is populated for hints

### DIFF
--- a/extensions/hints/init.lua
+++ b/extensions/hints/init.lua
@@ -78,7 +78,7 @@ function hints.displayHintsForDict(dict, prefixstring)
       local app = win:application()
       local fr = win:frame()
       local sfr = win:screen():frame()
-      if app and win:title() ~= "" and win:isStandard() then
+      if app and ((fr.w > 0 and fr.h > 0) or win:title() ~= "") and win:isStandard() then
         local c = {x = fr.x + (fr.w/2) - sfr.x, y = fr.y + (fr.h/2) - sfr.y}
         c = hints.bumpPos(c.x, c.y)
         if c.y < 0 then


### PR DESCRIPTION
Possible fix for #183 

I'm not sure how to build Hammerspoon, so I've not tested this, but could this potentially be a fix for #183? 

Instead of just checking to see if the window has a title, I see if the window has a width and a height or a title.