### PR TITLE
[READY] Hotkey nesting

### DIFF
--- a/extensions/alert/internal.m
+++ b/extensions/alert/internal.m
@@ -178,7 +178,8 @@ static int alert_show(lua_State* L) {
     if (lua_isnumber(L, 2))
         duration = lua_tonumber(L, 2);
 
-    HSShowAlert(str, duration);
+    if (duration>0.0)
+        HSShowAlert(str, duration);
 
     return 0;
 }

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -217,6 +217,43 @@ function hotkey.deleteAll(mods,key)
   hotkeys[idx]=nil
 end
 
+--- hs.hotkey.showHotkeys(mods, key)
+--- Function
+--- Creates (and enables) a hotkey that shows all currently enabled hotkeys while pressed
+---
+--- Parameters:
+---  * mods - (optional) A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---   * "cmd", "command" or "⌘"
+---   * "ctrl", "control" or "⌃"
+---   * "alt", "option" or "⌥"
+---   * "shift" or "⇧"
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---
+--- Returns:
+---  * The new `hs.hotkey` object
+
+local helpHotkey
+local function showHelp()
+  local t={}
+  for idx,hks in pairs(hotkeys) do
+    for i=#hks,1,-1 do
+      if hks[i].enabled and hks[i]~=helpHotkey then
+        t[#t+1] = hks[i]
+        break
+      end
+    end
+  end
+  table.sort(t,function(a,b)if#a.idx==#b.idx then return a.idx<b.idx else return #a.idx<#b.idx end end)
+  local s=''
+  for _,hk in ipairs(t) do s=s..hk.msg..'\n' end
+  --  hs.alert(s,math.min(15,math.max(#s/10),3))
+  hs.alert(string.sub(s,1,-2),3600)
+end
+function hotkey.showHotkeys(mods,key)
+  if helpHotkey then delete(helpHotkey) end
+  helpHotkey = hotkey.bind(mods,key,showHelp,hs.alert.closeAll,'Show enabled hotkeys',3600)
+  return helpHotkey
+end
 --- hs.hotkey.bind(mods, key, pressedfn, releasedfn, repeatfn, message, duration) -> hs.hotkey
 --- Constructor
 --- Creates a hotkey and enables it immediately

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -216,9 +216,24 @@ function hotkey.deleteAll(mods,key)
   hotkeys[idx]=nil
 end
 
---- hs.hotkey.showHotkeys(mods, key)
+--- hs.hotkey.getHotkeys() -> table
 --- Function
---- Creates (and enables) a hotkey that shows all currently enabled hotkeys while pressed
+--- Returns a list of all currently active hotkeys
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * A table containing the hotkeys that are active, i.e. enabled and not "shadowed", in the current context
+---    (usually, the global hotkey context, but it could be a modal hotkey context). Every element in the list
+---    is a table with two fields:
+---    * idx - a string describing the keyboard combination for the hotkey
+---    * msg - the hotkey message, if provided when the hotkey was created (prefixed with the keyboard combination)
+
+--- hs.hotkey.showHotkeys(mods, key) -> hs.hotkey
+--- Function
+--- Creates (and enables) a hotkey that shows all currently active hotkeys (i.e. enabled and not "shadowed"
+--- in the current context) while pressed
 ---
 --- Parameters:
 ---  * mods - (optional) A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
@@ -232,7 +247,7 @@ end
 ---  * The new `hs.hotkey` object
 
 local helpHotkey
-local function showHelp()
+function hotkey.getHotkeys()
   local t={}
   for idx,hks in pairs(hotkeys) do
     for i=#hks,1,-1 do
@@ -243,6 +258,11 @@ local function showHelp()
     end
   end
   table.sort(t,function(a,b)if#a.idx==#b.idx then return a.idx<b.idx else return #a.idx<#b.idx end end)
+  return t
+end
+
+local function showHelp()
+  local t=hotkey.getHotkeys()
   local s=''
   for _,hk in ipairs(t) do s=s..hk.msg..'\n' end
   hs.alert(string.sub(s,1,-2),3600)

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -10,8 +10,12 @@ local tonumber,pairs,ipairs,type,tremove,tinsert,tconcat = tonumber,pairs,ipairs
 local supper,slower,sfind=string.upper,string.lower,string.find
 
 local function getKeycode(s)
-  if (s:sub(1, 1) == '#') then return tonumber(s:sub(2))
-  else return keycodes.map[s:lower()] end
+  if type(s)~='string' then error('key must be a string',3) end
+  local n
+  if (s:sub(1, 1) == '#') then n=tonumber(s:sub(2))
+  else n=keycodes.map[s:lower()] end
+  if not n then error('Invalid key: '..s,3) end
+  return n
 end
 
 local hotkeys,hkmap = {},{}
@@ -24,8 +28,12 @@ local hotkeys,hkmap = {},{}
 ---  * None
 ---
 --- Returns:
----  * The `hs.hotkey` object
-
+---  * The `hs.hotkey` object for method chaining
+---
+--- Notes:
+---  * When you enable a hotkey that uses the same keyboard combination as another previously-enabled hotkey, the old
+---    one will stop working as it's being "shadowed" by the new one. As soon as the new hotkey is disabled or deleted
+---    the old one will trigger again.
 local function enable(self,force)
   if not force and self.enabled then return self end --this ensures "nested shadowing" behaviour
   local idx = hkmap[self]
@@ -48,7 +56,7 @@ end
 ---  * None
 ---
 --- Returns:
----  * The `hs.hotkey` object
+---  * The `hs.hotkey` object for method chaining
 local function disable(self)
   if not self.enabled then return self end
   local idx = hkmap[self]
@@ -60,7 +68,8 @@ local function disable(self)
   end
   return self
 end
---- hs.hotkey:delete() -> hs.hotkey
+
+--- hs.hotkey:delete()
 --- Method
 --- Disables and deletes a hotkey object
 ---
@@ -68,8 +77,7 @@ end
 ---  * None
 ---
 --- Returns:
----  * The `hs.hotkey` object
-
+---  * None
 local function delete(self)
   disable(self)
   local idx=hkmap[self]
@@ -80,6 +88,7 @@ local function delete(self)
   hkmap[self]=nil
   for k in pairs(self) do self[k]=nil end --gc
 end
+
 
 local function getMods(mods)
   local r={}
@@ -96,12 +105,16 @@ local function getMods(mods)
   find{'alt','option','⌥'} find{'shift','⇧'}
   return r
 end
+
+local function getIndex(mods,keycode)
+  return tconcat(getMods(mods))..'#'..keycode
+end
 --- hs.hotkey.new(mods, key, pressedfn, releasedfn, repeatfn, message, duration) -> hs.hotkey
 --- Constructor
 --- Creates a new hotkey
 ---
 --- Parameters:
----  * mods - A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---  * mods - (optional) A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
 ---   * "cmd", "command" or "⌘"
 ---   * "ctrl", "control" or "⌃"
 ---   * "alt", "option" or "⌥"
@@ -118,13 +131,13 @@ end
 ---
 --- Notes:
 ---  * If you don't need `releasedfn` nor `repeatfn`, you can simply use `hs.hotkey.new(mods,key,fn,"message")`
----  * You can create multiple `hs.hotkey` objects for the same hotkey, but only one can be active at any given time
+---  * You can create multiple `hs.hotkey` objects for the same keyboard combination, but only one can be active
+---    at any given time - see `hs.hotkey:enable()`
 
 --local SYMBOLS = {cmd='⌘',ctrl='⌃',alt='⌥',shift='⇧',hyper='✧'}
 local CONCAVE_DIAMOND='✧'
 function hotkey.new(mods, key, pressedfn, releasedfn, repeatfn, message, duration)
-  if type(key)~='string' then error('key must be a string',2) end
-  local keycode = getKeycode(key) or error("Invalid key: "..key,2)
+  local keycode = getKeycode(key)
   mods = getMods(mods)
   if type(pressedfn)~='function' and type(releasedfn)~='function' and type(repeatfn)~='function' then
     error('At least one of pressedfn, releasedfn or repeatfn must be a function',2) end
@@ -132,9 +145,10 @@ function hotkey.new(mods, key, pressedfn, releasedfn, repeatfn, message, duratio
   elseif type(repeatfn)=='string' then duration=message message=repeatfn repeatfn=nil end
   if type(message)~='string' then message=nil end
   if type(duration)~='number' then duration=nil end
-  local modstr = tconcat(mods)
-  if #mods>=4 then modstr=CONCAVE_DIAMOND end
-  local desc=modstr..supper(key)
+  local idx = getIndex(mods,keycode)
+  local desc = tconcat(mods)
+  if #mods>=4 then desc=CONCAVE_DIAMOND end
+  desc=desc..supper(key)
   if message then
     if #message>0 then desc=desc..': '..message end
     local actualfn=pressedfn or releasedfn or repeatfn
@@ -143,7 +157,6 @@ function hotkey.new(mods, key, pressedfn, releasedfn, repeatfn, message, duratio
     elseif releasedfn then releasedfn=fnalert
     elseif repeatfn then repeatfn=fnalert end
   end
-  local idx = modstr..keycode
   local hk = {_hk=hotkey._new(mods, keycode, pressedfn, releasedfn, repeatfn),enable=enable,disable=disable,delete=delete,desc=desc}
   hkmap[hk] = idx
   local h = hotkey[idx] or {}
@@ -154,10 +167,10 @@ end
 
 --- hs.hotkey.disableAll(mods, key)
 --- Function
---- Disables all previously set callbacks for a given hotkey
+--- Disables all previously set callbacks for a given keyboard combination
 ---
 --- Parameters:
----  * mods - A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---  * mods - (optional) A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
 ---   * "cmd", "command" or "⌘"
 ---   * "ctrl", "control" or "⌃"
 ---   * "alt", "option" or "⌥"
@@ -167,21 +180,26 @@ end
 --- Returns:
 ---  * None
 function hotkey.disableAll(mods,key)
-  if type(key)~='string' then error('key must be a string',2) end
-  local keycode = getKeycode(key) or error("Invalid key: "..key,2)
-  local idx=tconcat(getMods(mods))..keycode
-  for _,hk in ipairs(hotkey[idx] or {}) do
-    hk:disable()
-    --    hk._hk:disable() --objc
-    --    hkmap[hk]=nil
-  end
-  --  hotkey[idx]=nil
+  local idx=getIndex(mods,getKeycode(key))
+  for _,hk in ipairs(hotkey[idx] or {}) do hk:disable() end
 end
 
+--- hs.hotkey.deleteAll(mods, key)
+--- Function
+--- Deletes all previously set callbacks for a given keyboard combination
+---
+--- Parameters:
+---  * mods - (optional) A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---   * "cmd", "command" or "⌘"
+---   * "ctrl", "control" or "⌃"
+---   * "alt", "option" or "⌥"
+---   * "shift" or "⇧"
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---
+--- Returns:
+---  * None
 function hotkey.deleteAll(mods,key)
-  if type(key)~='string' then error('key must be a string',2) end
-  local keycode = getKeycode(key) or error("Invalid key: "..key,2)
-  local idx=tconcat(getMods(mods))..keycode
+  local idx=getIndex(mods,getKeycode(key))
   for _,hk in ipairs(hotkey[idx] or {}) do
     hk._hk:disable() --objc
     hkmap[hk]=nil
@@ -199,7 +217,7 @@ end
 ---   * "ctrl", "control" or "⌃"
 ---   * "alt", "option" or "⌥"
 ---   * "shift" or "⇧"
----  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---  * key - (optional) A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
 ---  * pressedfn - (optional) A function that will be called when the hotkey has been pressed
 ---  * releasedfn - (optional) A function that will be called when the hotkey has been released
 ---  * repeatfn - (optional) A function that will be called when a pressed hotkey is repeating
@@ -207,7 +225,7 @@ end
 ---  * duration - (optional) Duration of the alert message in seconds
 ---
 --- Returns:
----  * A new `hs.hotkey` object
+---  * A new `hs.hotkey` object for method chaining
 ---
 --- Notes:
 ---  * This function is just a wrapper that performs `hs.hotkey.new(...):enable()`
@@ -219,15 +237,12 @@ end
 ---
 --- Create/manage modal keyboard shortcut environments
 ---
---- This would be a simple example usage:
----
----     k = hs.hotkey.modal.new({"cmd", "shift"}, "d")
----
----     function k:entered() hs.alert.show('Entered mode') end
----     function k:exited()  hs.alert.show('Exited mode')  end
----
----     k:bind({}, 'escape', function() k:exit() end)
----     k:bind({}, 'J', function() hs.alert.show("Pressed J") end)
+--- Usage:
+--- k = hs.hotkey.modal.new("cmd-shift", "d")
+--- function k:entered() hs.alert.show('Entered mode') end
+--- function k:exited()  hs.alert.show('Exited mode')  end
+--- k:bind('', 'escape', function() k:exit() end)
+--- k:bind('', 'J', function() hs.alert.show("Pressed J") end)
 
 hotkey.modal = {}
 hotkey.modal.__index = hotkey.modal
@@ -243,8 +258,7 @@ hotkey.modal.__index = hotkey.modal
 ---  * None
 ---
 --- Notes:
----  * This is a pre-existing function that you should override if you need to use it
----  * The default implementation does nothing
+---  * This is a pre-existing function that you should override if you need to use it; the default implementation does nothing.
 function hotkey.modal:entered()
 end
 
@@ -259,31 +273,33 @@ end
 ---  * None
 ---
 --- Notes:
----  * This is a pre-existing function that you should override if you need to use it
----  * The default implementation does nothing
+---  * This is a pre-existing function that you should override if you need to use it; the default implementation does nothing.
 function hotkey.modal:exited()
 end
 
---- hs.hotkey.modal:bind(mods, key, pressedfn, releasedfn, repeatfn) -> hs.hotkey.modal
+--- hs.hotkey.modal:bind(mods, key, pressedfn, releasedfn, repeatfn, message, duration) -> hs.hotkey.modal
 --- Method
+--- Creates a hotkey that is enabled/disabled as the modal is entered/exited
 ---
 --- Parameters:
----  * mods - A table containing the keyboard modifiers required, which should be zero or more of the following strings:
----   * cmd
----   * alt
----   * shift
----   * ctrl
+---  * mods - (optional) A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---   * "cmd", "command" or "⌘"
+---   * "ctrl", "control" or "⌃"
+---   * "alt", "option" or "⌥"
+---   * "shift" or "⇧"
 ---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
----  * pressedfn - A function that will be called when the hotkey has been pressed
----  * releasedfn - An optional function that will be called when the hotkey has been released
----  * repeatfn - An optional function that will be called when a pressed hotkey is repeating
+---  * pressedfn - (optional) A function that will be called when the hotkey has been pressed
+---  * releasedfn - (optional) A function that will be called when the hotkey has been released
+---  * repeatfn - (optional) A function that will be called when a pressed hotkey is repeating
+---  * message - (optional) A string containing a message to be displayed via `hs.alert()` when the hotkey has been triggered
+---  * duration - (optional) Duration of the alert message in seconds
 ---
 --- Returns:
----  * The `hs.hotkey.modal` object
----
-function hotkey.modal:bind(mods, key, pressedfn, releasedfn, repeatfn)
-  local k = hotkey.new(mods, key, pressedfn, releasedfn, repeatfn)
-  tinsert(self.keys, k._hk)
+---  * The `hs.hotkey.modal` object for method chaining
+function hotkey.modal:bind(...)
+  --  local k = hotkey.new(...)
+  --  tinsert(self.keys, k._hk)
+  tinsert(self.keys, hotkey.new(...))
   return self
 end
 
@@ -295,16 +311,19 @@ end
 ---  * None
 ---
 --- Returns:
----  * The `hs.hotkey.modal` object
+---  * The `hs.hotkey.modal` object for method chaining
 ---
 --- Notes:
----  * This method will enable all of the hotkeys defined in the modal state, and disable the hotkey that entered the modal state (if one was defined)
----  * If the modal state has a hotkey, this method will be called automatically
+---  * This method will enable all of the hotkeys defined in the modal state via `hs.hotkey.modal:bind()`,
+---    and disable the hotkey that entered the modal state (if one was defined)
+---  * If the modal state was created with a keyboard combination, this method will be called automatically
 function hotkey.modal:enter()
   if (self.k) then
-    self.k:disable()
+    --    self.k._hk:disable()
+    disable(self.k)
   end
-  fnutils.each(self.keys, hs.getObjectMetatable("hs.hotkey").enable)
+  --  fnutils.each(self.keys, hotkey.enable)
+  fnutils.each(self.keys, enable)
   self:entered()
   return self
 end
@@ -322,35 +341,39 @@ end
 --- Notes:
 ---  * This method will disable all of the hotkeys defined in the modal state, and enable the hotkey for entering the modal state (if one was defined)
 function hotkey.modal:exit()
-  fnutils.each(self.keys, hs.getObjectMetatable("hs.hotkey").disable)
+  --  fnutils.each(self.keys, hotkey.disable)
+  fnutils.each(self.keys, disable)
   if (self.k) then
-    self.k:enable()
+    enable(self.k)
+    --    self.k._hk:enable()
   end
   self:exited()
   return self
 end
 
---- hs.hotkey.modal.new(mods, key) -> hs.hotkey.modal
+--- hs.hotkey.modal.new(mods, key, message, duration) -> hs.hotkey.modal
 --- Constructor
---- Creates a new modal state, optionally with a global hotkey to trigger it
+--- Creates a new modal state, optionally with a global keyboard combination to trigger it
 ---
 --- Parameters:
----  * mods - A table containing keyboard modifiers for the optional global hotkey
----  * key - A string containing the name of a keyboard key (as found in `hs.keycodes.map`)
+---  * mods - (optional) A string containing (as substrings, with any separator) the keyboard modifiers, which should be zero or more of the following:
+---   * "cmd", "command" or "⌘"
+---   * "ctrl", "control" or "⌃"
+---   * "alt", "option" or "⌥"
+---   * "shift" or "⇧"
+---  * key - (optional) A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---  * message - (optional) A string containing a message to be displayed via `hs.alert()` when the hotkey has been triggered
+---  * duration - (optional) Duration of the alert message in seconds
 ---
 --- Returns:
 ---  * A new `hs.hotkey.modal` object
 ---
 --- Notes:
----  * If `mods` and `key` are both nil, no global hotkey will be registered
-function hotkey.modal.new(mods, key)
-  if ((mods and not key) or (not mods and key)) then
-    hs.showError("Incorrect use of hs.hotkey.modal.new(). Both parameters must either be valid, or nil. You cannot mix valid and nil parameters")
-    return nil
-  end
+---  * If `key` is nil, no global hotkey will be registered (all other parameters will be ignored)
+function hotkey.modal.new(mods, key, message, duration)
   local m = setmetatable({keys = {}}, hotkey.modal)
-  if (mods and key) then
-    m.k = hotkey.bind(mods, key, function() m:enter() end)
+  if (key) then
+    m.k = hotkey.bind(mods, key, function() m:enter() end, message, duration)
   end
   return m
 end

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -15,9 +15,10 @@ local supper,slower,sfind=string.upper,string.lower,string.find
 local function error(err,lvl) return hs.showError(err,(lvl or 1)+1,true) end -- this should go away, #477
 
 local function getKeycode(s)
-  if type(s)~='string' then error('key must be a string',3) end
   local n
-  if (s:sub(1, 1) == '#') then n=tonumber(s:sub(2))
+  if type(s)=='number' then n=s
+  elseif type(s)~='string' then error('key must be a string or a number',3)
+  elseif (s:sub(1, 1) == '#') then n=tonumber(s:sub(2))
   else n=keycodes.map[slower(s)] end
   if not n then error('Invalid key: '..s,3) end
   return n
@@ -140,7 +141,7 @@ local function getIndex(mods,keycode) -- key for hotkeys table
   local mods = getMods(mods)
   mods = #mods>=4 and CONCAVE_DIAMOND or tconcat(mods)
   local key=keycodes.map[keycode]
-  key=key and supper(key) or keycode
+  key=key and supper(key) or '[#'..keycode..']'
   return mods..key
 end
 --- hs.hotkey.new(mods, key, [message,] pressedfn, releasedfn, repeatfn) -> hs.hotkey object
@@ -153,8 +154,7 @@ end
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
 ---    * "shift" or "⇧"
----  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or
----    if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
 ---  * message - (optional) A string containing a message to be displayed via `hs.alert()` when the hotkey has been
 ---    triggered; if omitted, no alert will be shown
 ---  * pressedfn - A function that will be called when the hotkey has been pressed, or nil
@@ -209,8 +209,7 @@ end
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
 ---    * "shift" or "⇧"
----  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or
----    if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
 ---
 --- Returns:
 ---  * None
@@ -228,8 +227,7 @@ end
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
 ---    * "shift" or "⇧"
----  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or
----    if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
 ---
 --- Returns:
 ---  * None
@@ -265,8 +263,7 @@ end
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
 ---    * "shift" or "⇧"
----  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or
----    if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
 ---
 --- Returns:
 ---  * The new `hs.hotkey` object
@@ -309,8 +306,7 @@ end
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
 ---    * "shift" or "⇧"
----  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or
----    if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
 ---  * message - A string containing a message to be displayed via `hs.alert()` when the hotkey has been triggered, or nil for no alert
 ---  * pressedfn - A function that will be called when the hotkey has been pressed, or nil
 ---  * releasedfn - A function that will be called when the hotkey has been released, or nil
@@ -379,8 +375,7 @@ end
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
 ---    * "shift" or "⇧"
----  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or
----    if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
 ---  * message - A string containing a message to be displayed via `hs.alert()` when the hotkey has been triggered, or nil for no alert
 ---  * pressedfn - A function that will be called when the hotkey has been pressed, or nil
 ---  * releasedfn - A function that will be called when the hotkey has been released, or nil
@@ -449,8 +444,7 @@ end
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
 ---    * "shift" or "⇧"
----  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or
----    if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
 ---  * message - A string containing a message to be displayed via `hs.alert()` when the hotkey has been triggered, or nil for no alert
 ---
 --- Returns:

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -34,7 +34,7 @@ local hotkeys = {}
 --- hs.hotkey.alertDuration = 0 -- hotkey alerts are disabled
 hotkey.alertDuration = 1
 
---- hs.hotkey:enable() -> hs.hotkey
+--- hs.hotkey:enable() -> hs.hotkey object
 --- Method
 --- Enables a hotkey object
 ---
@@ -65,7 +65,7 @@ local function enable(self,force,isModal)
   return self
 end
 
---- hs.hotkey:disable() -> hs.hotkey
+--- hs.hotkey:disable() -> hs.hotkey object
 --- Method
 --- Disables a hotkey object
 ---
@@ -136,7 +136,7 @@ local function getIndex(mods,keycode)
   key=key and supper(key) or keycode
   return mods..key
 end
---- hs.hotkey.new(mods, key, [message,] pressedfn, releasedfn, repeatfn) -> hs.hotkey
+--- hs.hotkey.new(mods, key, [message,] pressedfn, releasedfn, repeatfn) -> hs.hotkey object
 --- Constructor
 --- Creates a new hotkey
 ---
@@ -246,7 +246,7 @@ end
 ---    * idx - a string describing the keyboard combination for the hotkey
 ---    * msg - the hotkey message, if provided when the hotkey was created (prefixed with the keyboard combination)
 
---- hs.hotkey.showHotkeys(mods, key) -> hs.hotkey
+--- hs.hotkey.showHotkeys(mods, key) -> hs.hotkey object
 --- Function
 --- Creates (and enables) a hotkey that shows all currently active hotkeys (i.e. enabled and not "shadowed"
 --- in the current context) while pressed
@@ -291,7 +291,7 @@ function hotkey.showHotkeys(mods,key)
   helpHotkey = hotkey.bind(mods,key,'Show active hotkeys',showHelp,hs.alert.closeAll)
   return helpHotkey
 end
---- hs.hotkey.bind(mods, key, message, pressedfn, releasedfn, repeatfn) -> hs.hotkey
+--- hs.hotkey.bind(mods, key, message, pressedfn, releasedfn, repeatfn) -> hs.hotkey object
 --- Constructor
 --- Creates a hotkey and enables it immediately
 ---
@@ -361,7 +361,7 @@ end
 function hotkey.modal:exited()
 end
 
---- hs.hotkey.modal:bind(mods, key, message, pressedfn, releasedfn, repeatfn) -> hs.hotkey.modal
+--- hs.hotkey.modal:bind(mods, key, message, pressedfn, releasedfn, repeatfn) -> hs.hotkey.modal object
 --- Method
 --- Creates a hotkey that is enabled/disabled as the modal is entered/exited
 ---
@@ -385,7 +385,7 @@ function hotkey.modal:bind(...)
   return self
 end
 
---- hs.hotkey.modal:enter() -> hs.hotkey.modal
+--- hs.hotkey.modal:enter() -> hs.hotkey.modal object
 --- Method
 --- Enters a modal state
 ---
@@ -409,7 +409,7 @@ function hotkey.modal:enter()
   return self
 end
 
---- hs.hotkey.modal:exit() -> hs.hotkey.modal
+--- hs.hotkey.modal:exit() -> hs.hotkey.modal object
 --- Method
 --- Exits a modal state
 ---
@@ -417,7 +417,7 @@ end
 ---  * None
 ---
 --- Returns:
----  * The `hs.hotkey.modal` object
+---  * The `hs.hotkey.modal` object for method chaining
 ---
 --- Notes:
 ---  * This method will disable all of the hotkeys defined in the modal state, and enable the hotkey for entering the modal state (if one was defined)
@@ -431,7 +431,7 @@ function hotkey.modal:exit()
   return self
 end
 
---- hs.hotkey.modal.new(mods, key, message) -> hs.hotkey.modal
+--- hs.hotkey.modal.new(mods, key, message) -> hs.hotkey.modal object
 --- Constructor
 --- Creates a new modal state, optionally with a global keyboard combination to trigger it
 ---

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -147,7 +147,8 @@ end
 --- Creates a new hotkey
 ---
 --- Parameters:
----  * mods - A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
+---    which should be zero or more of the following:
 ---    * "cmd", "command" or "⌘"
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
@@ -202,7 +203,8 @@ end
 --- Function
 --- Disables all previously set callbacks for a given keyboard combination
 ---
----  * mods - A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
+---    which should be zero or more of the following:
 ---    * "cmd", "command" or "⌘"
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
@@ -220,7 +222,8 @@ end
 --- Function
 --- Deletes all previously set callbacks for a given keyboard combination
 ---
----  * mods - A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
+---    which should be zero or more of the following:
 ---    * "cmd", "command" or "⌘"
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
@@ -256,7 +259,8 @@ end
 --- in the current context) while pressed
 ---
 --- Parameters:
----  * mods - A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
+---    which should be zero or more of the following:
 ---    * "cmd", "command" or "⌘"
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
@@ -299,7 +303,8 @@ end
 --- Creates a hotkey and enables it immediately
 ---
 --- Parameters:
----  * mods - A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
+---    which should be zero or more of the following:
 ---    * "cmd", "command" or "⌘"
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
@@ -368,7 +373,8 @@ end
 --- Creates a hotkey that is enabled/disabled as the modal is entered/exited
 ---
 --- Parameters:
----  * mods - A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
+---    which should be zero or more of the following:
 ---    * "cmd", "command" or "⌘"
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"
@@ -437,7 +443,8 @@ end
 --- Creates a new modal state, optionally with a global keyboard combination to trigger it
 ---
 --- Parameters:
----  * mods - A string containing (as substrings, with any separator) the keyboard modifiers required, which should be zero or more of the following:
+---  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
+---    which should be zero or more of the following:
 ---    * "cmd", "command" or "⌘"
 ---    * "ctrl", "control" or "⌃"
 ---    * "alt", "option" or "⌥"

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -6,7 +6,7 @@ local hotkey = require "hs.hotkey.internal"
 local keycodes = require "hs.keycodes"
 local fnutils = require "hs.fnutils"
 
---- hs.hotkey.new(mods, key, pressedfn[, releasedfn, repeatfn]) -> hotkeyObject or nil
+--- hs.hotkey.new(mods, key, pressedfn[, releasedfn, repeatfn]) -> hs.hotkey
 --- Constructor
 --- Creates a new hotkey
 ---
@@ -22,7 +22,7 @@ local fnutils = require "hs.fnutils"
 ---  * repeatfn - An optional function that will be called when a pressed hotkey is repeating
 ---
 --- Returns:
----  * An `hs.hotkey` object, or nil if an error occurred
+---  * A new `hs.hotkey` object, or nil if an error occurred
 function hotkey.new(mods, key, pressedfn, releasedfn, repeatfn)
   local keycode
 
@@ -42,7 +42,7 @@ function hotkey.new(mods, key, pressedfn, releasedfn, repeatfn)
   return k
 end
 
---- hs.hotkey.bind(mods, key, pressedfn, releasedfn, repeatfn) -> hotkeyObject or nil
+--- hs.hotkey.bind(mods, key, pressedfn, releasedfn, repeatfn, message, duration) -> hs.hotkey
 --- Constructor
 --- Creates a hotkey and enables it immediately
 ---
@@ -54,21 +54,35 @@ end
 ---   * ctrl
 ---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or if the string begins with a `#` symbol, the remainder of the string will be treated as a raw keycode number
 ---  * pressedfn - A function that will be called when the hotkey has been pressed
----  * releasedfn - An optional function that will be called when the hotkey has been released
----  * repeatfn - An optional function that will be called when a pressed hotkey is repeating
+---  * releasedfn - (optional) A function that will be called when the hotkey has been released
+---  * repeatfn - (optional) A function that will be called when a pressed hotkey is repeating
+---  * message - (optional) A string containing a message to be displayed via `hs.alert()` when the hotkey has been pressed
+---  * duration - (optional) Duration of the alert message in seconds
 ---
 --- Returns:
----  * An `hs.hotkey` object or nil if an error occurred
+---  * A new `hs.hotkey` object or nil if an error occurred
 ---
 --- Notes:
----  * This function is a simple wrapper that performs: `hs.hotkey.new(mods, key, pressedfn, releasedfn, repeatfn):enable()`
-function hotkey.bind(...)
-  local key = hotkey.new(...)
-  if key then
-      return key:enable()
-  else
-      return nil
+---  * This function is a wrapper that essentially performs: `hs.hotkey.new(mods, key, pressedfn, releasedfn, repeatfn):enable()`
+---  * If you don't need `releasedfn` nor `repeatfn`, you can simply use `hs.hotkey.bind(mods,key,fn,"message")`
+local alert,SYMBOLS,supper,ipairs,type = require'hs.alert',require'hs.utf8'.registeredKeys,string.upper,ipairs,type
+--local SYMBOLS = {cmd='⌘',ctrl='⌃',alt='⌥',shift='⇧',hyper='✧'}
+function hotkey.bind(mods, key, pressedfn, releasedfn, repeatfn, message, duration)
+  if type(releasedfn)=='string' then duration=repeatfn message=releasedfn repeatfn=nil releasedfn=nil
+  elseif type(repeatfn)=='string' then duration=message message=repeatfn repeatfn=nil end
+  if type(message)~='string' then message=nil end
+  if type(duration)~='number' then duration=nil end
+  local fnalert
+  if message then
+    local s=''
+    for _,mod in ipairs(mods) do s=s..SYMBOLS[mod] end
+    if #mods>=4 then s=SYMBOLS.concaveDiamond end
+    s=s..supper(key)
+    if #message>0 then s=s..': '..message end
+    fnalert=function()alert(s,duration or 1)pressedfn()end
   end
+  local key=hotkey.new(mods,key,fnalert or pressedfn,releasedfn,repeatfn)
+  return key and key:enable()
 end
 
 --- === hs.hotkey.modal ===
@@ -120,7 +134,7 @@ end
 function hotkey.modal:exited()
 end
 
---- hs.hotkey.modal:bind(mods, key, pressedfn, releasedfn, repeatfn)
+--- hs.hotkey.modal:bind(mods, key, pressedfn, releasedfn, repeatfn) -> hs.hotkey.modal
 --- Method
 ---
 --- Parameters:
@@ -135,7 +149,7 @@ end
 ---  * repeatfn - An optional function that will be called when a pressed hotkey is repeating
 ---
 --- Returns:
----  * An `hs.hotkey.modal` object or nil if an error occurred
+---  * The `hs.hotkey.modal` object
 ---
 function hotkey.modal:bind(mods, key, pressedfn, releasedfn, repeatfn)
   local k = hotkey.new(mods, key, pressedfn, releasedfn, repeatfn)
@@ -143,7 +157,7 @@ function hotkey.modal:bind(mods, key, pressedfn, releasedfn, repeatfn)
   return self
 end
 
---- hs.hotkey.modal:enter()
+--- hs.hotkey.modal:enter() -> hs.hotkey.modal
 --- Method
 --- Enters a modal state
 ---
@@ -165,7 +179,7 @@ function hotkey.modal:enter()
   return self
 end
 
---- hs.hotkey.modal:exit()
+--- hs.hotkey.modal:exit() -> hs.hotkey.modal
 --- Method
 --- Exits a modal state
 ---
@@ -186,7 +200,7 @@ function hotkey.modal:exit()
   return self
 end
 
---- hs.hotkey.modal.new(mods, key) -> modal
+--- hs.hotkey.modal.new(mods, key) -> hs.hotkey.modal
 --- Constructor
 --- Creates a new modal state, optionally with a global hotkey to trigger it
 ---
@@ -195,7 +209,7 @@ end
 ---  * key - A string containing the name of a keyboard key (as found in `hs.keycodes.map`)
 ---
 --- Returns:
----  * An `hs.hotkey.modal` object
+---  * A new `hs.hotkey.modal` object
 ---
 --- Notes:
 ---  * If `mods` and `key` are both nil, no global hotkey will be registered

--- a/extensions/hotkey/internal.m
+++ b/extensions/hotkey/internal.m
@@ -182,15 +182,6 @@ static int hotkey_new(lua_State* L) {
     return 1;
 }
 
-/// hs.hotkey:enable() -> hotkeyObject
-/// Method
-/// Enables a hotkey object
-///
-/// Parameters:
-///  * None
-///
-/// Returns:
-///  * The `hs.hotkey` object
 static int hotkey_enable(lua_State* L) {
     hotkey_t* hotkey = luaL_checkudata(L, 1, USERDATA_TAG);
     lua_settop(L, 1);
@@ -218,15 +209,6 @@ static void stop(lua_State* L, hotkey_t* hotkey) {
     [keyRepeatManager stopTimer];
 }
 
-/// hs.hotkey:disable() -> hotkeyObject
-/// Method
-/// Disables a hotkey object
-///
-/// Parameters:
-///  * None
-///
-/// Returns:
-///  * The `hs.hotkey` object
 static int hotkey_disable(lua_State* L) {
     hotkey_t* hotkey = luaL_checkudata(L, 1, USERDATA_TAG);
     stop(L, hotkey);

--- a/extensions/utf8/init.lua
+++ b/extensions/utf8/init.lua
@@ -197,6 +197,7 @@ end
 ---     (U+21EA) capslock         ⇪
 ---     (U+2713) checkMark        ✓
 ---     (U+2318) cmd              ⌘
+---     (U+27E1) concaveDiamond   ✧
 ---     (U+00A9) copyrightSign    ©
 ---     (U+2303) ctrl             ⌃
 ---     (U+232B) delete           ⌫
@@ -290,6 +291,7 @@ module.registerCodepoint("sectionSign",      0x00A7)
 module.registerCodepoint("copyrightSign",    0x00A9)
 module.registerCodepoint("registeredSign",   0x00AE)
 module.registerCodepoint("checkMark",        0x2713)
+module.registerCodepoint("concaveDiamond",   0x27E1)
 
 --- hs.utf8.asciiOnly(string[, all]) -> string
 --- Function


### PR DESCRIPTION
This branch continues from #386, but different goal so separate PR.

- Fixed #184 and similar issues (potentially more troubling than the examples in that issue is the fact that modal hotkeys use the same global pool - one wouldn't expect conflicts there) by allowing multiple hotkeys to be registered for the same keyboard combo following nested shadowing logic; when a hotkey is enabled "over" of a previous one, the latter is disabled, and automatically reenabled should the former get disabled/deleted. (There's an undocumented parameter in `hotkey:enable` to override the nesting rule, so that an already shadowed hotkey can be forced back on top - no use case in mind, it's there just in case it turns out to be needed for something)
- Changed the `mods` parameter to string, like `'cmd-alt'` or `'⌘⌥'`  (`'controloptionshiftcommand'`will also work) + backward compatible with the old tables
- Added some basic logging (should help a bit when users are trying to wrap their head around modal hotkeys for the first time)
- Added `hotkey.showHotkeys` to (very crudely for now) list all active hotkeys (a-la cheatsheet) to help memory with new and/or huge configurations