### PR TITLE
Updates to allow core to edit application Preferences from lua (console)

### DIFF
--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -8,6 +8,7 @@
 #import "../extensions/hammerspoon.h"
 #import "MJMenuIcon.h"
 #import "MJPreferencesWindowController.h"
+#import "MJConsoleWindowController.h"
 #import "MJAutoLaunch.h"
 
 static LuaSkin* MJLuaState;
@@ -51,6 +52,27 @@ static int core_autolaunch(lua_State* L) {
 static int core_menuicon(lua_State* L) {
     if (lua_isboolean(L, -1)) { MJMenuIconSetVisible(lua_toboolean(L, -1)); }
     lua_pushboolean(L, MJMenuIconVisible()) ;
+    return 1;
+}
+
+
+// hs.dockIcon -- for historical reasons, this is actually handled by the hs.dockicon module, but a wrapper
+// in the lua portion of this (setup.lua) provides an interface to this module which follows the syntax
+// conventions used here.
+
+
+/// hs.consoleOnTop([state]) -> bool
+/// Function
+/// Set or display whether or not the Hammerspoon console is always on top when visible.
+///
+/// Parameters:
+///  * state - an optional boolean which will set whether or not the Hammerspoon console is always on top when visible.
+///
+/// Returns:
+///  * True if the console is currently set (or has just been) to be always on top when visible or False if it is not.
+static int core_consoleontop(lua_State* L) {
+    if (lua_isboolean(L, -1)) { MJConsoleWindowSetAlwaysOnTop(lua_toboolean(L, -1)); }
+    lua_pushboolean(L, MJConsoleWindowAlwaysOnTop()) ;
     return 1;
 }
 
@@ -180,6 +202,7 @@ static int core_notify(lua_State* L) {
 
 static luaL_Reg corelib[] = {
     {"openConsole", core_openconsole},
+    {"consoleOnTop", core_consoleontop},
     {"openAbout", core_openabout},
     {"menuIcon", core_menuicon},
     {"openPreferences", core_openpreferences},

--- a/Hammerspoon/MJPreferencesWindowController.m
+++ b/Hammerspoon/MJPreferencesWindowController.m
@@ -33,6 +33,19 @@
     return s;
 }
 
+- (void)updateFeedbackDisplay:(NSNotification __unused *)notification {
+    [self.openAtLoginCheckbox setState:MJAutoLaunchGet() ? NSOnState : NSOffState];
+    [self.showDockIconCheckbox setState: MJDockIconVisible() ? NSOnState : NSOffState];
+    [self.showMenuIconCheckbox setState: MJMenuIconVisible() ? NSOnState : NSOffState];
+    [self.keepConsoleOnTopCheckbox setState: MJConsoleWindowAlwaysOnTop() ? NSOnState : NSOffState];
+    [self.uploadCrashDataCheckbox setState: HSUploadCrashData() ? NSOnState : NSOffState];
+#ifndef CRASHLYTICS_API_KEY
+    [self.uploadCrashDataCheckbox setState:NSOffState];
+    [self.uploadCrashDataCheckbox setEnabled:NO];
+#endif
+
+}
+
 - (void) showWindow:(id)sender {
     if (![[self window] isVisible])
         [[self window] center];
@@ -60,19 +73,11 @@
     [self.uploadCrashDataCheckbox setEnabled:NO];
 #endif
 
-}
-
-- (void)updateFeedbackDisplay {
-
-    [self.openAtLoginCheckbox setState:MJAutoLaunchGet() ? NSOnState : NSOffState];
-    [self.showDockIconCheckbox setState: MJDockIconVisible() ? NSOnState : NSOffState];
-    [self.showMenuIconCheckbox setState: MJMenuIconVisible() ? NSOnState : NSOffState];
-    [self.keepConsoleOnTopCheckbox setState: MJConsoleWindowAlwaysOnTop() ? NSOnState : NSOffState];
-    [self.uploadCrashDataCheckbox setState: HSUploadCrashData() ? NSOnState : NSOffState];
-#ifndef CRASHLYTICS_API_KEY
-    [self.uploadCrashDataCheckbox setState:NSOffState];
-    [self.uploadCrashDataCheckbox setEnabled:NO];
-#endif
+    NSNotificationCenter *changeWatcher = [NSNotificationCenter defaultCenter];
+    [changeWatcher addObserver:self
+                      selector:@selector(updateFeedbackDisplay:)
+                          name:NSUserDefaultsDidChangeNotification
+                        object:nil];
 
 }
 

--- a/Hammerspoon/MJPreferencesWindowController.m
+++ b/Hammerspoon/MJPreferencesWindowController.m
@@ -47,9 +47,23 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         [self cacheIsAccessibilityEnabled];
     });
-    
+
     [[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(accessibilityChanged:) name:@"com.apple.accessibility.api" object:nil];
-    
+
+    [self.openAtLoginCheckbox setState:MJAutoLaunchGet() ? NSOnState : NSOffState];
+    [self.showDockIconCheckbox setState: MJDockIconVisible() ? NSOnState : NSOffState];
+    [self.showMenuIconCheckbox setState: MJMenuIconVisible() ? NSOnState : NSOffState];
+    [self.keepConsoleOnTopCheckbox setState: MJConsoleWindowAlwaysOnTop() ? NSOnState : NSOffState];
+    [self.uploadCrashDataCheckbox setState: HSUploadCrashData() ? NSOnState : NSOffState];
+#ifndef CRASHLYTICS_API_KEY
+    [self.uploadCrashDataCheckbox setState:NSOffState];
+    [self.uploadCrashDataCheckbox setEnabled:NO];
+#endif
+
+}
+
+- (void)updateFeedbackDisplay {
+
     [self.openAtLoginCheckbox setState:MJAutoLaunchGet() ? NSOnState : NSOffState];
     [self.showDockIconCheckbox setState: MJDockIconVisible() ? NSOnState : NSOffState];
     [self.showMenuIconCheckbox setState: MJMenuIconVisible() ? NSOnState : NSOffState];
@@ -140,10 +154,10 @@
 - (void) maybeWarnAboutDockMenuProblem {
     if (MJMenuIconVisible() || MJDockIconVisible())
         return;
-    
+
     if ([[NSUserDefaults standardUserDefaults] boolForKey:MJSkipDockMenuIconProblemAlertKey])
         return;
-    
+
     NSAlert* alert = [[NSAlert alloc] init];
     [alert setAlertStyle:NSWarningAlertStyle];
     [alert setMessageText:@"How to get back to this window"];

--- a/Hammerspoon/setup.lua
+++ b/Hammerspoon/setup.lua
@@ -173,37 +173,6 @@ if autoload_extensions then
   })
 end
 
-local hscrash = require("hs.crash")
-rawrequire = require
-require = function(modulename)
-    local result = rawrequire(modulename)
-    pcall(function()
-            hscrash.crashLog("require('"..modulename.."')")
-            if string.sub(modulename, 1, 3) == "hs." then
-                -- Reasonably certain that we're dealing with a Hammerspoon extension
-                local extname = string.sub(modulename, 4, -1)
-                for k,v in ipairs(hscrash.dumpCLIBS()) do
-                    if string.find(v, extname) then
-                        hscrash.crashLog("  Candidate CLIBS match: "..v)
-                    end
-                end
-            end
-            if string.sub(modulename, 1, 8) == "mjolnir." then
-                -- Reasonably certain that we're dealing with a Mjolnir module
-                local mjolnirmod = string.sub(modulename, 9, -1)
-                local mjolnirrep = {"application", "hotkey", "screen", "geometry", "fnutils", "keycodes", "alert", "cmsj.appfinder", "_asm.ipc", "_asm.modal_hotkey", "_asm.settings", "7bits.mjomatic", "_asm.eventtap.event", "_asm.timer", "_asm.pathwatcher", "_asm.eventtap", "_asm.notify", "lb.itunes", "_asm.utf8_53", "cmsj.caffeinate", "lb.spotify", "_asm.sys.mouse", "_asm.sys.battery", "_asm.ui.sound", "_asm.data.base64", "_asm.data.json"}
-                for _,v in pairs(mjolnirrep) do
-                    if v == mjolnirmod then
-                        hscrash.crashKV("MjolnirModuleLoaded", "YES")
-                        break
-                    end
-                end
-            end
-          end)
-    return result
-end
-hscrash.crashLog("Loaded from: "..modpath)
-
 --- hs.dockIcon([state]) -> bool
 --- Function
 --- Set or display whether or not the Hammerspoon dock icon is visible.
@@ -215,7 +184,7 @@ hscrash.crashLog("Loaded from: "..modpath)
 ---  * True if the icon is currently set (or has just been) to be visible or False if it is not.
 ---
 --- Notes:
----  * This function is a wrapper to similar functions found in the `hs.dockicon` module, but is provided here to provide a similiar interface to the functionality of `hs.menuIcon()`.
+---  * This function is a wrapper to functions found in the `hs.dockicon` module, but is provided here to provide an interface consistent with other selectable preference items.
 hs.dockIcon = function(value)
     local hsdi = require("hs.dockicon")
     if type(value) == "boolean" then
@@ -254,6 +223,37 @@ if not hasinitfile then
   print(string.format("-- Can't find %s; create it and reload your config.", prettypath))
   return runstring
 end
+
+local hscrash = require("hs.crash")
+rawrequire = require
+require = function(modulename)
+    local result = rawrequire(modulename)
+    pcall(function()
+            hscrash.crashLog("require('"..modulename.."')")
+            if string.sub(modulename, 1, 3) == "hs." then
+                -- Reasonably certain that we're dealing with a Hammerspoon extension
+                local extname = string.sub(modulename, 4, -1)
+                for k,v in ipairs(hscrash.dumpCLIBS()) do
+                    if string.find(v, extname) then
+                        hscrash.crashLog("  Candidate CLIBS match: "..v)
+                    end
+                end
+            end
+            if string.sub(modulename, 1, 8) == "mjolnir." then
+                -- Reasonably certain that we're dealing with a Mjolnir module
+                local mjolnirmod = string.sub(modulename, 9, -1)
+                local mjolnirrep = {"application", "hotkey", "screen", "geometry", "fnutils", "keycodes", "alert", "cmsj.appfinder", "_asm.ipc", "_asm.modal_hotkey", "_asm.settings", "7bits.mjomatic", "_asm.eventtap.event", "_asm.timer", "_asm.pathwatcher", "_asm.eventtap", "_asm.notify", "lb.itunes", "_asm.utf8_53", "cmsj.caffeinate", "lb.spotify", "_asm.sys.mouse", "_asm.sys.battery", "_asm.ui.sound", "_asm.data.base64", "_asm.data.json"}
+                for _,v in pairs(mjolnirrep) do
+                    if v == mjolnirmod then
+                        hscrash.crashKV("MjolnirModuleLoaded", "YES")
+                        break
+                    end
+                end
+            end
+          end)
+    return result
+end
+hscrash.crashLog("Loaded from: "..modpath)
 
 print("-- Loading " .. prettypath)
 local fn, err = loadfile(fullpath)

--- a/Hammerspoon/setup.lua
+++ b/Hammerspoon/setup.lua
@@ -204,6 +204,26 @@ require = function(modulename)
 end
 hscrash.crashLog("Loaded from: "..modpath)
 
+--- hs.dockIcon([state]) -> bool
+--- Function
+--- Set or display whether or not the Hammerspoon dock icon is visible.
+---
+--- Parameters:
+---  * state - an optional boolean which will set whether or not the Hammerspoon dock icon should be visible.
+---
+--- Returns:
+---  * True if the icon is currently set (or has just been) to be visible or False if it is not.
+---
+--- Notes:
+---  * This function is a wrapper to similar functions found in the `hs.dockicon` module, but is provided here to provide a similiar interface to the functionality of `hs.menuIcon()`.
+hs.dockIcon = function(value)
+    local hsdi = require("hs.dockicon")
+    if type(value) == "boolean" then
+        if value then hsdi.show() else hsdi.hide() end
+    end
+    return hsdi.visible()
+end
+
 --- hs.help(identifier)
 --- Function
 --- Prints the documentation for some part of Hammerspoon's API and Lua 5.3.  This function is actually sourced from hs.doc.help.


### PR DESCRIPTION
Added:

    hs.openPreferences() -- opens Hammerspoon preferences panel
    hs.openAbout() -- open Hammerspoon About panel
    hs.autoLaunch([boolean]) -- set/retrieve autolaunch status
    hs.menuIcon([boolean]) -- set/retrieve display of menu icon
    hs.dockIcon([boolean]) -- set/retrieve display of dock icon (actually just a wrapper to hs.dockicon module)
    hs.consoleOnTop([boolean]) -- set/retrieve whether the console should always be "on top" of other windows

Since I usually run a development version, I can't really test functions to set/check/do an update, so I have left those out for now.  Let me know if there is interest and I can try, but I'll need others to test it for me.

Also updated:

    hs.openConsole can take an optional boolean value which, if provided and set to false, will cause the console to be displayed, but not brought to the front (i.e. just revealed)
    an observer is also setup so that when defaults change via any method, the settings on the preferences pane (if it exists) reflect the current, not cached, values

I added these because I wanted a way to get rid of all of the default Hammerspoon visual elements but yet not lose an easy way to change any of them, should I need/want to.