### PR TITLE
allow external readonly access to MJLuaState

### DIFF
--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -154,3 +154,9 @@ NSString* MJLuaRunString(NSString* command) {
 
     return str;
 }
+
+// C-Code helper to return current active LuaState. Useful for callbacks to
+// verify stored LuaState still matches active one if GC fails to clear it.
+lua_State* MJGetActiveLuaState() {
+  return MJLuaState ;
+}


### PR DESCRIPTION
allows module to include

     extern lua_State* MJGetActiveLuaState() ;

to get the current LuaState for comparison to stored values in callbacks... allows an extra check in case GC doesn't or isn't able to remove the callback during a restart or reload.