### PR TITLE
hs.host additions

### DIFF
--- a/extensions/fs/internal.m
+++ b/extensions/fs/internal.m
@@ -323,7 +323,7 @@ static int lfs_lock_dir(lua_State *L) {
 }
 static int lfs_unlock_dir(lua_State *L) {
   lfs_Lock *lock = (lfs_Lock *)luaL_checkudata(L, 1, LOCK_METATABLE);
-  if(lock->fd != INVALID_HANDLE_VALUE) {    
+  if(lock->fd != INVALID_HANDLE_VALUE) {
     CloseHandle(lock->fd);
     lock->fd=INVALID_HANDLE_VALUE;
   }
@@ -1172,6 +1172,20 @@ static int tagsRemove(lua_State *L) {
     return 0;
 }
 
+/// hs.fs.temporaryDirectory() -> string
+/// Function
+/// Returns the path of the temporary directory for the current user.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * The path to the system designated temporary directory for the current user.
+static int hs_temporaryDirectory(lua_State *L) {
+    lua_pushstring(L, [NSTemporaryDirectory() UTF8String]) ;
+    return 1 ;
+}
+
 static const struct luaL_Reg fslib[] = {
         {"attributes", file_info},
         {"chdir", change_dir},
@@ -1190,6 +1204,7 @@ static const struct luaL_Reg fslib[] = {
         {"tagsRemove", tagsRemove},
         {"tagsSet", tagsSet},
         {"tagsGet", tagsGet},
+        {"temporaryDirectory", hs_temporaryDirectory},
         {NULL, NULL},
 };
 

--- a/extensions/host/internal.m
+++ b/extensions/host/internal.m
@@ -398,14 +398,88 @@ static int hs_operatingSystemVersion(lua_State *L) {
     return 1 ;
 }
 
+/// hs.host.temporaryDirectory() -> string
+/// Function
+/// Returns the path of the temporary directory for the current user.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * The path to the system preferred temporary directory for the current user.
+static int hs_temporaryDirectory(lua_State *L) {
+    lua_pushstring(L, [NSTemporaryDirectory() UTF8String]) ;
+    return 1 ;
+}
+
+/// hs.host.interfaceStyle() -> string
+/// Function
+/// Returns the OS X interface style for the current user.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * A string representing the current user interface style, or nil if the default style is in use.
+///
+/// Notes:
+///  * As of OS X 10.10.4, other than the default style, only "Dark" is recognized as a valid style.
+static int hs_interfaceStyle(lua_State *L) {
+    lua_pushstring(L, [[[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"] UTF8String]) ;
+    return 1 ;
+}
+
+/// hs.host.uuid() -> string
+/// Function
+/// Returns a newly generated UUID as a string
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a newly generated UUID as a string
+///
+/// Notes:
+///  * See also `hs.host.globallyUniqueString`
+///  * UUIDs (Universally Unique Identifiers), also known as GUIDs (Globally Unique Identifiers) or IIDs (Interface Identifiers), are 128-bit values. UUIDs created by NSUUID conform to RFC 4122 version 4 and are created with random bytes.
+static int hs_uuid(lua_State* L) {
+    lua_pushstring(L, [[[NSUUID UUID] UUIDString] UTF8String]);
+    return 1;
+}
+
+
+/// hs.host.globallyUniqueString() -> string
+/// Function
+/// Returns a newly generated global unique identifier as a string
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a newly generated global unique identifier as a string
+///
+/// Notes:
+///  * See also `hs.host.uuid`
+///  * The global unique identifier for a process includes the host name, process ID, and a time stamp, which ensures that the ID is unique for the network. This property generates a new string each time it is invoked, and it uses a counter to guarantee that strings are unique.
+///  * This is often used as a file or directory name in conjunction with `hs.host.temporaryDirectory()` when creating temporary files.
+static int hs_globallyUniqueString(lua_State* L) {
+    lua_pushstring(L, [[[NSProcessInfo processInfo] globallyUniqueString] UTF8String]);
+    return 1;
+}
+
+
 static const luaL_Reg hostlib[] = {
     {"addresses",                    hostAddresses},
     {"names",                        hostNames},
     {"localizedName",                hostLocalizedName},
     {"vmStat",                       hs_vmstat},
     {"cpuUsage",                     hs_cpuInfo},
+    {"temporaryDirectory",           hs_temporaryDirectory},
     {"operatingSystemVersion",       hs_operatingSystemVersion},
     {"operatingSystemVersionString", hs_operatingSystemVersionString},
+    {"interfaceStyle",               hs_interfaceStyle},
+    {"uuid",                         hs_uuid},
+    {"globallyUniqueString",         hs_globallyUniqueString},
 
     {}
 };

--- a/extensions/host/internal.m
+++ b/extensions/host/internal.m
@@ -398,20 +398,6 @@ static int hs_operatingSystemVersion(lua_State *L) {
     return 1 ;
 }
 
-/// hs.host.temporaryDirectory() -> string
-/// Function
-/// Returns the path of the temporary directory for the current user.
-///
-/// Parameters:
-///  * None
-///
-/// Returns:
-///  * The path to the system preferred temporary directory for the current user.
-static int hs_temporaryDirectory(lua_State *L) {
-    lua_pushstring(L, [NSTemporaryDirectory() UTF8String]) ;
-    return 1 ;
-}
-
 /// hs.host.interfaceStyle() -> string
 /// Function
 /// Returns the OS X interface style for the current user.
@@ -474,7 +460,6 @@ static const luaL_Reg hostlib[] = {
     {"localizedName",                hostLocalizedName},
     {"vmStat",                       hs_vmstat},
     {"cpuUsage",                     hs_cpuInfo},
-    {"temporaryDirectory",           hs_temporaryDirectory},
     {"operatingSystemVersion",       hs_operatingSystemVersion},
     {"operatingSystemVersionString", hs_operatingSystemVersionString},
     {"interfaceStyle",               hs_interfaceStyle},


### PR DESCRIPTION
The first three are often used in combination to create a temporary file or directory in an "approved Apple way".  The fourth is to serve as a flag if you want to offer different drawing elements (or at least different colors) depending upon the interface style.


hs.host.temporaryDirectory() -- returns the users system recommended "temporary" directory for the current user.

hs.host.globallyUniqueString() -- returns a unique identifier based on host, time, etc. guaranteed to be unique on the local network

hs.host.uuid() -- returns a new UUID as a string

hs.host.interfaceStyle() -- returns the value of the NSGlobalDomain's AppleInterfaceStyle key, which will contain `Dark` if the OS X interface style is set to Dark, or nil if it is not.

