### PR TITLE
add "windows" parameter to hints.windowHints

### DIFF
--- a/extensions/hints/init.lua
+++ b/extensions/hints/init.lua
@@ -146,13 +146,16 @@ end
 ---    we resort to multi-character hints
 ---  * If hints.style is set to "vimperator", every window hint is prefixed with the first
 ---    character of the parent application's name
-function hints.windowHints()
+function hints.windowHints(windows)
+  
+  windows = windows or window.allWindows()
+
   if (modalKey == nil) then
     modalKey = hints.setupModal()
   end
   hints.closeHints()
   hintDict = {}
-  for i, win in ipairs(window.allWindows()) do
+  for i, win in ipairs(windows) do
     local app = win:application()
     if app and win:isStandard() then
       if hints.style == "vimperator" then


### PR DESCRIPTION
Hello, I'm actually new to mjolnir/hammerspoon (and lua), I started today with mjolnir and then realized hammerspoon was more active, 

in the original mjolnir hints extension there was the hints.appHints(app) function which let you find windows by app, but in hammerspoon version that option is missing? I think the easiest solution is to just add an optional "windows" parameter to hints.windowHints, that way we can do stuff like:

```
hs.hotkey.bind(hyper_mod,"f",hs.hints.windowHints)
hs.hotkey.bind(hyper_mod,"a",function() hs.hints.windowHints(hs.window.focusedWindow():application():allWindows()) end)
hs.hotkey.bind(hyper_mod,"s",function() hs.hints.windowHints(hs.appfinder.appFromName("Sublime Text"):allWindows()) end)
```
