### PR TITLE
Add hs.drawing:setTextFont() for changing the font of an hs.drawing.text object

### DIFF
--- a/extensions/drawing/internal.m
+++ b/extensions/drawing/internal.m
@@ -691,6 +691,35 @@ static int drawing_setText(lua_State *L) {
     return 1;
 }
 
+/// hs.drawing:setTextFont(fontname) -> drawingObject
+/// Method
+/// Sets the font of a drawing object
+///
+/// Parameters:
+///  * fontname - A string containing the name of the font to use
+///
+/// Returns:
+///  * The drawing object
+///
+/// Notes:
+///  * This method should only be used on text drawing objects
+static int drawing_setTextFont(lua_State *L) {
+    drawing_t *drawingObject = get_item_arg(L, 1);
+    HSDrawingWindow *drawingWindow = (__bridge HSDrawingWindow *)drawingObject->window;
+    HSDrawingViewText *drawingView = (HSDrawingViewText *)drawingWindow.contentView;
+
+    if ([drawingView isKindOfClass:[HSDrawingViewText class]]) {
+        CGFloat pointSize = drawingView.textField.font.pointSize;
+        NSString *fontName = [NSString stringWithUTF8String:lua_tostring(L, 2)];
+        [drawingView.textField setFont:[NSFont fontWithName:fontName size:pointSize]];
+    } else {
+        showError(L, ":setTextFont() called on an hs.drawing object that isn't a text object");
+    }
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
 /// hs.drawing:setTextSize(size) -> drawingObject
 /// Method
 /// Sets the text size of a drawing object
@@ -709,7 +738,9 @@ static int drawing_setTextSize(lua_State *L) {
     HSDrawingViewText *drawingView = (HSDrawingViewText *)drawingWindow.contentView;
 
     if ([drawingView isKindOfClass:[HSDrawingViewText class]]) {
-        [drawingView.textField setFont:[NSFont systemFontOfSize:lua_tonumber(L, 2)]];
+        CGFloat pointSize = lua_tonumber(L, 2);
+        NSString *fontName = drawingView.textField.font.fontName;
+        [drawingView.textField setFont:[NSFont fontWithName:fontName size:pointSize]];
     } else {
         showError(L, ":setTextSize() called on an hs.drawing object that isn't a text object");
     }
@@ -1139,6 +1170,7 @@ static const luaL_Reg drawing_metalib[] = {
     {"setFillGradient", drawing_setFillGradient},
     {"setTextColor", drawing_setTextColor},
     {"setTextSize", drawing_setTextSize},
+    {"setTextFont", drawing_setTextFont},
     {"setText", drawing_setText},
     {"setImagePath", drawing_setImagePath},
     {"bringToFront", drawing_bringToFront},


### PR DESCRIPTION
This change introduces a new function in `hs.drawing`, `hs.drawing:setTextFont()`. It accepts a string indicating the name of the font to use for the `hs.drawing.text` object. It will preserve the text size set in `hs.drawing:setTextSize()`

This also augments `hs.drawing:setTextSize()` to preserve the font that was set on the `hs.drawing` object.

Example configuration using `hs.drawing.setTextFont()`:

    text = hs.drawing.text(hs.geometry.rect(50, 50, 1000, 1000), "Zanch")
    text:setTextSize(60):sendToBack():show()
    text:setTextFont('Zapfino')

will produce:

![screen shot 2015-04-24 at 10 22 23 pm](https://cloud.githubusercontent.com/assets/137576/7331704/75457830-ead0-11e4-8985-2eece4c10432.png)

Thanks for your review!
