### PR TITLE
Add support for scroll wheel

### DIFF
--- a/extensions/eventtap/init.lua
+++ b/extensions/eventtap/init.lua
@@ -165,6 +165,26 @@ function module.keyStroke(modifiers, character)
     module.event.newKeyEvent(modifiers, string.lower(character), false):post()
 end
 
+
+--- hs.eventtap.scrollWheel(offsets, modifiers, unit) -> event
+--- Function
+--- Generates and emits a scroll wheel event
+---
+--- Parameters:
+---  * offsets - A table containing the {horizontal, vertical} amount to scroll. Positive values scroll up or left, negative values scroll down or right.
+---  * mods - A table containing zero or more of the following:
+---   * cmd
+---   * alt
+---   * shift
+---   * ctrl
+---   * fn
+---  * unit - An optional string containing the name of the unit for scrolling. Either "line" (the default) or "pixel"
+---
+--- Returns:
+---  * None
+function module.scrollWheel(offsets, modifiers, unit)
+    module.event.newScrollEvent(offsets, modifiers, unit):post()
+end
 -- Return Module Object --------------------------------------------------
 
 return module


### PR DESCRIPTION
**Full Disclosure** - This is my first time working with OS X or the Lua C APIs and was hacked together through a combination of reference docs and Google results. Please review with care, and I welcome suggestions for improvement.

This adds support for creating and executing scroll wheel events. I figured it belonged in the event module next to the `newMouseEvent` support for clicking rather than the mouse module which seems to be not event based and just for movement.