### PR TITLE
Remove alerts from playback controls for iTunes and Spotify

### DIFF
--- a/extensions/itunes/init.lua
+++ b/extensions/itunes/init.lua
@@ -25,7 +25,6 @@ end
 ---  * None
 function itunes.play()
   tell('playpause')
-  alert.show(' ▶', 0.5)
 end
 
 --- hs.itunes.pause()
@@ -39,7 +38,6 @@ end
 ---  * None
 function itunes.pause()
   tell('pause')
-  alert.show(' ◼', 0.5)
 end
 
 --- hs.itunes.next()
@@ -53,7 +51,6 @@ end
 ---  * None
 function itunes.next()
   tell('next track')
-  alert.show(' ⇥', 0.5)
 end
 
 --- hs.itunes.previous()
@@ -67,7 +64,6 @@ end
 ---  * None
 function itunes.previous()
   tell('previous track')
-  alert.show(' ⇤', 0.5)
 end
 
 --- hs.itunes.displayCurrentTrack()

--- a/extensions/spotify/init.lua
+++ b/extensions/spotify/init.lua
@@ -25,7 +25,6 @@ end
 ---  * None
 function spotify.play()
   tell('playpause')
-  alert.show(' ▶', 0.5)
 end
 
 --- hs.spotify.pause()
@@ -39,7 +38,6 @@ end
 ---  * None
 function spotify.pause()
   tell('pause')
-  alert.show(' ◼', 0.5)
 end
 
 --- hs.spotify.next()
@@ -53,7 +51,6 @@ end
 ---  * None
 function spotify.next()
   tell('next track')
-  alert.show(' ⇥', 0.5)
 end
 
 --- hs.spotify.previous()
@@ -67,7 +64,6 @@ end
 ---  * None
 function spotify.previous()
   tell('previous track')
-  alert.show(' ⇤', 0.5)
 end
 
 --- hs.spotify.displayCurrentTrack()


### PR DESCRIPTION
I don't think Hammerspoon should show alerts for iTunes and Spotify playback commands.

`hs.alert` is something that config file authors are able to use for this functionality We can remove it from the base extensions.