### PR TITLE
Fixing vimperator enhancement

### DIFF
--- a/extensions/hints/init.lua
+++ b/extensions/hints/init.lua
@@ -104,13 +104,9 @@ function hints.processChar(char)
       modalKey:exit()
     elseif type(hintDict[char]) == "table" then
       hintDict = hintDict[char]
-      local hintDictLength = 0
-      for _ in pairs(hintDict) do hintDictLength = hintDictLength + 1 end
-      if hintDictLength == 1 then
-        for key, val in ipairs(hintDict) do
-          v:focus()
-          modalKey:exit()
-        end
+      if hintDict.count == 1 then
+        hintDict.A:focus()
+        modalKey:exit()
       else
         takenPositions = {}
         hints.displayHintsForDict(hintDict, "")


### PR DESCRIPTION
Now when using the vimperator version of hints, after pressing the first key, if there is only one possible window remaining, it will automatically be selected.