### PR TITLE
Add argument type checker to LuaSkin

### DIFF
--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -11,6 +11,18 @@
 #import "lualib.h"
 #import "lua.h"
 
+// Define some bits for masking operations in the argument checker
+#define LS_TBREAK         1 << 0
+#define LS_TOPTIONAL      1 << 1
+#define LS_TNIL           1 << 2
+#define LS_TBOOLEAN       1 << 3
+#define LS_TNUMBER        1 << 4
+#define LS_TSTRING        1 << 5
+#define LS_TTABLE         1 << 6
+#define LS_TFUNCTION      1 << 7
+#define LS_TUSERDATA      1 << 8
+#define LS_TNONE          1 << 9
+
 @interface LuaSkin : NSObject {
     lua_State *_L;
 }
@@ -153,6 +165,16 @@
  */
 - (void)pushLuaRef:(int)refTable ref:(int)ref;
 
-//TODO: Add methods for enforcing Lua function arguments
+/** Ensures a Lua->C call has the right arguments
+ 
+ @note If the arguments are incorrect, this call will never return and the user will get a nice Lua traceback instead.
+ @note Each argument can use boolean OR's to allow multiple types to be accepted (e.g. LS_TNIL | LS_TBOOLEAN).
+ @note Each argument can be OR'd with LS_TOPTIONAL to indicate that the argument is optional.
+ 
+ @param firstArg - An integer that defines the first acceptable Lua argument type. Possible values are LS_TNIL, LS_TBOOLEAN, LS_TNUMBER, LS_TSTRING, LS_TTABLE, LS_TFUNCTION, LS_TUSERDATA, LS_TBREAK
+ @param ... - One or more integers that define the remaining acceptable Lua argument types. See the previous parameter for possible values. The final value MUST be LS_TBREAK, to indicate the end of the list.
+ */
+- (void)checkArgs:(int)firstArg, ...;
+
 //TODO: Add methods for converting Lua<->objc types
 @end

--- a/extensions/alert/internal.m
+++ b/extensions/alert/internal.m
@@ -168,6 +168,9 @@ void HSShowAlert(NSString* oneLineMsg, CGFloat duration) {
 /// Returns:
 ///  * None
 static int alert_show(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TSTRING, LS_TNUMBER|LS_TOPTIONAL, LS_TBREAK];
+
     lua_settop(L, 2);
     NSString* str = [NSString stringWithUTF8String: luaL_checkstring(L, 1)];
 

--- a/extensions/pathwatcher/internal.m
+++ b/extensions/pathwatcher/internal.m
@@ -44,6 +44,7 @@ void event_callback(ConstFSEventStreamRef __unused streamRef, void *clientCallBa
 /// Returns a new watcher.path that can be started and stopped.  The function registered receives as it's argument, a table containing a list of the files which have changed since it was last invoked.
 static int watcher_path_new(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TSTRING, LS_TFUNCTION, LS_TBREAK];
 
     NSString* path = [NSString stringWithUTF8String: luaL_checkstring(L, 1)];
     luaL_checktype(L, 2, LUA_TFUNCTION);

--- a/extensions/wifi/watcher.m
+++ b/extensions/wifi/watcher.m
@@ -73,6 +73,7 @@ typedef struct _wifiwatcher_t {
 ///  * This means that when you switch from one network to another, you will receive a disconnection event as you leave the first network, and a connection event as you join the second. You are advised to keep a variable somewhere that tracks the name of the last network you were connected to, so you can track changes that involve multiple events.
 static int wifi_watcher_new(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TFUNCTION, LS_TBREAK];
 
     luaL_checktype(L, 1, LUA_TFUNCTION);
 


### PR DESCRIPTION
This one I'm not so sure about - it may be a solution in search of a problem, or at least to a larger extent than the other LuaSkin additions of late :)

I like the way it works, it's reasonably lightweight, and I like the idea of frontloading all of the type checking as soon as you cross the Lua->C boundary, rather than maybe-hopefully having lua_check* at various points in the code that follows.