### PR TITLE
add pasteboardTypes and contentTypes

### DIFF
--- a/extensions/pasteboard/internal.m
+++ b/extensions/pasteboard/internal.m
@@ -61,6 +61,49 @@ static int pasteboard_clearContents(lua_State* L) {
     return 0;
 }
 
+/// hs.pasteboard.pasteboardTypes([name]) -> boolean
+/// Function
+/// Return the pasteboard type identifier strings for the specified pasteboard.
+///
+/// Parameters:
+///  * name - An optional string containing the name of the pasteboard. Defaults to the system pasteboard
+///
+/// Returns:
+///  * a table containing the pasteboard type identifier strings
+static int pasteboard_pasteboardTypes(lua_State* L) {
+    NSPasteboard* thePasteboard = lua_to_pasteboard(L, 1);
+
+    lua_newtable(L) ;
+        for (NSString* type in [thePasteboard types]) {
+            lua_pushstring(L, [type UTF8String]) ; lua_rawseti(L, -2, luaL_len(L, -2) + 1) ;
+        }
+
+    return 1;
+}
+
+/// hs.pasteboard.contentTypes([name]) -> boolean
+/// Function
+/// Return the UTI strings of the data types for the first pasteboard item on the specified pasteboard.
+///
+/// Parameters:
+///  * name - An optional string containing the name of the pasteboard. Defaults to the system pasteboard
+///
+/// Returns:
+///  * a table containing the UTI strings of the data types for the first pasteboard item.
+static int pasteboard_pasteboardItemTypes(lua_State* L) {
+    NSPasteboard* thePasteboard = lua_to_pasteboard(L, 1);
+
+    lua_newtable(L) ;
+// make sure there is something on the pasteboard...
+    if ([[thePasteboard pasteboardItems] count] > 0) {
+        NSPasteboardItem* item = [[thePasteboard pasteboardItems] objectAtIndex:0];
+        for (NSString* type in [item types]) {
+            lua_pushstring(L, [type UTF8String]) ; lua_rawseti(L, -2, luaL_len(L, -2) + 1) ;
+        }
+    }
+    return 1;
+}
+
 /// hs.pasteboard.changeCount([name]) -> number
 /// Function
 /// Gets the number of times the pasteboard owner has changed
@@ -99,10 +142,12 @@ static int pasteboard_delete(lua_State* L) {
 
 // Functions for returned object when module loads
 static const luaL_Reg pasteboardLib[] = {
-    {"changeCount",  pasteboard_changeCount},
-    {"getContents",  pasteboard_getContents},
-    {"setContents",  pasteboard_setContents},
-    {"clearContents", pasteboard_clearContents},
+    {"changeCount",      pasteboard_changeCount},
+    {"getContents",      pasteboard_getContents},
+    {"setContents",      pasteboard_setContents},
+    {"clearContents",    pasteboard_clearContents},
+    {"pasteboardTypes",  pasteboard_pasteboardTypes},
+    {"contentTypes",     pasteboard_pasteboardItemTypes},
     {"deletePasteboard", pasteboard_delete},
     {NULL,      NULL}
 };


### PR DESCRIPTION
Added a way to get information about the sender and intent of the clipboard contents via pasteboardTypes and contentTypes.

In reference to https://groups.google.com/d/msgid/hammerspoon/9F87511F-8858-4034-9336-75778DDF4F82%40tenshu.net?utm_medium=email&utm_source=footer

See also http://nspasteboard.org.

Sample of the results from 1Password placing a password into the clipboard:

~~~
> inspect(hs.pasteboard.pasteboardTypes())
{ "public.utf8-plain-text", "NSStringPboardType", "com.agilebits.onepassword", "org.nspasteboard.ConcealedType" }

> inspect(hs.pasteboard.contentTypes())
{ "public.utf8-plain-text", "com.agilebits.onepassword", "org.nspasteboard.ConcealedType" }
~~~

Note the "org.nspasteboard.ConcealedType", which indicates that we should not store or save this data.

Currently contentTypes only returns the information about the 1st item on the pasteboard, but since that's the only one we can manipulate at present, that's not a problem.

