### PR TITLE
Fix chained actions on hs.window

### DIFF
--- a/extensions/timer/internal.m
+++ b/extensions/timer/internal.m
@@ -202,7 +202,7 @@ static int meta_gc(lua_State* __unused L) {
     return 0;
 }
 
-/// hs.timer.time() -> sec
+/// hs.timer.secondsSinceEpoch() -> sec
 /// Function
 /// Gets the number of seconds since the epoch, including the fractional part; this has much better precision than `os.time()`, which is limited to whole seconds.
 ///
@@ -211,7 +211,7 @@ static int meta_gc(lua_State* __unused L) {
 ///
 /// Returns:
 ///  * The number of seconds since the epoch
-static int timer_gettime(lua_State *L)
+static int timer_getSecondsSinceEpoch(lua_State *L)
 {
     struct timeval v;
     gettimeofday(&v, (struct timezone *) NULL);
@@ -234,7 +234,7 @@ static const luaL_Reg timerLib[] = {
     {"doAfter",    timer_doAfter},
     {"new",        timer_new},
     {"usleep",     timer_usleep},
-    {"time",       timer_gettime},
+    {"secondsSinceEpoch",       timer_getSecondsSinceEpoch},
     {NULL,          NULL}
 };
 

--- a/extensions/timer/internal.m
+++ b/extensions/timer/internal.m
@@ -1,4 +1,5 @@
 #import <Cocoa/Cocoa.h>
+#import <sys/time.h>
 #import <lua/lauxlib.h>
 #import "../hammerspoon.h"
 
@@ -201,6 +202,25 @@ static int meta_gc(lua_State* __unused L) {
     return 0;
 }
 
+/// hs.timer.time() -> sec
+/// Function
+/// Gets the number of seconds since the epoch, including the fractional part; this has much better precision than `os.time()`, which is limited to whole seconds.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * The number of seconds since the epoch
+static int timer_gettime(lua_State *L)
+{
+    struct timeval v;
+    gettimeofday(&v, (struct timezone *) NULL);
+    /* Unix Epoch time (time since January 1, 1970 (UTC)) */
+    lua_pushnumber(L, v.tv_sec + v.tv_usec/1.0e6);
+    return 1;
+}
+
+
 // Metatable for created objects when _new invoked
 static const luaL_Reg timer_metalib[] = {
     {"start",   timer_start},
@@ -214,6 +234,7 @@ static const luaL_Reg timerLib[] = {
     {"doAfter",    timer_doAfter},
     {"new",        timer_new},
     {"usleep",     timer_usleep},
+    {"time",       timer_gettime},
     {NULL,          NULL}
 };
 

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -105,6 +105,7 @@ function window:setFrame(f, duration)
     self:setTopLeft(f)
     self:setSize(f)
   end
+  return self
 end
 
 

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -152,7 +152,7 @@ function window:setFrame(f, duration)
   end
   local id = self:id()
   stopAnimation(self,id)
-  if duration<=0 then return self:_setFrame(f) end
+  if duration<=0 or not id then return self:_setFrame(f) end
   local frame = self:_frame()
   if not animations[id] then animations[id] = {window=self} end
   local anim = animations[id]

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -72,7 +72,7 @@ end
 --- Returns:
 ---  * A rect-table containing the co-ordinates of the top left corner of the window, and it's width and height
 function window:frame()
-  if cachedFrames[self] then print('cachedframe:',hs.inspect(cachedFrames[self])) return cachedFrames[self] end
+  if cachedFrames[self] then return cachedFrames[self] end
   local s = self:size()
   local tl = self:topLeft()
   return {x = tl.x, y = tl.y, w = s.w, h = s.h}

--- a/extensions/window/internal.m
+++ b/extensions/window/internal.m
@@ -135,7 +135,7 @@ static NSSize get_window_size(AXUIElementRef win) {
 
 static int window_transform(lua_State* L) {
     if (currentAnimation) {
-        currentAnimation.currentProgress = 1.0;
+        //currentAnimation.currentProgress = 1.0;
         [currentAnimation stopAnimation];
     }
 
@@ -170,7 +170,7 @@ static int window_transform(lua_State* L) {
 
 static int window_gc(lua_State* L) {
     if (currentAnimation) {
-        currentAnimation.currentProgress = 1.0;
+        //currentAnimation.currentProgress = 1.0;
         [currentAnimation stopAnimation];
     }
     AXUIElementRef win = get_window_arg(L, 1);
@@ -319,7 +319,7 @@ static int window_isstandard(lua_State* L) {
 ///
 /// Returns:
 ///  * A point-table containing the absolute co-ordinates of the top left corner of the window
-static int window_topleft(lua_State* L) {
+static int window__topleft(lua_State* L) {
     AXUIElementRef win = get_window_arg(L, 1);
     CGPoint topLeft = get_window_topleft(win);
     geom_pushpoint(L, topLeft);
@@ -335,7 +335,7 @@ static int window_topleft(lua_State* L) {
 ///
 /// Returns:
 ///  * A size-table containing the width and height of the window
-static int window_size(lua_State* L) {
+static int window__size(lua_State* L) {
     AXUIElementRef win = get_window_arg(L, 1);
     CGSize size = get_window_size(win);
     geom_pushsize(L, size);
@@ -351,9 +351,9 @@ static int window_size(lua_State* L) {
 ///
 /// Returns:
 ///  * The `hs.window` object
-static int window_settopleft(lua_State* L) {
+static int window__settopleft(lua_State* L) {
     if (currentAnimation) {
-        currentAnimation.currentProgress = 1.0;
+        //currentAnimation.currentProgress = 1.0;
         [currentAnimation stopAnimation];
     }
     AXUIElementRef win = get_window_arg(L, 1);
@@ -377,9 +377,9 @@ static int window_settopleft(lua_State* L) {
 ///
 /// Returns:
 ///  * The `hs.window` object
-static int window_setsize(lua_State* L) {
+static int window__setsize(lua_State* L) {
     if (currentAnimation) {
-        currentAnimation.currentProgress = 1.0;
+        //currentAnimation.currentProgress = 1.0;
         [currentAnimation stopAnimation];
     }
     AXUIElementRef win = get_window_arg(L, 1);
@@ -423,7 +423,7 @@ cleanup:
 ///  * The `hs.window` object
 static int window_togglezoom(lua_State* L) {
     if (currentAnimation) {
-        currentAnimation.currentProgress = 1.0;
+        //currentAnimation.currentProgress = 1.0;
         [currentAnimation stopAnimation];
     }
     window_pressbutton(L, kAXZoomButtonAttribute);
@@ -710,10 +710,10 @@ static const luaL_Reg windowlib[] = {
     {"subrole", window_subrole},
     {"role", window_role},
     {"isStandard", window_isstandard},
-    {"topLeft", window_topleft},
-    {"size", window_size},
-    {"setTopLeft", window_settopleft},
-    {"setSize", window_setsize},
+    {"_topLeft", window__topleft},
+    {"_size", window__size},
+    {"_setTopLeft", window__settopleft},
+    {"_setSize", window__setsize},
     {"transform", window_transform},
     {"minimize", window_minimize},
     {"unminimize", window_unminimize},


### PR DESCRIPTION
Workaround for issues with chained actions when hs.window.animationDuration>0.
(EDIT: AFAICT (and that's not very far at all) the problem seems to be that `currentAnimation.currentProgress = 1.0;` does *not* synchronously call `setCurrentProgress:(NSAnimationProgress)progress`, so the window attributes do not get immediately set. There's probably an obvious fix for that - which is beyond my non-existing ObjC expertise - that should result in *correct* (albeit still "weird" (windows jumping around)) behaviour)

Ideally the (ugly) hs.timer should be removed, and the corresponding cleanup (`init.lua` row 98) should instead happen in a function that in turn gets called from animationDidStop/End in `internal.m`. I don't know if that's possible; if it is, I surely have no idea how.

Example for testing:
```lua
local w=hs.window.focusedWindow()
w:moveToScreen(w:screen():next()):moveToScreen(w:screen():previous()):moveToUnit({x=0,y=0,w=0.5,h=0.5})
```
The `moveToScreen`s should cancel out and the window should just move to the top left quadrant of its current screen, if not already there.

-----

The changes seem potentially dangerous wrt GC (see comment) *and* lack thereof if the weak tables don't work as I expect (I don't use them very often), so close scrutiny/testing is warranted.

(@cmsj suggested on IRC as a possible alternative to strongly advise, in the documentation, to set `animationDuration` to 0 if any chaining might occur)