### PR TITLE
new drawing placement features

### DIFF
--- a/extensions/drawing/init.lua
+++ b/extensions/drawing/init.lua
@@ -12,4 +12,73 @@ module.color = {
     ["osx_red"]     = { ["red"]=0.996,["green"]=0.329,["blue"]=0.302,["alpha"]=1 },
     ["osx_yellow"]  = { ["red"]=1.000,["green"]=0.741,["blue"]=0.180,["alpha"]=1 },
 }
+
+local fnutils = require("hs.fnutils")
+
+local __tostring_for_tables = function(self)
+    local result = ""
+    local width = 0
+    for i,v in fnutils.sortByKeys(self) do
+        if type(i) == "string" and width < i:len() then width = i:len() end
+    end
+    for i,v in fnutils.sortByKeys(self) do
+        if type(i) == "string" then
+            result = result..string.format("%-"..tostring(width).."s %d\n", i, v)
+        end
+    end
+    return result
+end
+
+module.fontTraits      = setmetatable(module.fontTraits,      { __tostring = __tostring_for_tables })
+module.windowBehaviors = setmetatable(module.windowBehaviors, { __tostring = __tostring_for_tables })
+
+local tmp = module.rectangle({})
+local tmpMeta = getmetatable(tmp)
+
+--- hs.drawing:setBehaviorByLabels(table) -> object
+--- Method
+--- Sets the window behaviors based upon the labels specified in the table provided.
+---
+--- Parameters:
+---  * a table of label strings or numbers.  Recognized values can be found in `hs.drawing.windowBehaviors`.
+---
+--- Returns:
+---  * The `hs.drawing` object
+tmpMeta.setBehaviorByLabels = function(obj, stringTable)
+    local newBehavior = 0
+    for i,v in ipairs(stringTable) do
+        local flag = tonumber(v) or module.windowBehaviors[v]
+        newBehavior = newBehavior | flag
+    end
+    return obj:setBehavior(newBehavior)
+end
+
+--- hs.drawing:behaviorAsLabels() -> table
+--- Method
+--- Returns a table of the labels for the current behaviors of the object.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * Returns a table of the labels for the current behaviors with respect to Spaces and Exposé for the object.
+tmpMeta.behaviorAsLabels = function(obj)
+    local results = {}
+    local behaviorNumber = obj:behavior()
+
+    if behaviorNumber ~= 0 then
+        for i, v in pairs(module.windowBehaviors) do
+            if type(i) == "string" then
+                if (behaviorNumber & v) > 0 then table.insert(results, i) end
+            end
+        end
+    else
+        table.insert(results, module.windowBehaviors[0])
+    end
+    return results
+end
+
+tmp:delete()
+tmp = nil
+
 return module


### PR DESCRIPTION
Adds the following to hs.drawing objects:

* alpha/setAlpha -- allows the setting of an alpha to the window containing the object -- this is independent of the objects color, and works on hs.drawing.image objects as well

* orderAbove([obj])/orderBelow([obj]) -- sets the level of the object above or below the other specified object, or for all windows at object1's presentation layer (set by sendToBack/bringToFront), if [obj] is not present.

* hs.drawing.windowBehaviors -- table listing behavior types available for the windows of hs.drawing objects that dictate how the drawing object is treated by Spaces and Exposé.

* behavior/setBehavior and behaviorAsLabels/setBehaviorByLabels -- the first two deal in an integer number of or'd values from the above table, while the later two accept a table of the string keys from the above table.

With the behavior methods, objects can be defined as appearing in all spaces, being ignored by Spaces and Exposé completely, or hovering above the Spaces and Exposé screens.  The only thing I haven't figured out yet is how to make an object above a full-screen application that creates its own space when maximized.

Before anyone asks, I played with [NSWindow level] and [NSWindow setLevel], but was having problems getting consistent results -- the behaviors seemed to match, when I mirrored the activities of the sendToBack/bringToFront, but the numeric values returned, and other levels didn't seem reliable or consistent... without digging deeper or talking with someone more familiar with them, it seemed unwise to add what I have so far, when with a little planning, the existing methods, and these additional ones give us a way to effectively manage apparent z-levels of drawing objects, even if not numerically.