### PR TITLE
Userdata __tostring methods for application and window

### DIFF
--- a/extensions/menubar/internal.m
+++ b/extensions/menubar/internal.m
@@ -709,7 +709,7 @@ static int menubaritem_gc(lua_State *L) {
 static int userdata_tostring(lua_State* L) {
     NSString *title = [((__bridge NSStatusItem*)(get_item_arg(L, 1))->menuBarItemObject) title] ;
 
-    lua_pushstring(L, [[NSString stringWithFormat:@"%s:%@ (%p)", USERDATA_TAG, title, lua_topointer(L, 1)] UTF8String]) ;
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, title, lua_topointer(L, 1)] UTF8String]) ;
     return 1 ;
 }
 

--- a/extensions/window/internal.m
+++ b/extensions/window/internal.m
@@ -681,6 +681,41 @@ static int window_snapshot(lua_State* L) {
     }
 }
 
+// Trying to make this as close to paste and apply as possible, so not all aspects may apply
+// to each module... you may still need to tweak for your specific module.
+
+static int userdata_tostring(lua_State* L) {
+
+// For older modules that don't use this macro, Change this:
+#ifndef USERDATA_TAG
+#define USERDATA_TAG "hs.window"
+#endif
+
+// can't assume, since some older modules and userdata share __index
+    void *self = lua_touserdata(L, 1) ;
+    if (self) {
+// Change these to get the desired title, if available, for your module:
+        AXUIElementRef win ;
+        win = get_window_arg(L, 1) ;
+        NSString* title = get_window_prop(win, NSAccessibilityTitleAttribute, @"");
+// Use this instead, if you always want the title portion empty for your module
+//        NSString* title = @"" ;
+
+// Common code begins here:
+
+       lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, title, lua_topointer(L, 1)] UTF8String]) ;
+    } else {
+// For modules which share the same __index for the module table and the userdata objects, this replicates
+// current default, which treats the module as a table when checking for __tostring.  You could also put a fancier
+// string here for your module and set userdata_tostring as the module's __tostring as well...
+//
+// See lauxlib.c -- luaL_tolstring would invoke __tostring and loop, so let's
+// use its output for tables (the "default:" case in luaL_tolstring's switch)
+        lua_pushfstring(L, "%s: %p", luaL_typename(L, 1), lua_topointer(L, 1));
+    }
+    return 1 ;
+}
+
 static const luaL_Reg windowlib[] = {
     {"focusedWindow", window_focusedwindow},
     {"_orderedwinids", window__orderedwinids},
@@ -728,6 +763,9 @@ int luaopen_hs_window_internal(lua_State* L) {
         lua_getfield(L, -1, "__eq");
         lua_remove(L, -2);
         lua_setfield(L, -2, "__eq");
+
+        lua_pushcfunction(L, userdata_tostring) ;
+        lua_setfield(L, -2, "__tostring") ;
 
         lua_pushcfunction(L, window_gc);
         lua_setfield(L, -2, "__gc");


### PR DESCRIPTION
Via a fairly simple C-code function which can be added easily to most modules with just a little tweaking, you can get console output like the following in the console (I know most "users" won't see this, but it can be helpful when debugging and building):

~~~lua
> hs.fnutils.map(hs.window.allWindows(),print)
-- Loading extension: fnutils
-- Loading extension: window
hs.window:  (0x600000241978)
hs.window: Window (0x6080000506d8)
hs.window: Window (0x608000049c58)
hs.window: Window (0x608000049c28)
hs.window: Window (0x6080000511b8)
hs.window: Security & Privacy (0x600000241798)
hs.window: hammerspoon — bash — 80×24 (0x60800004f628)
hs.window: Google (0x6000002419a8)
hs.window: Pickwick Monitoring Links (0x600000241858)
hs.window: Hammerspoon Console (0x60800004f718)
table: 0x60800007d300

> hs.fnutils.map(hs.application.runningApplications(),print)
-- Loading extension: application
hs.application: loginwindow (0x600000243238)
hs.application: SystemUIServer (0x60800004b5d8)
hs.application: Dock (0x608000054488)
hs.application: universalaccessd (0x608000053d08)
hs.application: com.apple.dock.extra (0x6080000556e8)
hs.application: Spotlight (0x608000050c48)
hs.application: Photos Agent (0x60800004ad68)
hs.application: com.apple.internetaccounts (0x6000002409b8)
hs.application: Finder (0x608000054938)
hs.application: Little Snitch Agent (0x60000005f6d8)
hs.application: iTunes Helper (0x600000240c28)
hs.application: Dash (0x6080000521a8)
hs.application: Keychain Circle Notification (0x600000240808)
hs.application: Notification Center (0x600000240598)
hs.application: Little Snitch Network Monitor (0x6080000525c8)
hs.application: Tunnelblick (0x608000049208)
hs.application: GitHub Conduit (0x60800004e9f8)
hs.application: Wi-Fi (0x60800004ea58)
hs.application: com.apple.MailServiceAgent (0x600000243208)
hs.application: GeekTool Helper (0x6080000533d8)
hs.application: EscrowSecurityAlert (0x600000243268)
hs.application: nbagent (0x60000005fe58)
hs.application: LaterAgent (0x608000049238)
hs.application: AirPlayUIAgent (0x60800004ea88)
hs.application: sharingd (0x60800004eae8)
hs.application: CoreServicesUIAgent (0x60800004eb48)
hs.application: Image Capture Extension (0x6080000492f8)
hs.application: storeuid (0x60800004ebd8)
hs.application: System Preferences (0x60800004eb18)
hs.application: com.apple.preference.security.remoteservice (0x60800004ec98)
hs.application: universalAccessAuthWarn (0x60800004ecc8)
hs.application: Calendar (0x600000243088)
hs.application: 1Password mini (0x60800004e878)
hs.application: Spotlight Web Content (0x6000002430e8)
hs.application: QTKitServer-(36126) Spotlight Web Content (0x60000005ce88)
hs.application: Terminal (0x600000240b08)
hs.application: Safari (0x60800004ec68)
hs.application: Safari Web Content (0x60800004ede8)
hs.application: Safari Networking (0x60800004ee18)
hs.application: Safari Web Content (0x600000240b38)
hs.application: Safari Web Content (0x6080000493b8)
hs.application: QTKitServer-(47792) Safari (0x600000243028)
hs.application: Mail (0x60800004ecf8)
hs.application: Mail Web Content (0x600000240838)
hs.application: Mail Web Content (0x600000243478)
hs.application: LookupViewService (0x608000049448)
hs.application: Hammerspoon (0x60800004efc8)
table: 0x608000262600
~~~