### PR TITLE
support builtin system images with hs.drawing.image

### DIFF
--- a/extensions/drawing/init.lua
+++ b/extensions/drawing/init.lua
@@ -29,8 +29,18 @@ local __tostring_for_tables = function(self)
     return result
 end
 
-module.fontTraits      = setmetatable(module.fontTraits,      { __tostring = __tostring_for_tables })
-module.windowBehaviors = setmetatable(module.windowBehaviors, { __tostring = __tostring_for_tables })
+local __tostring_for_arrays = function(self)
+    local result = ""
+    for i,v in ipairs(self) do
+        result = result..v.."\n"
+    end
+    return result
+end
+
+table.sort(module.systemImageNames)
+module.systemImageNames = setmetatable(module.systemImageNames, { __tostring = __tostring_for_arrays })
+module.fontTraits       = setmetatable(module.fontTraits,       { __tostring = __tostring_for_tables })
+module.windowBehaviors  = setmetatable(module.windowBehaviors,  { __tostring = __tostring_for_tables })
 
 local tmp = module.rectangle({})
 local tmpMeta = getmetatable(tmp)

--- a/extensions/drawing/internal.m
+++ b/extensions/drawing/internal.m
@@ -319,6 +319,8 @@ NSMutableArray *drawingWindows;
         newImage = [NSImage imageWithASCIIRepresentation:rep color:color shouldAntialias:YES];
     } else {
         newImage = [[NSImage alloc] initByReferencingFile:filePath];
+        if (![newImage isValid])
+            newImage = [NSImage imageNamed:filePath] ;
     }
     if (!newImage) {
         CLS_NSLOG(@"HSDrawingViewImage::setImageFromPath: ERROR: unable to load image: %@", filePath);
@@ -661,7 +663,7 @@ static int drawing_newText(lua_State *L) {
 ///
 /// Parameters:
 ///  * sizeRect - A rect-table containing the location/size of the image
-///  * imagePath - A string containing a path to an image file. If the string begins with `ASCII:` then the rest of the string is interpreted as a special form of ASCII diagram, which will be rendered to an image. See the notes below for information about the special format of ASCII diagram.
+///  * imagePath - A string containing a path to an image file or the name representing a system image. If the string begins with `ASCII:` then the rest of the string is interpreted as a special form of ASCII diagram, which will be rendered to an image. See the notes below for information about the special format of ASCII diagram.
 ///
 /// Returns:
 ///  * An `hs.drawing` image object, or nil if an error occurs
@@ -669,6 +671,7 @@ static int drawing_newText(lua_State *L) {
 ///  * Animated GIFs are supported. They're not super friendly on your CPU, but they work
 ///
 /// Notes:
+///  * See `hs.drawing.systemImageNames` for a list of currently recognized internally defined system images.
 ///  * To use the ASCII diagram image support, see http://cocoamine.net/blog/2015/03/20/replacing-photoshop-with-nsstring/ and be sure to preface your ASCII diagram with the special string `ASCII:`
 static int drawing_newImage(lua_State *L) {
     NSRect windowRect;
@@ -1685,6 +1688,77 @@ static int pushCollectionTypeTable(lua_State *L) {
     return 1 ;
 }
 
+/// hs.drawing.systemImageNames[]
+/// Constant
+/// Array containing the names of internal system images for use with hs.drawing.image
+///
+/// Notes:
+///  * Image names pulled from NSImage.h
+///  * This table has a __tostring() metamethod which allows listing it's contents in the Hammerspoon console by typing `hs.drawing.systemImageNames`.
+static int pushNSImageNameTable(lua_State *L) {
+    lua_newtable(L) ;
+        lua_pushstring(L, [NSImageNameQuickLookTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameBluetoothTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameIChatTheaterTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameSlideshowTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameActionTemplate UTF8String] ) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameSmartBadgeTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameIconViewTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameListViewTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameColumnViewTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameFlowViewTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNamePathTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameInvalidDataFreestandingTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameLockLockedTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameLockUnlockedTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameGoRightTemplate UTF8String] ) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameGoLeftTemplate UTF8String] ) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameRightFacingTriangleTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameLeftFacingTriangleTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameAddTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameRemoveTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameRevealFreestandingTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameFollowLinkFreestandingTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameEnterFullScreenTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameExitFullScreenTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameStopProgressTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameStopProgressFreestandingTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameRefreshTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameRefreshFreestandingTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameBonjour UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameComputer UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameFolderBurnable UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameFolderSmart UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameFolder UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameNetwork UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameMobileMe UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameMultipleDocuments UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameUserAccounts UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNamePreferencesGeneral UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameAdvanced UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameInfo UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameFontPanel UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameColorPanel UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameUser UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameUserGroup UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameEveryone UTF8String] ) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameUserGuest UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameMenuOnStateTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameMenuMixedStateTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameApplicationIcon UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameTrashEmpty UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameTrashFull UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameHomeTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameBookmarksTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameCaution UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameStatusAvailable UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameStatusPartiallyAvailable UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameStatusUnavailable UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameStatusNone UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+        lua_pushstring(L, [NSImageNameShareTemplate UTF8String]) ;  lua_rawseti(L, -2, luaL_len(L, -2) + 1);
+    return 1;
+}
+
 /// hs.drawing:behavior() -> number
 /// Method
 /// Returns the current behavior of the hs.drawing object with respect to Spaces and Exposé for the object.
@@ -1780,6 +1854,7 @@ int luaopen_hs_drawing_internal(lua_State *L) {
     luaL_newlib(L, drawinglib);
         pushFontTraitsTable(L);       lua_setfield(L, -2, "fontTraits");
         pushCollectionTypeTable(L) ;  lua_setfield(L, -2, "windowBehaviors") ;
+        pushNSImageNameTable(L)    ;  lua_setfield(L, -2, "systemImageNames") ;
 
     return 1;
 }

--- a/extensions/menubar/internal.m
+++ b/extensions/menubar/internal.m
@@ -312,12 +312,13 @@ static int menubarSetTitle(lua_State *L) {
 /// Sets the image of a menubar item object. The image will be displayed in the system menubar
 ///
 /// Parameters:
-///  * `iconfilepath` - A string containing the path of an image file to load. If the string begins with `ASCII:` then the rest of the string is interpreted as a special form of ASCII diagram, which will be rendered to an image and used as the icon. See the notes below for information about the special format of ASCII diagram. If this parameter is nil, any current image is removed
+///  * `iconfilepath` - A string containing the path of an image file to load or the name representing a system image. If the string begins with `ASCII:` then the rest of the string is interpreted as a special form of ASCII diagram, which will be rendered to an image and used as the icon. See the notes below for information about the special format of ASCII diagram. If this parameter is nil, any current image is removed
 ///
 /// Returns:
 ///  * `true` if the image was loaded and set, `nil` if it could not be found or loaded
 ///
 /// Notes:
+///  * A list of known system images can be found in `hs.drawing.systemImageNames`.
 ///  * If you set a title as well as an icon, they will both be displayed next to each other
 ///  * Icons should be small, transparent images that roughly match the size of normal menubar icons, otherwise they will look very strange
 ///  * Retina scaling is supported if the image is either scalable (e.g. a PDF produced by Adobe Illustrator) or contain multiple sizes (e.g. a TIFF with small and large images). Images will not automatically do the right thing if you have a @2x version present
@@ -341,6 +342,8 @@ static int menubarSetIcon(lua_State *L) {
             iconImage = [NSImage imageWithASCIIRepresentation:rep color:color shouldAntialias:YES];
         } else {
             iconImage = [[NSImage alloc] initWithContentsOfFile:lua_to_nsstring(L, 2)];
+            if (![iconImage isValid])
+                iconImage = [NSImage imageNamed:lua_to_nsstring(L, 2)] ;
         }
         lua_settop(L, 1); // FIXME: This seems unnecessary?
         if (!iconImage) {


### PR DESCRIPTION
Allows you specify builtin system images by name with hs.drawing.image... see picture for example

![image](https://cloud.githubusercontent.com/assets/8139480/8631938/fcc4d9a2-274a-11e5-975e-8bca3f44ba2d.png)

or try this code:
~~~lua
a = {
  hs.drawing.rectangle{x=10, y=40, w=1420, h=720}
      :setRoundedRectRadii(20,20):setStroke(true):setStrokeWidth(10)
      :setFill(true):setFillColor{red=1, blue=1, green = 1, alpha = 1}:show()
}
for i,v in ipairs(hs.drawing.systemImageNames) do
    table.insert(a, hs.drawing.image({
          x=20 + ((i - 1) % 14) * 100,
          y=60 + math.floor((i-1)/14) * 140,
          h=100, w=100}, v):show())
    table.insert(a, hs.drawing.text({
          x=20 + ((i - 1) % 14) * 100,
          y=160 + math.floor((i-1)/14) * 140,
          h=40, w=100}, v)
          :setTextSize(10):setTextColor{red = 0, blue = 0, green = 0, alpha=1}
          :setTextFont("Menlo"):show())
end

-- hs.fnutils.map(a, function(a) a:delete() end) -- use this to clear from screen
~~~