### PR TITLE
Slight enhancement to the vimperator option

### DIFF
--- a/extensions/hints/init.lua
+++ b/extensions/hints/init.lua
@@ -104,8 +104,17 @@ function hints.processChar(char)
       modalKey:exit()
     elseif type(hintDict[char]) == "table" then
       hintDict = hintDict[char]
-      takenPositions = {}
-      hints.displayHintsForDict(hintDict, "")
+      local hintDictLength = 0
+      for _ in pairs(hintDict) do hintDictLength = hintDictLength + 1 end
+      if hintDictLength == 1 then
+        for key, val in ipairs(hintDict) do
+          v:focus()
+          modalKey:exit()
+        end
+      else
+        takenPositions = {}
+        hints.displayHintsForDict(hintDict, "")
+      end
     end
   end
 end


### PR DESCRIPTION
After hitting the first key, if there is just one window remaining, it 
will automatically select that window. For example, if you have
3 windows open, and the shortcuts are "xa", "xb", and "yc", hitting "y"
will immediately focus the "yc" window. Previously, you would have to
hit "y" then "c" to focus the "yc" window.