### PR TITLE
eventtap updates

### DIFF
--- a/extensions/eventtap/event.m
+++ b/extensions/eventtap/event.m
@@ -569,11 +569,15 @@ static int eventtap_event_systemKey(lua_State* L) {
 ///   * NSEventTypeEndGesture   --  An event that represents a gesture ending.
 ///   * NSEventTypeSmartMagnify --  NSEvent type for the smart zoom gesture (2-finger double tap on trackpads) along with a corresponding NSResponder method. In response to this event, you should intelligently magnify the content.
 ///   * NSEventTypeQuickLook    --  Supports the new event responder method that initiates a Quicklook.
-///   * NSEventTypePressure     --  An NSEvent type representing a change in pressure on a pressure-sensitive device. Requires a 64-bit processor.
 ///
 /// Notes:
 ///  * This table has a __tostring() metamethod which allows listing it's contents in the Hammerspoon console by typing `hs.eventtap.event.types`.
 ///  * In previous versions of Hammerspoon, type labels were defined with the labels in all lowercase.  This practice is deprecated, but an __index metamethod allows the lowercase labels to still be used; however a warning will be printed to the Hammerspoon console.  At some point, this may go away, so please update your code to follow the new format.
+
+// wait until Travis catches up with 10.10.3
+//
+//   * NSEventTypePressure     --  An NSEvent type representing a change in pressure on a pressure-sensitive device. Requires a 64-bit processor.
+
 static void pushtypestable(lua_State* L) {
     lua_newtable(L);
     lua_pushinteger(L, kCGEventLeftMouseDown);      lua_setfield(L, -2, "leftMouseDown");
@@ -640,8 +644,9 @@ static void pushtypestable(lua_State* L) {
     lua_pushstring(L, "NSEventTypeSmartMagnify") ;  lua_rawseti(L, -2, NSEventTypeSmartMagnify);
     lua_pushinteger(L, NSEventTypeQuickLook);       lua_setfield(L, -2, "NSEventTypeQuickLook");
     lua_pushstring(L, "NSEventTypeQuickLook") ;     lua_rawseti(L, -2, NSEventTypeQuickLook);
-    lua_pushinteger(L, NSEventTypePressure);        lua_setfield(L, -2, "NSEventTypePressure");
-    lua_pushstring(L, "NSEventTypePressure") ;      lua_rawseti(L, -2, NSEventTypePressure);
+// wait until Travis catches up with 10.10.3
+//    lua_pushinteger(L, NSEventTypePressure);        lua_setfield(L, -2, "NSEventTypePressure");
+//    lua_pushstring(L, "NSEventTypePressure") ;      lua_rawseti(L, -2, NSEventTypePressure);
 
 //     lua_pushinteger(L, kCGEventTapDisabledByTimeout);    lua_setfield(L, -2, "tapDisabledByTimeout");
 //     lua_pushstring(L, "tapDisabledByTimeout") ;         lua_rawseti(L, -2, kCGEventTapDisabledByTimeout);

--- a/extensions/eventtap/init.lua
+++ b/extensions/eventtap/init.lua
@@ -15,8 +15,23 @@ if not hs.keycodes then hs.keycodes = require("hs.keycodes") end
 
 local module = require("hs.eventtap.internal")
 module.event = require("hs.eventtap.event")
+local fnutils = require("hs.fnutils")
 
 -- private variables and methods -----------------------------------------
+
+local __tostring_for_tables = function(self)
+    local result = ""
+    local width = 0
+    for i,v in fnutils.sortByKeys(self) do
+        if type(i) == "string" and width < i:len() then width = i:len() end
+    end
+    for i,v in fnutils.sortByKeys(self) do
+        if type(i) == "string" then
+            result = result..string.format("%-"..tostring(width).."s %d\n", i, v)
+        end
+    end
+    return result
+end
 
 local __index_for_types = function(object, key)
     for i,v in pairs(object) do
@@ -42,8 +57,10 @@ local __index_for_props = function(object, key)
     return nil
 end
 
-module.event.types      = setmetatable(module.event.types,      { __index = __index_for_types })
-module.event.properties = setmetatable(module.event.properties, { __index = __index_for_props })
+module.event.types      = setmetatable(module.event.types,      { __index    = __index_for_types,
+                                                                  __tostring = __tostring_for_tables })
+module.event.properties = setmetatable(module.event.properties, { __index    = __index_for_props,
+                                                                  __tostring = __tostring_for_tables })
 
 -- Public interface ------------------------------------------------------
 


### PR DESCRIPTION
* Add additional NSEvent based events for watching
* add getRawEventData method to examine event data in more detail (really only useful to developers in determining what helper methods might be necessary, but read only, so harmless)
* Clean up types and properties documentation
* add systemKey method to get information about brightness, contrast, media, power key etc.
* add getCharacters method so eventtap can be used as a key-input capture method without having to understand every locales specific keycode arrangments
* made setKeyCode and setFlags chainable
* getProperties and setProperties know when to use integer versus number
* __tostring metamethods for properties and types tables
* auto-restart eventtaps when disabledByTimeOut or disabledByUserInput occurs
* cleaner shutdown/restart of eventtap, runloopsrc and machport
