### PR TITLE
Hotkey fixes

### DIFF
--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -161,7 +161,7 @@ function hotkey.modal:enter()
     self.k:disable()
   end
   fnutils.each(self.keys, hotkey.enable)
-  self.entered()
+  self:entered()
   return self
 end
 
@@ -182,7 +182,7 @@ function hotkey.modal:exit()
   if (self.k) then
     self.k:enable()
   end
-  self.exited()
+  self:exited()
   return self
 end
 

--- a/extensions/hotkey/internal.m
+++ b/extensions/hotkey/internal.m
@@ -322,7 +322,8 @@ static OSStatus trigger_hotkey_callback(lua_State* L, int eventUID, int eventKin
         }
         if (!isRepeat && eventKind == kEventHotKeyPressed) {
             //CLS_NSLOG(@"trigger_hotkey_callback: not a repeat, but it is a keydown, starting the timer");
-            [keyRepeatManager startTimer:L eventID:eventUID eventKind:eventKind];
+            if (hotkey->repeatfn != LUA_NOREF)
+                [keyRepeatManager startTimer:L eventID:eventUID eventKind:eventKind];
         }
     }
 


### PR DESCRIPTION
only trigger timer if hotkey definition has a repeatfn defined
call modal:entered and modal:exited as methods, rather than functions because that's how we define them (i.e. with an implicit self)

Fixes #358 