### PR TITLE
Documentation improvements

### DIFF
--- a/scripts/docs/templates/docs.css
+++ b/scripts/docs/templates/docs.css
@@ -7,13 +7,12 @@
 body {
   color: #333;
   font-family: system, -apple-system, ".SFNSDisplay-Regular", HelveticaNeue, LucidaGrande, sans-serif;
-  font-size: 13pt;
+  font-size: 12pt;
   line-height: 1.6;
   word-wrap: break-word;
   width: 80%;
   margin: 0.5em auto;
-  border: 1px solid rgb(221, 221, 221);
-  padding: 30px;
+  padding: 0 30px;
 }
 
 pre {
@@ -198,6 +197,9 @@ dd {
   margin-left: 0;
 }
 
+li {
+  line-height: 1.3em;
+}
 
 .octicon {
   font: normal normal 16px octicons-anchor;
@@ -246,7 +248,7 @@ h5,
 h6 {
   position: relative;
   margin-top: 1em;
-  margin-bottom: 16px;
+  margin-bottom: 0;
   font-weight: bold;
   line-height: 1.4;
 }
@@ -283,7 +285,8 @@ h6:hover .anchor .octicon-link {
 }
 
 h1 {
-  padding-bottom: 0.3em;
+  padding-bottom: 0.1em;
+  margin:0;
   font-size: 2.25em;
   line-height: 1.2;
   border-bottom: 1px solid #eee;
@@ -322,7 +325,7 @@ h4 .anchor {
 }
 
 h5 {
-  font-size: 1em;
+  font-size: 1.1em;
 }
 
 h5 .anchor {
@@ -423,6 +426,12 @@ table td {
   border: 1px solid #ddd;
 }
 
+/* Narrow to overview here,
+   otherwise we trample the function descriptions */
+table.api-documentation-overview td p {
+  margin: 0;
+}
+
 table tr {
   background-color: #fff;
   border-top: 1px solid #ccc;
@@ -502,6 +511,10 @@ pre code {
 pre code:before,
 pre code:after {
   content: normal;
+}
+
+.documentation-section {
+  border-bottom: 1px solid lightgray;
 }
 
 

--- a/scripts/docs/templates/ext.html.erb
+++ b/scripts/docs/templates/ext.html.erb
@@ -5,8 +5,6 @@
     <style type="text/css">
       a { text-decoration: none; }
       a:hover { text-decoration: underline; }
-      header { padding-bottom: 10px; }
-      section { border-top: 1px solid #777; padding-bottom: 20px; }
       th { background-color: #DDDDDD; vertical-align: top; padding: 3px; }
       td { width: 100%; background-color: #EEEEEE; vertical-align: top; padding: 3px; }
       table { width: 100% ; border: 1px solid #0; text-align: left; }
@@ -18,7 +16,7 @@
       <h1><%= mod['name'] %></h1>
       <%= GitHub::Markdown.render_gfm(mod['doc']) %>
       </header>
-      <h2>API Overview</h2>
+      <h3>API Overview</h3>
       <ul>
     <%
         sectionorder = %w(Deprecated Command Constant Variable Function Constructor Method);
@@ -53,13 +51,13 @@
         end
         %>
     </ul>
-    <h2>API Documentation</h2>
+    <h3>API Documentation</h3>
     <%
         sectionorder.each do |section|
             items = mod['items'].select{|m| m['type'] == section}.sort_by{|m|m['name']}
             if items.length > 0
                 %>
-                <h3><%= section %>s</h3>
+                <h4 class="documentation-section"><%= section %>s</h4>
                 <%
             end
             items.each do |item|
@@ -67,7 +65,7 @@
 
     <section id="<%= item['name'] %>">
     <a name="//apple_ref/cpp/<%= item['type'] %>/<%= item['name'] %>" class="dashAnchor"></a>
-    <h3><a href="#<%= item['name'] %>"><%= item['name'] %></a></h3>
+    <h5><a href="#<%= item['name'] %>"><%= item['name'] %></a></h5>
     <table>
         <tr>
             <th>Signature</td>

--- a/scripts/docs/templates/index.html.erb
+++ b/scripts/docs/templates/index.html.erb
@@ -19,7 +19,7 @@
     <section>
     <!-- tables suck., I know, but it's fast to code -->
     <h3>API documentation</h3>
-    <table>
+    <table class="api-documentation-overview">
         <% docmods.each do |mod| %>
             <tr>
                 <th><a href="<%= mod['name']%>.html"><%= mod['name'] %></a></th>


### PR DESCRIPTION
Hey, so I really like what's happened with the documentation pages. One thing I'm missing from the old ones however, was that they were significantly more condensed and easier to survey on my laptop screen. So I've dialed back the whitespace a bit, and removed some things that just clutter up the docs.

- Significantly decreased the amount of unnecessary whitespace on
  header elements and the body to make the documentation easier
  to browse on laptops
- Fixed bug where each table cell on the documentation startpage was
  getting extra bottom padding
- Removed superflous border on body
- Removed superflous border on each function section; instead using
  whitespace and proximity to guide the eye.
- Decreased all but the top header (h1) sizes on the module pages
  since h1s and h2s are so similar in size.