### PR TITLE
hide grid when switching spaces

### DIFF
--- a/extensions/grid/init.lua
+++ b/extensions/grid/init.lua
@@ -824,6 +824,9 @@ function grid.toggleShow()
   if showing then grid.hide() else grid.show() end
 end
 
+local spacesWatcher = require'hs.spaces'.watcher.new(grid.hide)
+spacesWatcher:start()
+
 -- Legacy stuff below
 
 


### PR DESCRIPTION
In a just world, there'd be a way of "dragging" the window along to the new space. Maybe a hack could be put in place with creative use of something like :setBehavior from the revamped hs.drawing module, but I doubt it'd be possible to do that on foreign windows anyway.