### PR TITLE
Make hs.screen:toEast etc stricter and more sensible

### DIFF
--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -44,6 +44,7 @@ function screen:next()
   return screens[i]
 end
 
+
 --- hs.screen:previous() -> screen
 --- Method
 --- Returns the screen 'before' this one (I have no idea how they're ordered though); this method wraps around to the last screen.
@@ -54,7 +55,18 @@ function screen:previous()
   return screens[i]
 end
 
-local function first_screen_in_direction(screen, numrotations)
+local min,max=math.min,math.max
+local function projection(base, rect) -- like hs.geometry,intersectionRect, but better
+  local basex,basey,basex2,basey2=base.x,base.y,base.x+base.w,base.y+base.h
+  local rectx,recty,rectx2,recty2=rect.x,rect.y,rect.x+(rect.w or 0),rect.y+(rect.h or 0)
+  if basex<rectx then rectx=min(basex2,rectx) rectx2=min(basex2,rectx2)
+  else rectx=max(basex,rectx) rectx2=max(basex,rectx2) end
+  if basey<recty then recty=min(basey2,recty) recty2=min(basey2,recty2)
+  else recty=max(basey,recty) recty2=max(basey,recty2) end
+  return {x=rectx,y=recty,w=rectx2-rectx,h=recty2-recty}
+end
+
+local function first_screen_in_direction(screen, numrotations, from, strict)
   if #screen.allScreens() == 1 then
     return nil
   end
@@ -68,7 +80,8 @@ local function first_screen_in_direction(screen, numrotations)
   -- thanks mark!
 
   local otherscreens = fnutils.filter(screen.allScreens(), function(s) return s ~= screen end)
-  local startingpoint = geometry.rectMidPoint(screen:fullFrame())
+  local myf=screen:fullFrame()
+  local startingpoint = geometry.rectMidPoint(from and projection(myf,from) or myf)
   local closestscreens = {}
 
   for _, s in pairs(otherscreens) do
@@ -89,17 +102,17 @@ local function first_screen_in_direction(screen, numrotations)
     end
   end
 
- -- exclude screens without any horizontal/vertical overlap
-  local myf=screen:fullFrame()
-  for i=#closestscreens,1,-1 do
-    local of=closestscreens[i].s:fullFrame()
-    if numrotations==1 or numrotations==3 then
-      if of.x+of.w-1<myf.x or myf.x+myf.w-1<of.x then table.remove(closestscreens,i) end
-    else
-      if of.y+of.h-1<myf.y or myf.y+myf.h-1<of.y then table.remove(closestscreens,i) end
+  if strict or screen.strictScreenInDirection then
+    -- exclude screens without any horizontal/vertical overlap
+    for i=#closestscreens,1,-1 do
+      local of=closestscreens[i].s:fullFrame()
+      if numrotations==1 or numrotations==3 then
+        if of.x+of.w-1<myf.x or myf.x+myf.w-1<of.x then table.remove(closestscreens,i) end
+      else
+        if of.y+of.h-1<myf.y or myf.y+myf.h-1<of.y then table.remove(closestscreens,i) end
+      end
     end
   end
-
   table.sort(closestscreens, function(a, b) return a.score < b.score end)
 
   if #closestscreens > 0 then
@@ -109,24 +122,42 @@ local function first_screen_in_direction(screen, numrotations)
   end
 end
 
+--- hs.screen.strictScreenInDirection
+--- Variable
+--- If set to `true`, the methods `hs.screen:toEast()`, `:toNorth()` etc. will disregard screens that lie perpendicularly to the desired axis
+screen.strictScreenInDirection = false
+
 --- hs.screen:toEast()
 --- Method
---- Get the first screen to the east of this one, ordered by proximity.
-function screen:toEast()  return first_screen_in_direction(self, 0) end
+--- Get the first screen to the east of this one, ordered by proximity to its center or a specified point.
+---
+--- Parameters:
+---   * from - An `hs.geometry.rect` or `hs.geometry.point` object; if omitted, the geometric center of this screen will be used
+---   * strict - If `true`, disregard screens that lie completely above or below this one (alternatively, set `hs.screen.strictScreenInDirection`)
+function screen:toEast(...)  return first_screen_in_direction(self, 0, ...) end
 
 --- hs.screen:toWest()
 --- Method
---- Get the first screen to the west of this one, ordered by proximity.
-function screen:toWest()  return first_screen_in_direction(self, 2) end
+--- Get the first screen to the west of this one, ordered by proximity to its center or a specified point.
+--- Parameters:
+---   * from - An `hs.geometry.rect` or `hs.geometry.point` object; if omitted, the geometric center of this screen will be used
+---   * strict - If `true`, disregard screens that lie completely above or below this one (alternatively, set `hs.screen.strictScreenInDirection`)
+function screen:toWest(...)  return first_screen_in_direction(self, 2, ...) end
 
 --- hs.screen:toNorth()
 --- Method
---- Get the first screen to the north of this one, ordered by proximity.
-function screen:toNorth() return first_screen_in_direction(self, 1) end
+--- Get the first screen to the north of this one, ordered by proximity to its center or a specified point.
+--- Parameters:
+---   * from - An `hs.geometry.rect` or `hs.geometry.point` object; if omitted, the geometric center of this screen will be used
+---   * strict - If `true`, disregard screens that lie completely to the left or to the right of this one (alternatively, set `hs.screen.strictScreenInDirection`)
+function screen:toNorth(...) return first_screen_in_direction(self, 1, ...) end
 
 --- hs.screen:toSouth()
 --- Method
---- Get the first screen to the south of this one, ordered by proximity.
-function screen:toSouth() return first_screen_in_direction(self, 3) end
+--- Get the first screen to the south of this one, ordered by proximity to its center or a specified point.
+--- Parameters:
+---   * from - An `hs.geometry.rect` or `hs.geometry.point` object; if omitted, the geometric center of this screen will be used
+---   * strict - If `true`, disregard screens that lie completely to the left or to the right of this one (alternatively, set `hs.screen.strictScreenInDirection`)
+function screen:toSouth(...) return first_screen_in_direction(self, 3, ...) end
 
 return screen

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -102,7 +102,7 @@ local function first_screen_in_direction(screen, numrotations, from, strict)
     end
   end
 
-  if strict or screen.strictScreenInDirection then
+  if strict or (screen.strictScreenInDirection and strict~=false) then
     -- exclude screens without any horizontal/vertical overlap
     for i=#closestscreens,1,-1 do
       local of=closestscreens[i].s:fullFrame()

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -89,6 +89,17 @@ local function first_screen_in_direction(screen, numrotations)
     end
   end
 
+ -- exclude screens without any horizontal/vertical overlap
+  local myf=screen:fullFrame()
+  for i=#closestscreens,1,-1 do
+    local of=closestscreens[i].s:fullFrame()
+    if numrotations==1 or numrotations==3 then
+      if of.x+of.w-1<myf.x or myf.x+myf.w-1<of.x then table.remove(closestscreens,i) end
+    else
+      if of.y+of.h-1<myf.y or myf.y+myf.h-1<of.y then table.remove(closestscreens,i) end
+    end
+  end
+
   table.sort(closestscreens, function(a, b) return a.score < b.score end)
 
   if #closestscreens > 0 then


### PR DESCRIPTION
I have 4 screens placed horizontally, with different pixel heights. Currently hs.screen:toNorth()/toSouth() can jump "laterally" across screens due to the difference in height (as long as the geometric centres are horizontally misaligned, the target screen is considered to be "north" or "south"); this doesn't seem to make much sense.
The fix takes care of this by discarding screens which have (in the North/South case) *no* horizontal overlap.

Note that this means that an arrangement like this
![screen shot 2015-07-01 at 15 52 01](https://cloud.githubusercontent.com/assets/6718755/8456063/3812456a-2009-11e5-8462-0904ae8d5036.png)
would probably make the rightmost screen "unreachable" by either toEast or toNorth; but I don't think anyone would ever have such an arrangement.