### PR TITLE
add new shorthands for delayed and repeated functions

### DIFF
--- a/extensions/timer/init.lua
+++ b/extensions/timer/init.lua
@@ -56,6 +56,117 @@ function module.days(n)    return 60 * 60 * 24 * n end
 ---  * The number of seconds in n weeks
 function module.weeks(n)   return 60 * 60 * 24 * 7 * n end
 
+--- hs.timer.waitUntil(predicateFn, actionFn[, checkInterval]) -> timer
+--- Constructor
+--- Creates and starts a timer which will perform `actionFn` when `predicateFn` returns true.  The timer is automatically stopped when `actionFn` is called.
+---
+--- Parameters:
+---  * predicateFn - a function which determines when `actionFn` should be called.  This function takes no arguments, but should return true when it is time to call `actionFn`.
+---  * actionFn - a function which performs the desired action.  This function may take a single argument, the timer itself.
+---  * checkInterval - an optional parameter indicating how often to repeat the `predicateFn` check. Defaults to 1 second.
+---
+--- Returns:
+---  * a timer object
+---
+--- Notes:
+---  * The timer is stopped before `actionFn` is called, but the timer is passed as an argument to `actionFn` so that the actionFn may restart the timer to be called again the next time predicateFn returns true.
+---  * See also `hs.timer.waitWhile`
+module.waitUntil = function(predicateFn, actionFn, checkInterval)
+    checkInterval = checkInterval or 1
+
+    local stopWatch
+    stopWatch = module.new(checkInterval, function()
+        if predicateFn() then
+            stopWatch:stop()
+            actionFn(stopWatch)
+        end
+    end):start()
+    return stopWatch
+end
+
+--- hs.timer.doUntil(predicateFn, actionFn[, checkInterval]) -> timer
+--- Constructor
+--- Creates and starts a timer which will perform `actionFn` every `checkinterval` seconds until `predicateFn` returns true.  The timer is automatically stopped when `predicateFn` returns false.
+---
+--- Parameters:
+---  * predicateFn - a function which determines when to stop calling `actionFn`.  This function takes no arguments, but should return true when it is time to stop calling `actionFn`.
+---  * actionFn - a function which performs the desired action.  This function may take a single argument, the timer itself.
+---  * checkInterval - an optional parameter indicating how often to repeat the `predicateFn` check. Defaults to 1 second.
+---
+--- Returns:
+---  * a timer object
+---
+--- Notes:
+---  * The timer is passed as an argument to `actionFn` so that it may stop the timer prematurely (i.e. before predicateFn returns true) if desired.
+---  * See also `hs.timer.doWhile`
+module.doUntil = function(predicateFn, actionFn, checkInterval)
+    checkInterval = checkInterval or 1
+    local stopWatch
+    stopWatch = module.new(checkInterval, function()
+        if not predicateFn() then
+            actionFn(stopWatch)
+        else
+            stopWatch:stop()
+        end
+    end):start()
+    return stopWatch
+end
+
+--- hs.timer.doEvery(interval, fn) -> timer
+--- Constructor
+--- Repeats fn every interval seconds.
+---
+--- Parameters:
+---  * interval - A number of seconds between triggers
+---  * fn - A function to call every time the timer triggers
+---
+--- Returns:
+---  * An `hs.timer` object
+---
+--- Notes:
+---  * This function is a shorthand for `hs.timer.new(interval, fn):start()`
+module.doEvery = function(...)
+    return module.new(...):start()
+end
+
+--- hs.timer.waitWhile(predicateFn, actionFn[, checkInterval]) -> timer
+--- Constructor
+--- Creates and starts a timer which will perform `actionFn` when `predicateFn` returns false.  The timer is automatically stopped when `actionFn` is called.
+---
+--- Parameters:
+---  * predicateFn - a function which determines when `actionFn` should be called.  This function takes no arguments, but should return false when it is time to call `actionFn`.
+---  * actionFn - a function which performs the desired action.  This function may take a single argument, the timer itself.
+---  * checkInterval - an optional parameter indicating how often to repeat the `predicateFn` check. Defaults to 1 second.
+---
+--- Returns:
+---  * a timer object
+---
+--- Notes:
+---  * The timer is stopped before `actionFn` is called, but the timer is passed as an argument to `actionFn` so that the actionFn may restart the timer to be called again the next time predicateFn returns false.
+---  * See also `hs.timer.waitUntil`
+module.waitWhile = function(predicateFn, ...)
+    return module.waitUntil(function() return not predicateFn() end, ...)
+end
+
+--- hs.timer.doWhile(predicateFn, actionFn[, checkInterval]) -> timer
+--- Constructor
+--- Creates and starts a timer which will perform `actionFn` every `checkinterval` seconds while `predicateFn` returns true.  The timer is automatically stopped when `predicateFn` returns false.
+---
+--- Parameters:
+---  * predicateFn - a function which determines when to stop calling `actionFn`.  This function takes no arguments, but should return false when it is time to stop calling `actionFn`.
+---  * actionFn - a function which performs the desired action.  This function may take a single argument, the timer itself.
+---  * checkInterval - an optional parameter indicating how often to repeat the `predicateFn` check. Defaults to 1 second.
+---
+--- Returns:
+---  * a timer object
+---
+--- Notes:
+---  * The timer is passed as an argument to `actionFn` so that it may stop the timer prematurely (i.e. before predicateFn returns false) if desired.
+---  * See also `hs.timer.doUntil`
+module.doWhile = function(predicateFn, ...)
+    return module.doUntil(function() return not predicateFn() end, ...)
+end
+
 -- Return Module Object --------------------------------------------------
 
 return module


### PR DESCRIPTION
* `hs.timer.doEvery(...)`
   shortcut for hs.timer.new(...):start()

* `hs.timer.doUntil(predicateFn, actionFn [, interval])`
   repeat actionFn until predicateFn returns true

* `hs.timer.doWhile(predicateFn, actionFn [, interval])`
   repeat actionFn while predicateFn returns true

* `hs.timer.waitUntil(predicateFn, actionFn [, interval])`
   delay actionFn until predicateFn return true

* `hs.timer.waitWhile(predicateFn, actionFn [, interval])`
   delay actionFn while predicateFn returns true

* `hs.timer:running()`
   returns true if timer is running (active) or false if stopped.

also added descriptive __tostring to hs.timer object