### PR TITLE
improve window.focusWindow.. and window.windowsTo.. methods

### DIFF
--- a/extensions/windowfilter/init.lua
+++ b/extensions/windowfilter/init.lua
@@ -1455,7 +1455,7 @@ for n,dir in ipairs{'East','North','West','South'}do
     return window['windowsTo'..dir](win,self:getWindows(),...)
   end
   wf['focusWindow'..dir]=function(self,win,...)
-    return window['focusWindow'..dir](win,self:getWindows(),...)
+    if window['focusWindow'..dir](win,self:getWindows(),...) then self.log.i('Focused window '..dir:lower()) end
   end
 end
 

--- a/extensions/windowfilter/init.lua
+++ b/extensions/windowfilter/init.lua
@@ -350,7 +350,7 @@ end
 --TODO hs.windowsnap (or snapareas)
 --[[
 function wf:setScreens(screens)
-  if not screens then self.screens=nil 
+  if not screens then self.screens=nil
   else
     if type(screens)=='userdata' then screens={screens} end
     if type(screens)~='table' then error('screens must be a `hs.screen` object, or table of objects',2) end
@@ -361,7 +361,7 @@ function wf:setScreens(screens)
     self.screens=screens
   end
   if activeFilters[self] then refreshWindows(self) end
-  return self  
+  return self
 end
 --]]
 --- hs.windowfilter.new(fn,logname,loglevel) -> hs.windowfilter
@@ -1383,7 +1383,7 @@ end
 --- Notes:
 ---  * This is a convenience wrapper that returns `hs.window.windowsToSouth(window,self:getWindows(),...)`
 
---- hs.window:focusWindowEast(window, frontmost, strict)
+--- hs.windowfilter:focusWindowEast(window, frontmost, strict)
 --- Method
 --- Focuses the nearest window to the east of a given window
 ---
@@ -1400,7 +1400,7 @@ end
 ---  * This is a convenience wrapper that performs `hs.window.focusWindowEast(window,self:getWindows(),...)`
 ---  * You'll likely want to add `:trackSpaces(true)` to the windowfilter used for this method call.
 
---- hs.window:focusWindowWest(window, frontmost, strict)
+--- hs.windowfilter:focusWindowWest(window, frontmost, strict)
 --- Method
 --- Focuses the nearest window to the west of a given window
 ---
@@ -1417,7 +1417,7 @@ end
 ---  * This is a convenience wrapper that performs `hs.window.focusWindowWest(window,self:getWindows(),...)`
 ---  * You'll likely want to add `:trackSpaces(true)` to the windowfilter used for this method call.
 
---- hs.window:focusWindowSouth(window, frontmost, strict)
+--- hs.windowfilter:focusWindowSouth(window, frontmost, strict)
 --- Method
 --- Focuses the nearest window to the north of a given window
 ---
@@ -1434,7 +1434,7 @@ end
 ---  * This is a convenience wrapper that performs `hs.window.focusWindowSouth(window,self:getWindows(),...)`
 ---  * You'll likely want to add `:trackSpaces(true)` to the windowfilter used for this method call.
 
---- hs.window:focusWindowNorth(window, frontmost, strict)
+--- hs.windowfilter:focusWindowNorth(window, frontmost, strict)
 --- Method
 --- Focuses the nearest window to the south of a given window
 ---

--- a/extensions/windowfilter/init.lua
+++ b/extensions/windowfilter/init.lua
@@ -1308,13 +1308,155 @@ function wf:delete()
   stopGlobalWatcher()
 end
 
-
-
 local defaultwf
 function windowfilter.setLogLevel(lvl)
   log.setLogLevel(lvl)
   if defaultwf then defaultwf.setLogLevel(lvl) end
   return windowfilter
+end
+
+
+
+-- utilities
+
+--- hs.windowfilter:windowsToEast(window, frontmost, strict) -> list of `hs.window` objects
+--- Method
+--- Gets all visible windows allowed by this windowfilter that lie to the east a given window
+---
+--- Parameters:
+---  * window - (optional) an `hs.window` object; if nil, `hs.window.frontmostWindow()` will be used
+---  * frontmost - (optional) boolean, if true unoccluded windows will be placed before occluded ones in the result list
+---  * strict - (optional) boolean, if true only consider windows at an angle between 45° and -45° on the
+---    eastward axis
+---
+--- Returns:
+---  * A list of `hs.window` objects representing all windows positioned east (i.e. right) of the window, in ascending order of distance
+---
+--- Notes:
+---  * This is a convenience wrapper that returns `hs.window.windowsToEast(window,self:getWindows(),...)`
+
+--- hs.windowfilter:windowsToWest(window, frontmost, strict) -> list of `hs.window` objects
+--- Method
+--- Gets all visible windows allowed by this windowfilter that lie to the west a given window
+---
+--- Parameters:
+---  * window - (optional) an `hs.window` object; if nil, `hs.window.frontmostWindow()` will be used
+---  * frontmost - (optional) boolean, if true unoccluded windows will be placed before occluded ones in the result list
+---  * strict - (optional) boolean, if true only consider windows at an angle between 45° and -45° on the
+---    westward axis
+---
+--- Returns:
+---  * A list of `hs.window` objects representing all windows positioned west (i.e. left) of the window, in ascending order of distance
+---
+--- Notes:
+---  * This is a convenience wrapper that returns `hs.window.windowsToWest(window,self:getWindows(),...)`
+
+--- hs.windowfilter:windowsToNorth(window, frontmost, strict) -> list of `hs.window` objects
+--- Method
+--- Gets all visible windows allowed by this windowfilter that lie to the north a given window
+---
+--- Parameters:
+---  * window - (optional) an `hs.window` object; if nil, `hs.window.frontmostWindow()` will be used
+---  * frontmost - (optional) boolean, if true unoccluded windows will be placed before occluded ones in the result list
+---  * strict - (optional) boolean, if true only consider windows at an angle between 45° and -45° on the
+---    northward axis
+---
+--- Returns:
+---  * A list of `hs.window` objects representing all windows positioned north (i.e. up) of the window, in ascending order of distance
+---
+--- Notes:
+---  * This is a convenience wrapper that returns `hs.window.windowsToNorth(window,self:getWindows(),...)`
+
+--- hs.windowfilter:windowsToSouth(window, frontmost, strict) -> list of `hs.window` objects
+--- Method
+--- Gets all visible windows allowed by this windowfilter that lie to the south a given window
+---
+--- Parameters:
+---  * window - (optional) an `hs.window` object; if nil, `hs.window.frontmostWindow()` will be used
+---  * frontmost - (optional) boolean, if true unoccluded windows will be placed before occluded ones in the result list
+---  * strict - (optional) boolean, if true only consider windows at an angle between 45° and -45° on the
+---    southward axis
+---
+--- Returns:
+---  * A list of `hs.window` objects representing all windows positioned south (i.e. down) of the window, in ascending order of distance
+---
+--- Notes:
+---  * This is a convenience wrapper that returns `hs.window.windowsToSouth(window,self:getWindows(),...)`
+
+--- hs.window:focusWindowEast(window, frontmost, strict)
+--- Method
+--- Focuses the nearest window to the east of a given window
+---
+--- Parameters:
+---  * window - (optional) an `hs.window` object; if nil, `hs.window.frontmostWindow()` will be used
+---  * frontmost - (optional) boolean, if true focuses the nearest window that isn't occluded by any other window in this windowfilter
+---  * strict - (optional) boolean, if true only consider windows at an angle between 45° and -45° on the
+---    eastward axis
+---
+--- Returns:
+---  * None
+---
+--- Notes:
+---  * This is a convenience wrapper that performs `hs.window.focusWindowEast(window,self:getWindows(),...)`
+---  * You'll likely want to add `:trackSpaces(true)` to the windowfilter used for this method call.
+
+--- hs.window:focusWindowWest(window, frontmost, strict)
+--- Method
+--- Focuses the nearest window to the west of a given window
+---
+--- Parameters:
+---  * window - (optional) an `hs.window` object; if nil, `hs.window.frontmostWindow()` will be used
+---  * frontmost - (optional) boolean, if true focuses the nearest window that isn't occluded by any other window in this windowfilter
+---  * strict - (optional) boolean, if true only consider windows at an angle between 45° and -45° on the
+---    westward axis
+---
+--- Returns:
+---  * None
+---
+--- Notes:
+---  * This is a convenience wrapper that performs `hs.window.focusWindowWest(window,self:getWindows(),...)`
+---  * You'll likely want to add `:trackSpaces(true)` to the windowfilter used for this method call.
+
+--- hs.window:focusWindowSouth(window, frontmost, strict)
+--- Method
+--- Focuses the nearest window to the north of a given window
+---
+--- Parameters:
+---  * window - (optional) an `hs.window` object; if nil, `hs.window.frontmostWindow()` will be used
+---  * frontmost - (optional) boolean, if true focuses the nearest window that isn't occluded by any other window in this windowfilter
+---  * strict - (optional) boolean, if true only consider windows at an angle between 45° and -45° on the
+---    northward axis
+---
+--- Returns:
+---  * None
+---
+--- Notes:
+---  * This is a convenience wrapper that performs `hs.window.focusWindowSouth(window,self:getWindows(),...)`
+---  * You'll likely want to add `:trackSpaces(true)` to the windowfilter used for this method call.
+
+--- hs.window:focusWindowNorth(window, frontmost, strict)
+--- Method
+--- Focuses the nearest window to the south of a given window
+---
+--- Parameters:
+---  * window - (optional) an `hs.window` object; if nil, `hs.window.frontmostWindow()` will be used
+---  * frontmost - (optional) boolean, if true focuses the nearest window that isn't occluded by any other window in this windowfilter
+---  * strict - (optional) boolean, if true only consider windows at an angle between 45° and -45° on the
+---    southward axis
+---
+--- Returns:
+---  * None
+---
+--- Notes:
+---  * This is a convenience wrapper that performs `hs.window.focusWindowNorth(window,self:getWindows(),...)`
+---  * You'll likely want to add `:trackSpaces(true)` to the windowfilter used for this method call.
+for n,dir in ipairs{'East','North','West','South'}do
+  wf['windowsTo'..dir]=function(self,win,...)
+    return window['windowsTo'..dir](win,self:getWindows(),...)
+  end
+  wf['focusWindow'..dir]=function(self,win,...)
+    return window['focusWindow'..dir](win,self:getWindows(),...)
+  end
 end
 
 local rawget=rawget


### PR DESCRIPTION
Added `candidateWindows`, `frontmost`, `strict` parameters; removed `sameApp` parameter (but backward compatibility is maintained) because I suspect it's not a general use one, i.e. it's only likely to be used for apps like terminals, editors and browsers; for those cases, better to encourage specialised windowfilters, now that it's a thing.

I also want to add module-level variables for `frontmost` and `strict`.
