### PR TITLE
[WIP] Add luaskin reference support

### DIFF
--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -13,6 +13,7 @@
 
 static LuaSkin* MJLuaState;
 static int evalfn;
+int refTable;
 
 /// === hs ===
 ///
@@ -313,7 +314,7 @@ void MJLuaSetup(void) {
     MJLuaState = [LuaSkin shared];
     lua_State* L = MJLuaState.L;
 
-    [MJLuaState registerLibrary:corelib metaFunctions:nil];
+    refTable = [MJLuaState registerLibrary:corelib metaFunctions:nil];
     push_hammerAppInfo(L) ;
     lua_setfield(L, -2, "processInfo") ;
 
@@ -340,7 +341,7 @@ void MJLuaSetup(void) {
 
     lua_pcall(L, 7, 1, 0);
 
-    evalfn = luaL_ref(L, LUA_REGISTRYINDEX);
+    evalfn = [MJLuaState luaRef:refTable];
 }
 
 void MJLuaTeardown(void) {
@@ -350,7 +351,7 @@ void MJLuaTeardown(void) {
 NSString* MJLuaRunString(NSString* command) {
     lua_State* L = MJLuaState.L;
 
-    lua_rawgeti(L, LUA_REGISTRYINDEX, evalfn);
+    [MJLuaState pushLuaRef:refTable ref:evalfn];
     if (!lua_isfunction(L, -1)) {
         CLS_NSLOG(@"ERROR: MJLuaRunString doesn't seem to have an evalfn");
         if (lua_isstring(L, -1)) {

--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -246,6 +246,20 @@ static int core_focus(lua_State* L) {
     return 0;
 }
 
+/// hs.getObjectMetatable(name) -> table or nil
+/// Function
+/// Fetches the Lua metatable for objects produced by an extension
+///
+/// Parameters:
+///  * name - A string containing the name of a module to fetch object metadata for (e.g. `"hs.screen"`)
+///
+/// Returns:
+///  * The extension's object metatable, or nil if an error occurred
+static int core_getObjectMetatable(lua_State *L) {
+    luaL_getmetatable(L, lua_tostring(L,1));
+    return 1;
+}
+
 static int core_exit(lua_State* L) {
     if (lua_toboolean(L, 2))
         lua_close(L);
@@ -287,6 +301,7 @@ static luaL_Reg corelib[] = {
     {"reload", core_reload},
     {"focus", core_focus},
     {"accessibilityState", core_accessibilityState},
+    {"getObjectMetatable", core_getObjectMetatable},
     {"_exit", core_exit},
     {"_logmessage", core_logmessage},
     {"_notify", core_notify},

--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -119,10 +119,38 @@
  @param functions - A static array of mappings between Lua function names and C function pointers. This provides the public API of the Lua library
  @param metaFunctions - A static array of mappings between special meta Lua function names (such as "__gc") and C function pointers.
  @param objectFunctions - A static array of mappings between Lua object method names and C function pointers. This provides the public API of objects created by this library. Note that this object is also used as the metatable, so special functions (e.g. "__gc") should be included here.
+ @return A Lua reference to the table created for this library to store its own references
  */
-- (void)registerLibraryWithObject:(char *)libraryName functions:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions objectFunctions:(const luaL_Reg *)objectFunctions;
+- (int)registerLibraryWithObject:(char *)libraryName functions:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions objectFunctions:(const luaL_Reg *)objectFunctions;
 
-//TODO: Figure out a generic way to create library objects
+/** Stores a reference to the object at the top of the Lua stack, in the supplied table, and pops the object off the stack
+ 
+ @note This method is functionally analogous to luaL_ref(), it just takes care of pushing the supplied table ref onto the stack, and removes it afterwards
+
+ @param refTable - An integer reference to a table (e.g. the result of a previous luaRef on a table object)
+ @return An integer reference to the object that was at the top of the stack
+ */
+- (int)luaRef:(int)refTable;
+
+/** Removes a reference from the supplied table
+ 
+ @note This method is functionally analogous to luaL_unref(), it just takes care of pushing the supplied table ref onto the Lua stack, and removes it afterwards
+ 
+ @param refTable - An integer reference to a table (e.g the result of a previous luaRef on a table object)
+ @param ref - An integer reference for an object that should be removed from the refTable table
+ @return An integer, always LUA_NOREF (you are advised to store this value in the variable containing the ref parameter, so it does not become a stale reference)
+ */
+- (int)luaUnref:(int)refTable ref:(int)ref;
+
+/** Pushes a stored reference onto the Lua stack
+ 
+ @note This method is functionally analogous to lua_rawgeti(), it just takes care of pushing the supplied table ref onto the Lua stack, and removes it afterwards
+ 
+ @param refTable - An integer reference to a table (e.h. the result of a previous luaRef on a table object)
+ @param ref - An integer reference for an object that should be pushed onto the stack
+ */
+- (void)pushLuaRef:(int)refTable ref:(int)ref;
+
 //TODO: Add methods for enforcing Lua function arguments
 //TODO: Add methods for converting Lua<->objc types
 @end

--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -74,7 +74,7 @@
 
 #pragma mark - Methods for registering libraries with Lua
 
-/** Defines a Lua library
+/** Defines a Lua library and creates a references table for the library
  @code
  static const luaL_Reg myShinyLibrary[] = {
  {"doThing", function_doThing},
@@ -86,13 +86,14 @@
  }
  [luaSkin registerLibrary:myShinyLibrary metaFunctions:myShinyMetaLibrary];
  @endcode
- 
+
  @note Every C function pointer must point to a function of the form: static int someFunction(lua_State *L);
- 
+
  @param functions - A static array of mappings between Lua function names and C function pointers. This provides the public API of the Lua library
  @param metaFunctions - A static array of mappings between special meta Lua function names (such as "__gc") and C function pointers.
+ @return A Lua reference to the table created for this library to store its own references
  */
-- (void)registerLibrary:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions;
+- (int)registerLibrary:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions;
 
 /** Defines a Lua library that creates objects, which have methods
  @code
@@ -116,6 +117,7 @@
 
  @note Every C function pointer must point to a function of the form: static int someFunction(lua_State *L);
 
+ @param libraryName - A C string containing the name of this library
  @param functions - A static array of mappings between Lua function names and C function pointers. This provides the public API of the Lua library
  @param metaFunctions - A static array of mappings between special meta Lua function names (such as "__gc") and C function pointers.
  @param objectFunctions - A static array of mappings between Lua object method names and C function pointers. This provides the public API of objects created by this library. Note that this object is also used as the metatable, so special functions (e.g. "__gc") should be included here.

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -114,7 +114,10 @@
     }
 }
 
-- (void)registerLibraryWithObject:(char *)libraryName functions:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions objectFunctions:(const luaL_Reg *)objectFunctions {
+- (int)registerLibraryWithObject:(char *)libraryName functions:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions objectFunctions:(const luaL_Reg *)objectFunctions {
+    lua_newtable(_L);
+    int moduleRefTable = luaL_ref(_L, LUA_REGISTRYINDEX);
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconstant-conversion"
     luaL_newlib(_L, objectFunctions);
@@ -124,6 +127,60 @@
     lua_setfield(_L, LUA_REGISTRYINDEX, libraryName);
     
     [self registerLibrary:functions metaFunctions:metaFunctions];
+
+    return moduleRefTable;
+}
+
+- (int)luaRef:(int)refTable {
+    NSAssert((refTable != LUA_NOREF && refTable != LUA_REFNIL), @"ERROR: LuaSkin::luaRef was passed a NOREF/REFNIL refTable", nil);
+    if (lua_isnil(_L, -1)) {
+        return LUA_REFNIL;
+    }
+
+    // Push refTable onto the stack
+    lua_rawgeti(_L, LUA_REGISTRYINDEX, refTable);
+
+    // Move refTable to second on the stack, underneath the object to reference
+    lua_insert(_L, -2);
+
+    // Reference the object at the top of the stack (pops it off)
+    int ref = luaL_ref(_L, -2);
+
+    // Remove refTable from the stack
+    lua_remove(_L, -1);
+
+    return ref;
+}
+
+- (int)luaUnref:(int)refTable ref:(int)ref {
+    NSAssert((refTable != LUA_NOREF && refTable != LUA_REFNIL), @"ERROR: LuaSkin::luaUnref was passed a NOREF/REFNIL refTable", nil);
+    if (ref != LUA_NOREF && ref != LUA_REFNIL) {
+        // Push refTable onto the stack
+        lua_rawgeti(_L, LUA_REGISTRYINDEX, refTable);
+
+        // Dereference the supplied ref, from refTable
+        luaL_unref(_L, -1, ref);
+
+        // Remove refTable from the stack
+        lua_remove(_L, -1);
+    }
+    return LUA_NOREF;
+}
+
+- (void)pushLuaRef:(int)refTable ref:(int)ref {
+    NSAssert((refTable != LUA_NOREF && refTable != LUA_REFNIL), @"ERROR: LuaSkin::pushLuaRef was passed a NOREF/REFNIL refTable", nil);
+    NSAssert((ref != LUA_NOREF && ref != LUA_REFNIL), @"ERROR: LuaSkin::luaRef was passed a NOREF/REFNIL ref", nil);
+
+    // Push refTable onto the stack
+    lua_rawgeti(_L, LUA_REGISTRYINDEX, refTable);
+
+    // Push ref onto the stack
+    lua_rawgeti(_L, -1, ref);
+
+    // Remove refTable from the stack
+    lua_remove(_L, -2);
+
+    return;
 }
 
 @end

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -103,7 +103,7 @@
 
 #pragma mark - Methods for registering libraries with Lua
 
-- (void)registerLibrary:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions {
+- (int)registerLibrary:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconstant-conversion"
     luaL_newlib(_L, functions);
@@ -112,11 +112,11 @@
 #pragma GCC diagnostic pop
         lua_setmetatable(_L, -2);
     }
+    lua_newtable(_L);
+    return luaL_ref(_L, LUA_REGISTRYINDEX);
 }
 
 - (int)registerLibraryWithObject:(char *)libraryName functions:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions objectFunctions:(const luaL_Reg *)objectFunctions {
-    lua_newtable(_L);
-    int moduleRefTable = luaL_ref(_L, LUA_REGISTRYINDEX);
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconstant-conversion"
@@ -126,7 +126,7 @@
     lua_setfield(_L, -2, "__index");
     lua_setfield(_L, LUA_REGISTRYINDEX, libraryName);
     
-    [self registerLibrary:functions metaFunctions:metaFunctions];
+    int moduleRefTable = [self registerLibrary:functions metaFunctions:metaFunctions];
 
     return moduleRefTable;
 }

--- a/extensions/alert/internal.m
+++ b/extensions/alert/internal.m
@@ -217,11 +217,9 @@ static const luaL_Reg metalib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_alert_internal(lua_State* L) {
-    luaL_newlib(L, alertlib);
-
-    luaL_newlib(L, metalib);
-    lua_setmetatable(L, -2);
+int luaopen_hs_alert_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:alertlib metaFunctions:metalib];
 
     return 1;
 }

--- a/extensions/applescript/internal.m
+++ b/extensions/applescript/internal.m
@@ -2,8 +2,6 @@
 #import <LuaSkin/LuaSkin.h>
 #import "../hammerspoon.h"
 
-// Check out NSScriptClassDescription for expanding obj return values...
-
 /// hs.applescript._applescript(string) -> bool, result
 /// Function
 /// Runs AppleScript code
@@ -29,13 +27,10 @@ static int runapplescript(lua_State* L) {
     NSAppleEventDescriptor* result = [script executeAndReturnError:&error];
 
     lua_pushboolean(L, (result != nil));
-    if (result == nil)
-//         mjolnir_push_luavalue_for_nsobject(L, (NSArray *)error); // I don't think this ever worked, but it is what was in Hydra
+    if (result == nil) {
         lua_pushstring(L, [[NSString stringWithFormat:@"%@", error] UTF8String]);
-    else {
-//         lua_pushstring(L, [[result stringValue] UTF8String]); // worked only for string results...
+    } else {
         lua_pushstring(L, [[NSString stringWithFormat:@"%@", result] UTF8String]); // ugly, but parseable in Lua, sorta...
-//         mjolnir_push_luavalue_for_nsobject(L, arrayFromDescriptor(result)); // my pipe dream, but not yet...
     }
     return 2;
 }
@@ -45,80 +40,9 @@ static const luaL_Reg scriptlib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_applescript_internal(lua_State* L) {
-    luaL_newlib(L, scriptlib);
+int luaopen_hs_applescript_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:scriptlib metaFunctions:nil];
 
     return 1;
 }
-
-// // Still chokes on "index a binary value" for NSError as NSDictionary... gonna have to dig.
-// // plus, I don't like the examples in Hydra... one treats a NSDictionary of 1 element as a
-// // boolean (settings... since it's plists, it might be right, need to check) and another
-// // treats a NSNumber of 1 or 0 as boolean, all others as NSNumber... probably because C does,
-// // but it's a bad default for a general function...
-//
-// void mjolnir_push_luavalue_for_nsobject(lua_State* L, id obj) {
-//     if (obj == nil) {
-//         // not set yet
-//         lua_pushnil(L);
-//     }
-//     else if ([obj isKindOfClass: [NSDictionary class]]) {
-//         NSDictionary* thing = obj;
-//         lua_newtable(L);
-//         for (id key in thing) {
-//             mjolnir_push_luavalue_for_nsobject(L, key);
-//             mjolnir_push_luavalue_for_nsobject(L, [thing objectForKey:key]);
-//             lua_settable(L, -3);
-//         }
-//     }
-//     else if ([obj isKindOfClass: [NSNumber class]]) {
-//         if (obj == (id)kCFBooleanTrue)
-//             lua_pushboolean(L, YES);
-//         else if (obj == (id)kCFBooleanFalse)
-//             lua_pushboolean(L, NO);
-//         else
-//             lua_pushnumber(L, [(NSNumber*)obj doubleValue]);
-//     }
-// //     else if ([obj isKindOfClass: [NSNumber class]]) {
-// //         NSNumber* number = obj;
-// //         lua_pushnumber(L, [number doubleValue]);
-// //     }
-//     else if ([obj isKindOfClass: [NSString class]]) {
-//         NSString* string = obj;
-//         lua_pushstring(L, [string UTF8String]);
-//     }
-//     else if ([obj isKindOfClass: [NSArray class]]) {
-//         NSArray* list = obj;
-//         lua_newtable(L);
-//
-//         for (int i = 0; i < [list count]; i += 2) {
-//             id key = [list objectAtIndex:i];
-//             id val = [list objectAtIndex:i + 1];
-//             mjolnir_push_luavalue_for_nsobject(L, key);
-//             mjolnir_push_luavalue_for_nsobject(L, val);
-//             lua_settable(L, -3);
-//         }
-//     }
-// }
-
-// // Almost, but I need to understand NSAppleEventDescriptor better...
-// id arrayFromDescriptor(NSAppleEventDescriptor *descriptor) {
-//     NSMutableArray *returnArray = [NSMutableArray array];
-//     int counter, count = [descriptor numberOfItems];
-//
-//     for (counter = 1; counter <= count; counter++) {
-//         NSAppleEventDescriptor *desc = [descriptor descriptorAtIndex:counter];
-//         if (nil != [desc descriptorAtIndex:1]) {
-//             [returnArray addObject:arrayFromDescriptor(desc)];
-//         } else {
-//             NSString *stringValue = [[descriptor descriptorAtIndex:counter] stringValue];
-//             if (nil != stringValue) {
-//                 [returnArray addObject:stringValue];
-//             } else {
-//                 NSString *holder = [NSString stringWithFormat:@"%@", desc];
-//                 [returnArray addObject:holder];
-//             }
-//         }
-//     }
-//     return returnArray;
-// }

--- a/extensions/application/watcher.m
+++ b/extensions/application/watcher.m
@@ -79,6 +79,11 @@ typedef enum _event_t {
     NSRunningApplication* app = [dict objectForKey:@"NSWorkspaceApplicationKey"];
     if (app == nil)
         return;
+    if (!self.object->running)
+        return;
+
+    LuaSkin *skin = [LuaSkin shared];
+    lua_State *L = skin.L;
 
     // Depending on the event the name of the NSRunningApplication object may not be available
     // anymore. Fallback to the application name which is provided directly in the notification
@@ -86,12 +91,6 @@ typedef enum _event_t {
     NSString* appName = [app localizedName];
     if (appName == nil)
         appName = [dict objectForKey:@"NSApplicationName"];
-
-    if (!self.object->running)
-        return;
-
-    LuaSkin *skin = [LuaSkin shared];
-    lua_State *L = skin.L;
 
     lua_rawgeti(L, LUA_REGISTRYINDEX, self.object->fn);
 

--- a/extensions/audiodevice/internal.m
+++ b/extensions/audiodevice/internal.m
@@ -439,6 +439,7 @@ static const luaL_Reg audiodevice_metalib[] = {
     {"setVolume",               audiodevice_setvolume},
     {"muted",                   audiodevice_muted},
     {"setMuted",                audiodevice_setmuted},
+    {"__eq",                    audiodevice_eq},
     {NULL, NULL}
 };
 
@@ -448,17 +449,9 @@ static const luaL_Reg audiodeviceLib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_audiodevice_internal(lua_State* L) {
-// Metatable for created objects
-    luaL_newlib(L, audiodevice_metalib);
-        lua_pushvalue(L, -1);
-        lua_setfield(L, -2, "__index");
-        lua_pushcfunction(L, audiodevice_eq);
-        lua_setfield(L, -2, "__eq");
-        lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
-
-// Create table for luaopen
-    luaL_newlib(L, audiodeviceLib);
+int luaopen_hs_audiodevice_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:audiodeviceLib metaFunctions:nil objectFunctions:audiodevice_metalib];
 
     return 1;
 }

--- a/extensions/base64/internal.m
+++ b/extensions/base64/internal.m
@@ -52,7 +52,9 @@ static const luaL_Reg base64_lib[] = {
     {NULL,      NULL}
 };
 
-int luaopen_hs_base64_internal(lua_State* L) {
-    luaL_newlib(L, base64_lib);
+int luaopen_hs_base64_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:base64_lib metaFunctions:nil];
+
     return 1;
 }

--- a/extensions/battery/internal.m
+++ b/extensions/battery/internal.m
@@ -410,7 +410,9 @@ static const luaL_Reg battery_lib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_battery_internal(lua_State* L) {
-    luaL_newlib(L, battery_lib);
+int luaopen_hs_battery_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:battery_lib metaFunctions:nil];
+
     return 1;
 }

--- a/extensions/battery/watcher.m
+++ b/extensions/battery/watcher.m
@@ -142,17 +142,9 @@ static const luaL_Reg meta_gcLib[] = {
     {NULL,      NULL}
 };
 
-int luaopen_hs_battery_watcher(lua_State* L) {
-// Metatable for created objects
-    luaL_newlib(L, battery_metalib);
-        lua_pushvalue(L, -1);
-        lua_setfield(L, -2, "__index");
-        lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
-
-// Create table for luaopen
-    luaL_newlib(L, batteryLib);
-        luaL_newlib(L, meta_gcLib);
-        lua_setmetatable(L, -2);
+int luaopen_hs_battery_watcher(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:batteryLib metaFunctions:meta_gcLib objectFunctions:battery_metalib];
 
     return 1;
 }

--- a/extensions/brightness/internal.m
+++ b/extensions/brightness/internal.m
@@ -124,7 +124,9 @@ static const luaL_Reg brightnessLib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_brightness_internal(lua_State* L) {
-    luaL_newlib(L, brightnessLib);
+int luaopen_hs_brightness_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:brightnessLib metaFunctions:nil];
+
     return 1;
 }

--- a/extensions/caffeinate/internal.m
+++ b/extensions/caffeinate/internal.m
@@ -181,10 +181,9 @@ static const luaL_Reg metalib[] = {
 /* NOTE: The substring "hs_caffeinate_internal" in the following function's name
          must match the require-path of this file, i.e. "hs.caffeinate.internal". */
 
-int luaopen_hs_caffeinate_internal(lua_State *L) {
-    luaL_newlib(L, caffeinatelib);
-    luaL_newlib(L, metalib);
-    lua_setmetatable(L, -2);
+int luaopen_hs_caffeinate_internal(lua_State *L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:caffeinatelib metaFunctions:metalib];
 
     return 1;
 }

--- a/extensions/crash/internal.m
+++ b/extensions/crash/internal.m
@@ -104,8 +104,6 @@ static int crashKV(lua_State *L) {
     return 0;
 }
 
-// ----------------------- Lua/hs glue GAR ---------------------
-
 static const luaL_Reg crashlib[] = {
     {"crash", burnTheWorld},
     {"isMainThread", isMainThread},
@@ -118,9 +116,9 @@ static const luaL_Reg crashlib[] = {
 /* NOTE: The substring "hs_crash_internal" in the following function's name
          must match the require-path of this file, i.e. "hs.crash.internal". */
 
-int luaopen_hs_crash_internal(lua_State *L) {
-    // Table for luaopen
-    luaL_newlib(L, crashlib);
+int luaopen_hs_crash_internal(lua_State *L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:crashlib metaFunctions:nil];
 
     return 1;
 }

--- a/extensions/dockicon/internal.m
+++ b/extensions/dockicon/internal.m
@@ -81,7 +81,9 @@ static luaL_Reg icon_lib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_dockicon_internal(lua_State* L) {
-    luaL_newlib(L, icon_lib);
+int luaopen_hs_dockicon_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:icon_lib metaFunctions:nil];
+
     return 1;
 }

--- a/extensions/drawing/init.lua
+++ b/extensions/drawing/init.lua
@@ -16,6 +16,8 @@ module.color = {
 local fnutils = require("hs.fnutils")
 local imagemod = require("hs.image")
 
+local drawingObject = hs.getObjectMetatable("hs.drawing")
+
 local __tostring_for_tables = function(self)
     local result = ""
     local width = 0
@@ -130,9 +132,6 @@ module.appImage = function(sizeRect, bundleID)
     end
 end
 
-local tmp = module.rectangle({})
-local tmpMeta = getmetatable(tmp)
-
 --- hs.drawing:setBehaviorByLabels(table) -> object
 --- Method
 --- Sets the window behaviors based upon the labels specified in the table provided.
@@ -142,7 +141,7 @@ local tmpMeta = getmetatable(tmp)
 ---
 --- Returns:
 ---  * The `hs.drawing` object
-tmpMeta.setBehaviorByLabels = function(obj, stringTable)
+drawingObject.setBehaviorByLabels = function(obj, stringTable)
     local newBehavior = 0
     for i,v in ipairs(stringTable) do
         local flag = tonumber(v) or module.windowBehaviors[v]
@@ -160,7 +159,7 @@ end
 ---
 --- Returns:
 ---  * Returns a table of the labels for the current behaviors with respect to Spaces and Exposé for the object.
-tmpMeta.behaviorAsLabels = function(obj)
+drawingObject.behaviorAsLabels = function(obj)
     local results = {}
     local behaviorNumber = obj:behavior()
 
@@ -175,8 +174,5 @@ tmpMeta.behaviorAsLabels = function(obj)
     end
     return results
 end
-
-tmp:delete()
-tmp = nil
 
 return module

--- a/extensions/drawing/internal.m
+++ b/extensions/drawing/internal.m
@@ -1979,16 +1979,14 @@ static const luaL_Reg drawing_metalib[] = {
 };
 
 int luaopen_hs_drawing_internal(lua_State *L) {
-    // Metatable for creted objects
-    luaL_newlib(L, drawing_metalib);
-    lua_pushvalue(L, -1);
-    lua_setfield(L, -2, "__index");
-    lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:drawinglib metaFunctions:nil objectFunctions:drawing_metalib];
 
-    // Table for luaopen
-    luaL_newlib(L, drawinglib);
-        pushFontTraitsTable(L);       lua_setfield(L, -2, "fontTraits");
-        pushCollectionTypeTable(L) ;  lua_setfield(L, -2, "windowBehaviors") ;
+    pushFontTraitsTable(L);
+    lua_setfield(L, -2, "fontTraits");
+
+    pushCollectionTypeTable(L);
+    lua_setfield(L, -2, "windowBehaviors") ;
 
     return 1;
 }

--- a/extensions/eventtap/event.m
+++ b/extensions/eventtap/event.m
@@ -923,21 +923,14 @@ static luaL_Reg eventtapeventlib[] = {
 // };
 
 int luaopen_hs_eventtap_event(lua_State* L) {
-// Metatable for created objects
-    luaL_newlib(L, eventtapevent_metalib);
-        lua_pushvalue(L, -1);
-        lua_setfield(L, -2, "__index");
-        lua_setfield(L, LUA_REGISTRYINDEX, EVENT_USERDATA_TAG);
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:EVENT_USERDATA_TAG functions:eventtapeventlib metaFunctions:nil objectFunctions:eventtapevent_metalib];
 
-    luaL_newlib(L, eventtapeventlib);
-        pushtypestable(L);
-        lua_setfield(L, -2, "types");
+    pushtypestable(L);
+    lua_setfield(L, -2, "types");
 
-        pushpropertiestable(L);
-        lua_setfield(L, -2, "properties");
-
-//         luaL_newlib(L, meta_gcLib);
-//         lua_setmetatable(L, -2);
+    pushpropertiestable(L);
+    lua_setfield(L, -2, "properties");
 
     return 1;
 }

--- a/extensions/eventtap/internal.m
+++ b/extensions/eventtap/internal.m
@@ -387,16 +387,9 @@ static const luaL_Reg meta_gcLib[] = {
     {NULL,      NULL}
 };
 
-int luaopen_hs_eventtap_internal(lua_State* L) {
-// Metatable for created objects
-    luaL_newlib(L, eventtap_metalib);
-        lua_pushvalue(L, -1);
-        lua_setfield(L, -2, "__index");
-        lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
-
-    luaL_newlib(L, eventtaplib);
-        luaL_newlib(L, meta_gcLib);
-        lua_setmetatable(L, -2);
+int luaopen_hs_eventtap_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:eventtaplib metaFunctions:meta_gcLib objectFunctions:eventtap_metalib];
 
     return 1;
 }

--- a/extensions/geometry/internal.m
+++ b/extensions/geometry/internal.m
@@ -64,7 +64,9 @@ static const luaL_Reg geometrylib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_geometry_internal(lua_State* L) {
-    luaL_newlib(L, geometrylib);
+int luaopen_hs_geometry_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:geometrylib metaFunctions:nil];
+
     return 1;
 }

--- a/extensions/hints/internal.m
+++ b/extensions/hints/internal.m
@@ -204,7 +204,6 @@ static int hints_new(lua_State* L) {
 static const luaL_Reg hintslib[] = {
     {"test", hints_test},
     {"new", hints_new},
-    {"close", hint_close},
 
     {NULL, NULL} // necessary sentinel
 };
@@ -212,6 +211,7 @@ static const luaL_Reg hintslib[] = {
 static const luaL_Reg hints_metalib[] = {
     {"__eq", hint_eq},
     {"__gc", hint_close},
+    {"close", hint_close},
 
     {NULL, NULL}
 };

--- a/extensions/host/internal.m
+++ b/extensions/host/internal.m
@@ -469,9 +469,11 @@ static const luaL_Reg hostlib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_host_internal(lua_State* L) {
+int luaopen_hs_host_internal(lua_State* L __unused) {
     host = [NSHost currentHost];
-    luaL_newlib(L, hostlib);
+
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:hostlib metaFunctions:nil];
 
     return 1;
 }

--- a/extensions/host/internal.m
+++ b/extensions/host/internal.m
@@ -470,9 +470,10 @@ static const luaL_Reg hostlib[] = {
 };
 
 int luaopen_hs_host_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+
     host = [NSHost currentHost];
 
-    LuaSkin *skin = [LuaSkin shared];
     [skin registerLibrary:hostlib metaFunctions:nil];
 
     return 1;

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -160,7 +160,7 @@ function hotkey.modal:enter()
   if (self.k) then
     self.k:disable()
   end
-  fnutils.each(self.keys, hotkey.enable)
+  fnutils.each(self.keys, hs.getObjectMetatable("hs.hotkey").enable)
   self:entered()
   return self
 end
@@ -178,7 +178,7 @@ end
 --- Notes:
 ---  * This method will disable all of the hotkeys defined in the modal state, and enable the hotkey for entering the modal state (if one was defined)
 function hotkey.modal:exit()
-  fnutils.each(self.keys, hotkey.disable)
+  fnutils.each(self.keys, hs.getObjectMetatable("hs.hotkey").disable)
   if (self.k) then
     self.k:enable()
   end

--- a/extensions/hotkey/internal.m
+++ b/extensions/hotkey/internal.m
@@ -104,6 +104,8 @@ typedef struct _hotkey_t {
 
 
 static int hotkey_new(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared];
+
     luaL_checktype(L, 1, LUA_TTABLE);
     UInt32 keycode = (UInt32)luaL_checkinteger(L, 2);
     BOOL hasDown = NO;
@@ -141,8 +143,6 @@ static int hotkey_new(lua_State* L) {
     // use 'hs.hotkey' metatable
     luaL_getmetatable(L, USERDATA_TAG);
     lua_setmetatable(L, -2);
-
-    LuaSkin *skin = [LuaSkin shared];
 
     // store pressedfn
     if (hasDown) {
@@ -235,8 +235,9 @@ static int hotkey_disable(lua_State* L) {
 }
 
 static int hotkey_gc(lua_State* L) {
-    hotkey_t* hotkey = luaL_checkudata(L, 1, USERDATA_TAG);
     LuaSkin *skin = [LuaSkin shared];
+
+    hotkey_t* hotkey = luaL_checkudata(L, 1, USERDATA_TAG);
 
     stop(L, hotkey);
 
@@ -341,10 +342,11 @@ static const luaL_Reg hotkey_objectlib[] = {
 };
 
 int luaopen_hs_hotkey_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+
     handlers = [NSMutableIndexSet indexSet];
     keyRepeatManager = [[HSKeyRepeatManager alloc] init];
 
-    LuaSkin *skin = [LuaSkin shared];
     refTable = [skin registerLibraryWithObject:USERDATA_TAG functions:hotkeylib metaFunctions:metalib objectFunctions:hotkey_objectlib];
 
     // watch for hotkey events

--- a/extensions/http/internal.m
+++ b/extensions/http/internal.m
@@ -234,12 +234,10 @@ static const luaL_Reg metalib[] = {
     {NULL, NULL} // This must end with an empty struct
 };
 
-int luaopen_hs_http_internal(lua_State* L) {
+int luaopen_hs_http_internal(lua_State* L __unused) {
     delegates = [[NSMutableArray alloc] init];
-    luaL_newlib(L, httplib);
-
-    luaL_newlib(L, metalib);
-    lua_setmetatable(L, -2);
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:httplib metaFunctions:metalib];
 
     return 1;
 }

--- a/extensions/image/internal.m
+++ b/extensions/image/internal.m
@@ -476,18 +476,11 @@ static luaL_Reg moduleLib[] = {
 // };
 
 int luaopen_hs_image_internal(lua_State* L) {
-// Metatable for userdata objects
-    luaL_newlib(L, userdata_metaLib);
-        lua_pushvalue(L, -1);
-        lua_setfield(L, -2, "__index");
-        lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:moduleLib metaFunctions:nil objectFunctions:userdata_metaLib];
 
-// Create table for luaopen
-    luaL_newlib(L, moduleLib);
-        pushNSImageNameTable(L) ; lua_setfield(L, -2, "systemImageNames") ;
+    pushNSImageNameTable(L);
+    lua_setfield(L, -2, "systemImageNames") ;
 
-// // Module metatable, if needed
-//         luaL_newlib(L, module_metaLib);
-//         lua_setmetatable(L, -2);
     return 1;
 }

--- a/extensions/ipc/internal.m
+++ b/extensions/ipc/internal.m
@@ -91,7 +91,9 @@ static const luaL_Reg ipcLib[] = {
     {NULL,              NULL}
 };
 
-int luaopen_hs_ipc_internal(lua_State* L) {
-    luaL_newlib(L, ipcLib);
+int luaopen_hs_ipc_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:ipcLib metaFunctions:nil];
+
     return 1;
 }

--- a/extensions/json/internal.m
+++ b/extensions/json/internal.m
@@ -205,8 +205,9 @@ static const luaL_Reg jsonLib[] = {
     {NULL,      NULL}
 };
 
-int luaopen_hs_json_internal(lua_State* L) {
-    // setup the module
-    luaL_newlib(L, jsonLib);
+int luaopen_hs_json_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:jsonLib metaFunctions:nil];
+
     return 1;
 }

--- a/extensions/location/internal.m
+++ b/extensions/location/internal.m
@@ -250,10 +250,9 @@ static const luaL_Reg metalib[] = {
 /* NOTE: The substring "hs_location_internal" in the following function's name
          must match the require-path of this file, i.e. "hs.location.internal". */
 
-int luaopen_hs_location_internal(lua_State *L) {
-    luaL_newlib(L, locationlib);
-    luaL_newlib(L, metalib);
-    lua_setmetatable(L, -2);
+int luaopen_hs_location_internal(lua_State *L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:locationlib metaFunctions:metalib];
 
     return 1;
 }

--- a/extensions/menubar/init.lua
+++ b/extensions/menubar/init.lua
@@ -7,10 +7,9 @@ local imagemod = require("hs.image")
 
 -- This is the wrapper for hs.menubar:setIcon(). It is documented in internal.m
 
-local tmp = menubar.new()
-local tmpmetatable = getmetatable(tmp)
+local menubarObject = hs.getObjectMetatable("hs.menubar")
 
-tmpmetatable.setIcon = function(object, imagePath)
+menubarObject.setIcon = function(object, imagePath)
     local tmpImage = nil
 
     if type(imagePath) == "userdata" then
@@ -25,7 +24,5 @@ tmpmetatable.setIcon = function(object, imagePath)
 
     return object:_setIcon(tmpImage)
 end
-
-tmp:delete()
 
 return menubar

--- a/extensions/menubar/internal.m
+++ b/extensions/menubar/internal.m
@@ -726,11 +726,10 @@ static int menubarGetIcon(lua_State *L) {
 
 // ----------------------- Lua/hs glue GAR ---------------------
 
-static int menubar_setup(lua_State* __unused L) {
+void menubar_setup() {
     if (!dynamicMenuDelegates) {
         dynamicMenuDelegates = [[NSMutableArray alloc] init];
     }
-    return 0;
 }
 
 static int menubar_gc(lua_State* __unused L) {
@@ -785,19 +784,11 @@ static const luaL_Reg menubar_gclib[] = {
 /* NOTE: The substring "hs_menubar_internal" in the following function's name
          must match the require-path of this file, i.e. "hs.menubar.internal". */
 
-int luaopen_hs_menubar_internal(lua_State *L) {
-    menubar_setup(L);
+int luaopen_hs_menubar_internal(lua_State *L __unused) {
+    menubar_setup();
 
-    // Metatable for created objects
-    luaL_newlib(L, menubar_metalib);
-    lua_pushvalue(L, -1);
-    lua_setfield(L, -2, "__index");
-    lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
-
-    // Table for luaopen
-    luaL_newlib(L, menubarlib);
-    luaL_newlib(L, menubar_gclib);
-    lua_setmetatable(L, -2);
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:menubarlib metaFunctions:menubar_gclib objectFunctions:menubar_metalib];
 
     return 1;
 }

--- a/extensions/milight/init.lua
+++ b/extensions/milight/init.lua
@@ -4,6 +4,7 @@
 
 local milight = require "hs.milight.internal"
 milight.cmd = milight._cacheCommands()
+local milightObject = hs.getObjectMetatable("hs.milight")
 
 --- hs.milight.minBrightness
 --- Constant
@@ -69,7 +70,7 @@ end
 ---
 --- Returns:
 ---  * True if the command was sent correctly, otherwise false
-function milight:zoneOff(zone)
+function milightObject:zoneOff(zone)
     return milight.send(self, milight.cmd[zone2cmdkey(zone, "off")])
 end
 
@@ -82,7 +83,7 @@ end
 ---
 --- Returns:
 ---  * True if the command was sent correctly, otherwise false
-function milight:zoneOn(zone)
+function milightObject:zoneOn(zone)
     return milight.send(self, milight.cmd[zone2cmdkey(zone, "on")])
 end
 
@@ -95,7 +96,7 @@ end
 ---
 --- Returns:
 ---  * True if the command was sent correctly, otherwise false
-function milight:discoCycle(zone)
+function milightObject:discoCycle(zone)
     if (self:zoneOn(zone)) then
         return milight.send(self, milight.cmd["disco"])
     else
@@ -113,7 +114,7 @@ end
 ---
 --- Returns:
 ---  * A number containing the value that was sent to the WiFi bridge, or -1 if an error occurred
-function milight:zoneBrightness(zone, value)
+function milightObject:zoneBrightness(zone, value)
     return brightnessHelper(self, zone2cmdkey(zone, "on"), value)
 end
 
@@ -127,7 +128,7 @@ end
 ---
 --- Returns:
 ---  * True if the command was sent correctly, otherwise false
-function milight:zoneColor(zone, value)
+function milightObject:zoneColor(zone, value)
     return colorHelper(self, zone2cmdkey(zone, "on"), value)
 end
 
@@ -140,7 +141,7 @@ end
 ---
 --- Returns:
 ---  * True if the command was sent correctly, otherwise false
-function milight:zoneWhite(zone)
+function milightObject:zoneWhite(zone)
     if (self:zoneOn(zone)) then
         return milight.send(self, milight.cmd[zone2cmdkey(zone, "white")])
     else

--- a/extensions/milight/internal.m
+++ b/extensions/milight/internal.m
@@ -193,8 +193,19 @@ static int milight_metagc(lua_State *L) {
 static const luaL_Reg milightlib[] = {
     {"_cacheCommands", milight_cacheCommands},
     {"new", milight_new},
+
+    {NULL, NULL},
+};
+
+static const luaL_Reg milight_objectlib[] = {
     {"delete", milight_del},
     {"send", milight_send},
+
+    {NULL, NULL}
+};
+
+static const luaL_Reg milightlib_gc[] = {
+    {"__gc", milight_metagc},
 
     {NULL, NULL}
 };
@@ -203,16 +214,8 @@ static const luaL_Reg milightlib[] = {
          must match the require-path of this file, i.e. "hs.milight.internal". */
 
 int luaopen_hs_milight_internal(lua_State *L) {
-    luaL_newlib(L, milightlib);
-
-    if (luaL_newmetatable(L, USERDATA_TAG)) {
-        lua_pushvalue(L, -2);
-        lua_setfield(L, -2, "__index");
-
-        lua_pushcfunction(L, milight_metagc);
-        lua_setfield(L, -2, "__gc");
-    }
-    lua_pop(L, 1);
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:milightlib metaFunctions:milightlib_gc objectFunctions:milight_objectlib];
 
     return 1;
 }

--- a/extensions/mouse/internal.m
+++ b/extensions/mouse/internal.m
@@ -59,8 +59,10 @@ static const luaL_Reg mouseLib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_mouse_internal(lua_State* L) {
-    luaL_newlib(L, mouseLib);
+int luaopen_hs_mouse_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:mouseLib metaFunctions:nil];
+
     return 1;
 }
 

--- a/extensions/pasteboard/internal.m
+++ b/extensions/pasteboard/internal.m
@@ -152,8 +152,9 @@ static const luaL_Reg pasteboardLib[] = {
     {NULL,      NULL}
 };
 
-int luaopen_hs_pasteboard_internal(lua_State* L) {
-    luaL_newlib(L, pasteboardLib);
+int luaopen_hs_pasteboard_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:pasteboardLib metaFunctions:nil];
 
     return 1;
 }

--- a/extensions/pathwatcher/internal.m
+++ b/extensions/pathwatcher/internal.m
@@ -47,14 +47,15 @@ static int watcher_path_new(lua_State* L) {
 
     NSString* path = [NSString stringWithUTF8String: luaL_checkstring(L, 1)];
     luaL_checktype(L, 2, LUA_TFUNCTION);
-    lua_settop(L, 2);
 
     watcher_path_t* watcher_path = lua_newuserdata(L, sizeof(watcher_path_t));
-    watcher_path->closureref = [skin luaRef:refTable];
     watcher_path->started = NO;
 
     luaL_getmetatable(L, USERDATA_TAG);
     lua_setmetatable(L, -2);
+
+    lua_pushvalue(L, 2);
+    watcher_path->closureref = [skin luaRef:refTable];
 
     FSEventStreamContext context;
     context.info = watcher_path;

--- a/extensions/pathwatcher/internal.m
+++ b/extensions/pathwatcher/internal.m
@@ -140,17 +140,9 @@ static const luaL_Reg meta_gcLib[] = {
     {NULL,      NULL}
 };
 
-int luaopen_hs_pathwatcher_internal(lua_State* L) {
-// Metatable for created objects
-    luaL_newlib(L, path_metalib);
-        lua_pushvalue(L, -1);
-        lua_setfield(L, -2, "__index");
-        lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
-
-// Create table for luaopen
-    luaL_newlib(L, pathLib);
-        luaL_newlib(L, meta_gcLib);
-        lua_setmetatable(L, -2);
+int luaopen_hs_pathwatcher_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:pathLib metaFunctions:meta_gcLib objectFunctions:path_metalib];
 
     return 1;
 }

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -166,7 +166,7 @@ local function projection(base, rect) -- like hs.geometry,intersectionRect, but 
   return {x=rectx,y=recty,w=rectx2-rectx,h=recty2-recty}
 end
 
-local function first_screen_in_direction(screen, numrotations, from, strict, allscreens)
+local function first_screen_in_direction(aScreen, numrotations, from, strict, allscreens)
   if not allscreens then
     allscreens = screen.allScreens()
     if #allscreens==1 then return end
@@ -181,7 +181,7 @@ local function first_screen_in_direction(screen, numrotations, from, strict, all
 
   -- thanks mark!
 
-  local otherscreens = fnutils.filter(allscreens, function(s) return s ~= screen end)
+  local otherscreens = fnutils.filter(allscreens, function(s) return s ~= aScreen end)
   local myf=screen:fullFrame()
   local p1 = geometry.rectMidPoint(from and projection(myf,from) or myf)
   local screens = {}

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -18,15 +18,14 @@ screen.watcher = require "hs.screen.watcher"
 local pairs,min,max,cos,atan=pairs,math.min,math.max,math.cos,math.atan
 local tinsert,tremove,tsort=table.insert,table.remove,table.sort
 
+local screenObject = hs.getObjectMetatable("hs.screen")
+
 --- hs.screen.primaryScreen() -> screen
 --- Constructor
 --- Returns the primary screen, i.e. the one containing the menubar
 function screen.primaryScreen()
   return screen.allScreens()[1]
 end
-
-local primaryScreen = screen.primaryScreen()
-local screenObject = getmetatable(primaryScreen)
 
 --- hs.screen.findByName(name) -> screen or nil
 --- Function

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -25,6 +25,9 @@ function screen.primaryScreen()
   return screen.allScreens()[1]
 end
 
+local primaryScreen = screen.primaryScreen()
+local screenObject = getmetatable(primaryScreen)
+
 --- hs.screen.findByName(name) -> screen or nil
 --- Function
 --- Finds a screen by its name
@@ -106,7 +109,7 @@ end
 ---
 --- Returns:
 ---  * two integers indicating the screen position in the current screen arrangement, in the x and y axis respectively.
-function screen:position()
+function screenObject:position()
   local id = self:id()
   local pos=screen.screenPositions()
   for s,p in pairs(pos) do
@@ -116,7 +119,7 @@ end
 --- hs.screen:fullFrame() -> rect
 --- Method
 --- Returns the screen's rect in absolute coordinates, including the dock and menu.
-function screen:fullFrame()
+function screenObject:fullFrame()
   local primary_screen = screen.allScreens()[1]
   local f = self:_frame()
   f.y = primary_screen:_frame().h - f.h - f.y
@@ -126,7 +129,7 @@ end
 --- hs.screen:frame() -> rect
 --- Method
 --- Returns the screen's rect in absolute coordinates, without the dock or menu.
-function screen:frame()
+function screenObject:frame()
   local primary_screen = screen.allScreens()[1]
   local f = self:_visibleframe()
   f.y = primary_screen:_frame().h - f.h - f.y
@@ -136,7 +139,7 @@ end
 --- hs.screen:next() -> screen
 --- Method
 --- Returns the screen 'after' this one (I have no idea how they're ordered though); this method wraps around to the first screen.
-function screen:next()
+function screenObject:next()
   local screens = screen.allScreens()
   local i = fnutils.indexOf(screens, self) + 1
   if i > # screens then i = 1 end
@@ -147,7 +150,7 @@ end
 --- hs.screen:previous() -> screen
 --- Method
 --- Returns the screen 'before' this one (I have no idea how they're ordered though); this method wraps around to the last screen.
-function screen:previous()
+function screenObject:previous()
   local screens = screen.allScreens()
   local i = fnutils.indexOf(screens, self) - 1
   if i < 1 then i = # screens end
@@ -224,7 +227,7 @@ screen.strictScreenInDirection = false
 --- Parameters:
 ---   * from - An `hs.geometry.rect` or `hs.geometry.point` object; if omitted, the geometric center of this screen will be used
 ---   * strict - If `true`, disregard screens that lie completely above or below this one (alternatively, set `hs.screen.strictScreenInDirection`)
-function screen:toEast(...)  return first_screen_in_direction(self, 0, ...) end
+function screenObject:toEast(...)  return first_screen_in_direction(self, 0, ...) end
 
 --- hs.screen:toWest()
 --- Method
@@ -232,7 +235,7 @@ function screen:toEast(...)  return first_screen_in_direction(self, 0, ...) end
 --- Parameters:
 ---   * from - An `hs.geometry.rect` or `hs.geometry.point` object; if omitted, the geometric center of this screen will be used
 ---   * strict - If `true`, disregard screens that lie completely above or below this one (alternatively, set `hs.screen.strictScreenInDirection`)
-function screen:toWest(...)  return first_screen_in_direction(self, 2, ...) end
+function screenObject:toWest(...)  return first_screen_in_direction(self, 2, ...) end
 
 --- hs.screen:toNorth()
 --- Method
@@ -240,7 +243,7 @@ function screen:toWest(...)  return first_screen_in_direction(self, 2, ...) end
 --- Parameters:
 ---   * from - An `hs.geometry.rect` or `hs.geometry.point` object; if omitted, the geometric center of this screen will be used
 ---   * strict - If `true`, disregard screens that lie completely to the left or to the right of this one (alternatively, set `hs.screen.strictScreenInDirection`)
-function screen:toNorth(...) return first_screen_in_direction(self, 1, ...) end
+function screenObject:toNorth(...) return first_screen_in_direction(self, 1, ...) end
 
 --- hs.screen:toSouth()
 --- Method
@@ -248,7 +251,7 @@ function screen:toNorth(...) return first_screen_in_direction(self, 1, ...) end
 --- Parameters:
 ---   * from - An `hs.geometry.rect` or `hs.geometry.point` object; if omitted, the geometric center of this screen will be used
 ---   * strict - If `true`, disregard screens that lie completely to the left or to the right of this one (alternatively, set `hs.screen.strictScreenInDirection`)
-function screen:toSouth(...) return first_screen_in_direction(self, 3, ...) end
+function screenObject:toSouth(...) return first_screen_in_direction(self, 3, ...) end
 
 --- hs.screen:shotAsPNG(filePath[, screenRect])
 --- Method
@@ -260,7 +263,7 @@ function screen:toSouth(...) return first_screen_in_direction(self, 3, ...) end
 ---
 --- Returns:
 ---  * None
-function screen:shotAsPNG(filePath, screenRect)
+function screenObject:shotAsPNG(filePath, screenRect)
   local image = self:snapshot(screenRect)
   image:saveToFile(filePath, "PNG")
 end
@@ -275,7 +278,7 @@ end
 ---
 --- Returns:
 ---  * None
-function screen:shotAsJPG(filePath, screenRect)
+function screenObject:shotAsJPG(filePath, screenRect)
   local image = self:snapshot(screenRect)
   image:saveToFile(filePath, "JPG")
 end

--- a/extensions/screen/internal.m
+++ b/extensions/screen/internal.m
@@ -836,6 +836,8 @@ static const luaL_Reg metalib[] = {
 };
 
 int luaopen_hs_screen_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+
     // Start off by initialising gamma related structures, populating them and registering appropriate callbacks
     originalGammas = [[NSMutableDictionary alloc] init];
     currentGammas = [[NSMutableDictionary alloc] init];
@@ -843,7 +845,6 @@ int luaopen_hs_screen_internal(lua_State* L __unused) {
     notificationQueue = dispatch_queue_create("org.hammerspoon.Hammerspoon.gammaReapplyNotificationQueue", NULL);
     CGDisplayRegisterReconfigurationCallback(displayReconfigurationCallback, NULL);
 
-    LuaSkin *skin = [LuaSkin shared];
     [skin registerLibraryWithObject:USERDATA_TAG functions:screenlib metaFunctions:metalib objectFunctions:screen_objectlib];
 
     return 1;

--- a/extensions/screen/watcher.m
+++ b/extensions/screen/watcher.m
@@ -150,16 +150,8 @@ static const luaL_Reg meta_gcLib[] = {
 };
 
 int luaopen_hs_screen_watcher(lua_State* L) {
-// Metatable for created objects
-    luaL_newlib(L, screen_metalib);
-        lua_pushvalue(L, -1);
-        lua_setfield(L, -2, "__index");
-        lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
-
-// Create table for luaopen
-    luaL_newlib(L, screenLib);
-        luaL_newlib(L, meta_gcLib);
-        lua_setmetatable(L, -2);
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:screenLib metaFunctions:meta_gcLib objectFunctions:screen_metalib];
 
     return 1;
 }

--- a/extensions/settings/internal.m
+++ b/extensions/settings/internal.m
@@ -284,21 +284,21 @@ static const luaL_Reg settingslib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_settings_internal(lua_State* L) {
-    // setup the module
-    luaL_newlib(L, settingslib);
+int luaopen_hs_settings_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:settingslib metaFunctions:nil];
 
 /// hs.settings.dateFormat
 /// Constant
 /// A string representing the expected format of date and time when presenting the date and time as a string to `hs.setDate()`.  e.g. `os.date(hs.settings.dateFormat)`
-        lua_pushstring(L, "!%Y-%m-%dT%H:%M:%SZ") ;
-        lua_setfield(L, -2, "dateFormat") ;
+        lua_pushstring(skin.L, "!%Y-%m-%dT%H:%M:%SZ") ;
+        lua_setfield(skin.L, -2, "dateFormat") ;
 
 /// hs.settings.bundleID
 /// Constant
 /// A string representing the ID of the bundle Hammerspoon's settings are stored in . You can use this with the command line tool `defaults` or other tools which allow access to the `User Defaults` of applications, to access these outside of Hammerspoon
-        lua_pushstring(L, [[[NSBundle mainBundle] bundleIdentifier] UTF8String]) ;
-        lua_setfield(L, -2, "bundleID") ;
+        lua_pushstring(skin.L, [[[NSBundle mainBundle] bundleIdentifier] UTF8String]) ;
+        lua_setfield(skin.L, -2, "bundleID") ;
 
     return 1;
 }

--- a/extensions/timer/internal.m
+++ b/extensions/timer/internal.m
@@ -250,17 +250,9 @@ static const luaL_Reg meta_gcLib[] = {
     {NULL,      NULL}
 };
 
-int luaopen_hs_timer_internal(lua_State* L) {
-// Metatable for created objects
-    luaL_newlib(L, timer_metalib);
-        lua_pushvalue(L, -1);
-        lua_setfield(L, -2, "__index");
-        lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
-
-// Create table for luaopen
-    luaL_newlib(L, timerLib);
-        luaL_newlib(L, meta_gcLib);
-        lua_setmetatable(L, -2);
+int luaopen_hs_timer_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:timerLib metaFunctions:meta_gcLib objectFunctions:timer_metalib];
 
     return 1;
 }

--- a/extensions/uielement/internal.m
+++ b/extensions/uielement/internal.m
@@ -197,9 +197,10 @@ static watcher_t* get_watcher(lua_State* L, int elem) {
 
 static void watcher_observer_callback(AXObserverRef observer __unused, AXUIElementRef element,
                                       CFStringRef notificationName, void* contextData) {
+    LuaSkin *skin = [LuaSkin shared];
+
     watcher_t* watcher = (watcher_t*) contextData;
 
-    LuaSkin *skin = [LuaSkin shared];
     lua_State *L = skin.L;
 
     lua_rawgeti(L, LUA_REGISTRYINDEX, watcher->handler_ref);

--- a/extensions/usb/internal.m
+++ b/extensions/usb/internal.m
@@ -102,10 +102,9 @@ static const luaL_Reg metalib[] = {
     {NULL, NULL}
 };
 
-int luaopen_hs_usb_internal(lua_State* L) {
-    luaL_newlib(L, usblib);
-    luaL_newlib(L, metalib);
-    lua_setmetatable(L, -2);
+int luaopen_hs_usb_internal(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:usblib metaFunctions:metalib];
 
     return 1;
 }

--- a/extensions/usb/watcher.m
+++ b/extensions/usb/watcher.m
@@ -291,17 +291,9 @@ static const luaL_Reg meta_gcLib[] = {
     {NULL,      NULL}
 };
 
-int luaopen_hs_usb_watcher(lua_State* L) {
-    // Metatable for created objects
-    luaL_newlib(L, usb_metalib);
-    lua_pushvalue(L, -1);
-    lua_setfield(L, -2, "__index");
-    lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
-
-    // Create table for luaopen
-    luaL_newlib(L, usbLib);
-    luaL_newlib(L, meta_gcLib);
-    lua_setmetatable(L, -2);
+int luaopen_hs_usb_watcher(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:usbLib metaFunctions:meta_gcLib objectFunctions:usb_metalib];
 
     return 1;
 }

--- a/extensions/wifi/internal.m
+++ b/extensions/wifi/internal.m
@@ -75,9 +75,8 @@ static const luaL_Reg metalib[] = {
 };
 
 int luaopen_hs_wifi_internal(lua_State* L) {
-    luaL_newlib(L, wifilib);
-    luaL_newlib(L, metalib);
-    lua_setmetatable(L, -2);
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibrary:wifilib metaFunctions:metalib];
 
     return 1;
 }

--- a/extensions/wifi/watcher.m
+++ b/extensions/wifi/watcher.m
@@ -176,17 +176,9 @@ static const luaL_Reg meta_gcLib[] = {
     {NULL,      NULL}
 };
 
-int luaopen_hs_wifi_watcher(lua_State* L) {
-// Metatable for created objects
-    luaL_newlib(L, wifi_metalib);
-        lua_pushvalue(L, -1);
-        lua_setfield(L, -2, "__index");
-        lua_setfield(L, LUA_REGISTRYINDEX, USERDATA_TAG);
-
-// Create table for luaopen
-    luaL_newlib(L, wifiLib);
-        luaL_newlib(L, meta_gcLib);
-        lua_setmetatable(L, -2);
+int luaopen_hs_wifi_watcher(lua_State* L __unused) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin registerLibraryWithObject:USERDATA_TAG functions:wifiLib metaFunctions:meta_gcLib objectFunctions:wifi_metalib];
 
     return 1;
 }


### PR DESCRIPTION
Closes #454 

The idea here is that each time an extension is registered with its own objects, we create a separate table for it in LUA_REGISTRYINDEX and it should then use the new LuaSkin ref/unref/push wrappers to interact with its reference table.

This doesn't stop us from corrupting the reference tables by accidentally over-unreffing, but it does mean that the damage is isolated in each module, instead of removing/re-using arbitrary items in LUA_REGISTRYINDEX, as we have now, so it should make debugging these issues significantly easier.

Currently a WIP because all that exists right now is the base implementation in LuaSkin and a quick port of the hotkey module to use the new API.