### PR TITLE
add __tostring methods to result tables for easier use in console

### DIFF
--- a/extensions/battery/init.lua
+++ b/extensions/battery/init.lua
@@ -7,11 +7,26 @@
 
 
 local module = require("hs.battery.internal")
+local fnutils = require("hs.fnutils")
 
 -- private variables and methods -----------------------------------------
 
 local check_list = {}
 for i,v in pairs(module) do check_list[#check_list + 1] = i end
+
+local __tostring_for_tables = function(self)
+    local result = ""
+    local width = 0
+    for i,v in fnutils.sortByKeys(self) do
+        if type(i) == "string" and width < i:len() then width = i:len() end
+    end
+    for i,v in fnutils.sortByKeys(self) do
+        if type(i) == "string" then
+            result = result..string.format("%-"..tostring(width).."s %s\n", i, tostring(v))
+        end
+    end
+    return result
+end
 
 -- Public interface ------------------------------------------------------
 
@@ -37,7 +52,7 @@ module.getAll = function()
         if t[v] == nil then t[v] = "n/a" end
     end
 
-    return t
+    return setmetatable(t, {__tostring = __tostring_for_tables })
 end
 
 -- Return Module Object --------------------------------------------------

--- a/extensions/host/init.lua
+++ b/extensions/host/init.lua
@@ -3,4 +3,37 @@
 --- Inspect information about the machine Hammerspoon is running on
 
 local host = require "hs.host.internal"
+local fnutils = require "hs.fnutils"
+
+local __tostring_for_tables = function(self)
+    local result = ""
+    local width = 0
+    for i,v in fnutils.sortByKeys(self) do
+        if type(i) == "string" and width < i:len() then width = i:len() end
+    end
+    for i,v in fnutils.sortByKeys(self) do
+        if type(i) == "string" then
+            result = result..string.format("%-"..tostring(width).."s %s\n", i, tostring(v))
+        end
+    end
+    return result
+end
+
+local vmStat = host.vmStat
+local cpuUsage = host.cpuUsage
+
+host.vmStat = function(...)
+    return setmetatable(vmStat(...), {__tostring = __tostring_for_tables })
+end
+
+host.cpuUsage = function(...)
+    local result = cpuUsage(...)
+    for i,v in pairs(result) do
+        if tostring(i) ~= "n" then
+            result[i] = setmetatable(v, { __tostring = __tostring_for_tables })
+        end
+    end
+    return result
+end
+
 return host

--- a/extensions/host/internal.m
+++ b/extensions/host/internal.m
@@ -123,6 +123,7 @@ static int hostLocalizedName(lua_State* L) {
 ///    * uncompressedPages       -- the total number of pages (uncompressed) held within the compressor
 ///
 /// Notes:
+///  * The table returned has a __tostring() metamethod which allows listing it's contents in the Hammerspoon console by typing `hs.host.vmStats()`.
 ///  * Except for the addition of cacheHits, cacheLookups, pageSize and memSize, the results for this function should be identical to the OS X command `vm_stat`.
 ///  * Adapted primarily from the source code to Apple's vm_stat command located at http://www.opensource.apple.com/source/system_cmds/system_cmds-643.1.1/vm_stat.tproj/vm_stat.c
 static int hs_vmstat(lua_State *L) {
@@ -199,14 +200,18 @@ static int hs_vmstat(lua_State *L) {
 ///  * None
 ///
 /// Returns:
-///  * An array of tables for each CPU core and a keyed entry, `overall`, for total usage across all cores.  Each entry's table will contain the following keys:
-///    * user   -- percentage of CPU time occupied by user level processes.
-///    * system -- percentage of CPU time occupied by system (kernel) level processes.
-///    * nice   -- percentage of CPU time occupied by user level processes with a positive nice value (lower scheduling priority).
-///    * active -- For convenience, when you just want percent in use, this is the sum of user, system, and nice.
-///    * idle   -- percentage of CPU time spent idle
+///  * A table containing the following:
+///    * A tables, indexed by the core number, for each CPU core with the following keys in each subtable:
+///      * user   -- percentage of CPU time occupied by user level processes.
+///      * system -- percentage of CPU time occupied by system (kernel) level processes.
+///      * nice   -- percentage of CPU time occupied by user level processes with a positive nice value (lower scheduling priority).
+///      * active -- For convenience, when you just want the total CPU usage, this is the sum of user, system, and nice.
+///      * idle   -- percentage of CPU time spent idle
+///    * The key `overall` containing the same keys as described above but based upon the average of all cores combined.
+///    * The key `n` containing the number of cores detected.
 ///
 /// Notes:
+///  * The subtables for each core and `overall` have a __tostring() metamethod which allows listing it's contents in the Hammerspoon console by typing `hs.host.cpuUsage()[#]` where # is the core you are interested in or the string "overall".
 ///  * Adapted primarily from code found at http://stackoverflow.com/questions/6785069/get-cpu-percent-usage
 static int hs_cpuInfo(lua_State *L) {
     unsigned numCPUs;
@@ -257,6 +262,8 @@ static int hs_cpuInfo(lua_State *L) {
         showError(L, errStr) ;
         return 0 ;
     }
+
+    lua_pushinteger(L, numCPUs) ; lua_setfield(L, -2, "n") ;
     return 1 ;
 }
 


### PR DESCRIPTION
Doing some cleanup and adding methods to make data more easily identifiable and useful in console or in printed output.  Probably more to follow, but I want to keep this minor stuff separate from new modules or significant changes to anything.

So far:  hs.battery.getAll(), hs.host.vmStats(), and hs.host.cpuUsage()[x] all output to the console or via print without need for hs.inspect.