### PR TITLE
[READY] add hs.screen.find (needs #471)

### DIFF
--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -168,6 +168,22 @@ function screenObject:frame()
   return f
 end
 
+--- hs.screen:fromUnitRect(unitrect) -> hs.geometry rect
+--- Method
+--- Returns the absolute rect of a given unit rect within this screen
+---
+--- Parameters:
+---  * unitrect - an hs.geometry unit rect, or arguments to construct one
+---
+--- Returns:
+---  * an hs.geometry rect describing the given frame in absolute coordinates
+---
+--- Notes:
+---  * this method is just a convenience wrapper for `hs.geometry.fromUnitRect(unitrect,this_screen:fullFrame())`
+function screenObject:fromUnitRect(unit,...)
+  return geometry(unit,...):fromUnitRect(self:fullFrame())
+end
+
 --- hs.screen:next() -> screen
 --- Method
 --- Returns the screen 'after' this one (in arbitrary order); this method wraps around to the first screen.

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -228,7 +228,7 @@ local function first_screen_in_direction(fromScreen, numrotations, fromPoint, st
     end
   end
   tsort(screens, function(a, b) return a.score < b.score end)
-  return #screens>0 and screens[1].s
+  return #screens>0 and screens[1].s or nil
 end
 
 --- hs.screen.strictScreenInDirection
@@ -246,7 +246,6 @@ screen.strictScreenInDirection = false
 ---
 --- Returns:
 ---   * the desired hs.screen object, or `nil` if not found
-function screenObject:toEast(...)  return first_screen_in_direction(self, 0, ...) end
 
 --- hs.screen:toWest() -> hs.screen object
 --- Method
@@ -258,7 +257,6 @@ function screenObject:toEast(...)  return first_screen_in_direction(self, 0, ...
 ---
 --- Returns:
 ---   * the desired hs.screen object, or `nil` if not found
-function screenObject:toWest(...)  return first_screen_in_direction(self, 2, ...) end
 
 --- hs.screen:toNorth() -> hs.screen object
 --- Method
@@ -270,7 +268,6 @@ function screenObject:toWest(...)  return first_screen_in_direction(self, 2, ...
 ---
 --- Returns:
 ---   * the desired hs.screen object, or `nil` if not found
-function screenObject:toNorth(...) return first_screen_in_direction(self, 1, ...) end
 
 --- hs.screen:toSouth() -> hs.screen object
 --- Method
@@ -282,7 +279,9 @@ function screenObject:toNorth(...) return first_screen_in_direction(self, 1, ...
 ---
 --- Returns:
 ---   * the desired hs.screen object, or `nil` if not found
-function screenObject:toSouth(...) return first_screen_in_direction(self, 3, ...) end
+for r,d in pairs{[0]='East','North','West','South'} do
+  screenObject['to'..d]=function(self,...) return first_screen_in_direction(self,r,...) end
+end
 
 --- hs.screen:shotAsPNG(filePath[, screenRect])
 --- Method

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -17,7 +17,6 @@ screen.watcher = require "hs.screen.watcher"
 
 local type,pairs,ipairs,min,max,cos,atan=type,pairs,ipairs,math.min,math.max,math.cos,math.atan
 local tinsert,tremove,tsort,tunpack=table.insert,table.remove,table.sort,table.unpack
-local sfind=string.find
 local getmetatable,pcall=getmetatable,pcall
 
 local screenObject = hs.getObjectMetatable("hs.screen")
@@ -44,17 +43,20 @@ end
 --- Returns:
 ---  * one or more hs.screen objects that match the supplied search criterion, or `nil` if none found
 ---
+--- Notes:
+---  * for convenience you call call this as `hs.screen(hint)`
+---
 --- Usage:
 --- -- by id
---- hs.screen.find(724562417):name() --> Color LCD
+--- hs.screen(724562417):name() --> Color LCD
 --- -- by name
---- hs.screen.find'Dell':name() --> DELL U2414M
+--- hs.screen'Dell':name() --> DELL U2414M
 --- -- by position
---- hs.screen.find(0,0):name() --> PHL BDM4065 - same as hs.screen.primaryScreen()
---- hs.screen.find{x=-1,y=0}:name() --> DELL U2414M - screen to the immediate left of the primary screen
+--- hs.screen(0,0):name() --> PHL BDM4065 - same as hs.screen.primaryScreen()
+--- hs.screen{x=-1,y=0}:name() --> DELL U2414M - screen to the immediate left of the primary screen
 --- -- by frame
---- hs.screen.find(-1200,240,1200,1920):name() --> DELL U2414M - exact frame
---- hs.screen.find'3840x2160':name() --> PHL BDM4065 - resolution
+--- hs.screen(-1200,240,1200,1920):name() --> DELL U2414M - exact frame
+--- hs.screen'3840x2160':name() --> PHL BDM4065 - resolution
 function screen.find(p,...)
   if p==nil then return end
   local typ=type(p)
@@ -63,7 +65,7 @@ function screen.find(p,...)
     local screens=screen.allScreens()
     if typ=='number' and p>20 then for _,s in ipairs(screens) do if p==s:id() then return s end return end -- not found
     elseif typ=='string' then
-      local f=moses.filter(screens,function(_,s)return sfind(s:name():lower(),p:lower())end)
+      local f=moses.filter(screens,function(_,s)return s:name():lower():find(p:lower())end)
       if #f>0 then return tunpack(f) end
     elseif typ~='table' then error('hint can be a number, string or table',2) end
     local ok
@@ -312,4 +314,5 @@ function screenObject:shotAsJPG(filePath, screenRect,...)
   image:saveToFile(filePath, "JPG")
 end
 
+getmetatable(screen).__call=function(_,...)return screen.find(...)end
 return screen

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -148,24 +148,36 @@ function screenObject:position()
     if s:id()==id then return p.x,p.y end
   end
 end
---- hs.screen:fullFrame() -> rect
+--- hs.screen:fullFrame() -> hs.geometry rect
 --- Method
---- Returns the screen's rect in absolute coordinates, including the dock and menu.
+--- Returns the screen frame, including the dock and menu.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * an hs.geometry rect describing this screen's frame in absolute coordinates
 function screenObject:fullFrame()
   local primary_screen = screen.allScreens()[1]
   local f = self:_frame()
   f.y = primary_screen:_frame().h - f.h - f.y
-  return f
+  return geometry(f)
 end
 
---- hs.screen:frame() -> rect
+--- hs.screen:frame() -> hs.geometry rect
 --- Method
---- Returns the screen's rect in absolute coordinates, without the dock or menu.
+--- Returns the screen frame, without the dock or menu.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * an hs.geometry rect describing this screen's "usable" frame (i.e. without the dock and menu bar) in absolute coordinates
 function screenObject:frame()
   local primary_screen = screen.allScreens()[1]
   local f = self:_visibleframe()
   f.y = primary_screen:_frame().h - f.h - f.y
-  return f
+  return geometry(f)
 end
 
 --- hs.screen:fromUnitRect(unitrect) -> hs.geometry rect


### PR DESCRIPTION
original message:
> hs.grid.show() is currently broken, merge this before next release

Whops, I've accidentally overwritten the wrong branch and lost the original commit... However it was an easy fix: https://github.com/Hammerspoon/hammerspoon/blob/master/extensions/screen/init.lua#L185 `screen`->`aScreen`

The *current* PR here does include the fix, but it has unmet dependencies (geometry #471), so it might not land for a while.
