### PR TITLE
Improve hs.hints: Fix bugs and add window title feature

### DIFF
--- a/extensions/hints/init.lua
+++ b/extensions/hints/init.lua
@@ -73,7 +73,7 @@ end
 
 function hints.displayHintsForDict(dict, prefixstring)
   for key, val in pairs(dict) do
-    if type(val) == "userdata" then -- this is a window
+    if type(val) == "userdata" and val:screen() then -- this is an onscreen window
       local win = val
       local app = win:application()
       local fr = win:frame()

--- a/extensions/hints/internal.m
+++ b/extensions/hints/internal.m
@@ -75,7 +75,14 @@ static NSDictionary *hintTextAttributes;
 - (void)setText:(NSString *)newText {
     text = newText;
     textSize = [text sizeWithAttributes:hintTextAttributes];
-    //self.frame = NSMakeRect(self.frame.origin.x, self.frame.origin.y, textSize.width + 100, hintHeight);
+    // Might need to resize if text is long
+    CGFloat newWidth = textSize.width + hintHeight/2 + 20;
+    if(newWidth > 100) {
+      self.frame = NSMakeRect(self.frame.origin.x, self.frame.origin.y, newWidth, hintHeight);
+      NSRect newWinFrame = self.window.frame;
+      newWinFrame.size.width = newWidth;
+      [[self window] setFrame:newWinFrame display:YES];
+    }
 }
 
 - (void)drawRect:(NSRect __unused)dirtyRect {
@@ -130,9 +137,9 @@ static NSDictionary *hintTextAttributes;
         [self makeKeyAndOrderFront:NSApp];
         [self setLevel:(NSScreenSaverWindowLevel - 1)];
         HintView *label = [[HintView alloc] initWithFrame:frame fontName:fontName fontSize:fontSize];
-        [label setText:txt];
-        [label setIconFromBundleID:bundle];
         [self setContentView:label];
+        [label setIconFromBundleID:bundle];
+        [label setText:txt];
     }
     return self;
 }


### PR DESCRIPTION
Hi, original author of `mjolnir.th.hints` here. I switched to Hammerspoon recently since it included my hints module (and improved it). 

Recently I encountered a bug triggered by some windows not having an associated screen that caused the hints operation to crash. This PR fixes that issue by checking if windows have a screen.

I also added an improved version of a feature that was in my original module which is showing titles in hints. When switching within an app and when using the vimperator mode the icon isn't always useful so showing the window title is very helpful for knowing which window to switch to. However, it gets really cluttered when there are too many hints on the screen.

Thus this PR adds a new variable `hints.showTitleThresh` (default 4) where if there are more than that many windows it won't show titles. To do this I added some auto-sizing frame logic to the Objective-C and some hint counting logic to the Lua.

I've tested this code with the vimperator mode on and off and checking different window counts are properly thresholded. It properly counts even the nested tables used in the vimperator mode.

Here's what titles look like:
![screen shot 2015-04-02 at 4 05 40 pm](https://cloud.githubusercontent.com/assets/887610/6972502/3985e56c-d952-11e4-8240-28a0166f4af0.png)

