### PR TITLE
Correct the naming of hs.screen:getGamma(), hs.screen:restoreGamma(), and hs.screen:setGamma() in the documentation

### DIFF
--- a/extensions/screen/internal.m
+++ b/extensions/screen/internal.m
@@ -213,7 +213,7 @@ static int screen_setMode(lua_State* L) {
     return 1;
 }
 
-/// hs.screen.gammaRestore()
+/// hs.screen.restoreGamma()
 /// Function
 /// Restore the gamma settings to defaults
 ///
@@ -231,7 +231,7 @@ static int screen_gammaRestore(lua_State* L __unused) {
     return 0;
 }
 
-/// hs.screen:gammaGet() -> [whitepoint, blackpoint] or nil
+/// hs.screen:getGamma() -> [whitepoint, blackpoint] or nil
 /// Method
 /// Gets the current whitepoint and blackpoint of the screen
 ///
@@ -405,7 +405,7 @@ void displayReconfigurationCallback(CGDirectDisplayID display, CGDisplayChangeSu
     return;
 }
 
-/// hs.screen:gammaSet(whitepoint, blackpoint) -> boolean
+/// hs.screen:setGamma(whitepoint, blackpoint) -> boolean
 /// Method
 /// Sets the current white point and black point of the screen
 ///


### PR DESCRIPTION
This pull request corrects the naming of these gamma-related functions (from 0dcedf6855f4782c200baaa5c56d26e52bb9d632) in the documentation.

Note that the Objective-C implementations of these functions in `extensions/screen/internal.m` still use the old names (with "gamma" as the first word in the function). This seemed fine to leave for now, but could be changed in a future commit.

I did not opt to rename the Lua functions to `gammaGet() / Restore() / Set()` out of convention. Objective-C APIs tend to have the verb as the first word of the function (`-setFrame:`), as do the other Hammerspoon APIs (`hs.window:setFrame()`).