### PR TITLE
developmental file changes

### DIFF
--- a/Hammerspoon/setup.lua
+++ b/Hammerspoon/setup.lua
@@ -44,8 +44,9 @@ hs.docstrings_json_file = docstringspath
 ---     if not ok then hs.showError(err) end```
 function hs.showError(err)
   hs._notify("Hammerspoon config error") -- undecided on this line
-  print(debug.traceback())
-  print(err)
+--  print(debug.traceback())
+--  print(err)
+  print(debug.traceback(err, 2))
   hs.focus()
   hs.openConsole()
 end

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,7 @@ clean:
 	rm -rf extensions/.build
 	rm -rf extensions/*/*.dSYM
 
-.PHONY: release clean
+clean-docs:
+	rm -fr build/Hammerspoon.docset build/Hammerspoon.tgz build/html build/docs.json
+
+.PHONY: release clean clean-docs

--- a/extensions/hammerspoon.h
+++ b/extensions/hammerspoon.h
@@ -1,9 +1,13 @@
 // Import the Lua API so we can do Lua things here
 #import <LuaSkin/LuaSkin.h>
 
+#ifndef HS_EXTERNAL_MODULE
 // Import the Crashlytics API so we can define our own crashlog+NSLog call
 #import "../Crashlytics.framework/Headers/Crashlytics.h"
 #define CLS_NSLOG(__FORMAT__, ...) CLSNSLog((@"%s line %d $ " __FORMAT__), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)
+#else
+#define CLS_NSLOG NSLog
+#endif
 
 // Define some useful utility functions
 


### PR DESCRIPTION
* hammerspoon.h - added a check for the macro HS_EXTERNAL_MODULE so that adding `-DHS_EXTERNAL_MODULE` to EXTRA_CFLAGS in a Makefile for an external module allows for including this file during development.

* Makefile - added `clean-docs` target, so docs can be cleaned and rebuilt without rebuilding the entire Hammerspoon package during doc review before pushing a new module to core.

* setup.lua - modified hs.showError so that it invokes `debug.traceback(err, 2)` to put message at top of stack trace, instead of bottom, and to prevent inclusion of the hs.showError function itself in the traceback.