### PR TITLE
WIP hs.notify updates

### DIFF
--- a/extensions/notify/init.lua
+++ b/extensions/notify/init.lua
@@ -1,13 +1,68 @@
+
 --- === hs.notify ===
 ---
---- On-screen notifications using Notification Center
+--- This module allows you to create on screen notifications in the User Notification Center located at the right of the users screen.
+---
+--- Notifications can be sent immediately or scheduled for delivery at a later time, even if that scheduled time occurs when Hammerspoon is not currently running.  Currently, if you take action on a notification while Hammerspoon is not running, the callback function is not honored for the first notification clicked upon -- This is expected to be fixed in a future release.
+---
+--- When setting up a callback function, you have the option of specifying it with the creation of the notification (hs.notify.new) or by pre-registering it with hs.notify.register and then referring it to by the tag name specified with hs.notify.register.  If you use this registration method for defining your callback functions, and make sure to register all expected callback functions within your init.lua file or files it includes, then callback functions will remain available for existing notifications in the User Notification Center even if Hammerspoon's configuration is reloaded or if Hammerspoon is restarted.  If the callback tag is not present when the user acts on the notification, the Hammerspoon console will be raised as a default action.
+---
+--- A shorthand, based upon the original inspiration for this module from Hydra and Mjolnir, hs.notify.show, is provided if you just require a quick and simple informative notification without the bells and whistles.
 ---
 --- This module is based in part on code from the previous incarnation of Mjolnir by [Steven Degutis](https://github.com/sdegutis/).
 
-local module = require("hs.notify.internal")
+-- package.loadlib(
+--     package.searchpath("hs._asm.extras.objectconversion",
+--     package.cpath),"*")
+
+local module   = require("hs.notify.internal")
+local host     = require("hs.host")
+local imagemod = require("hs.image")
+
+local _kMetaTable = {}
+_kMetaTable._k = {}
+_kMetaTable.__index = function(obj, key)
+        if _kMetaTable._k[obj] then
+            if _kMetaTable._k[obj][key] then
+                return _kMetaTable._k[obj][key]
+            else
+                for k,v in pairs(_kMetaTable._k[obj]) do
+                    if v == key then return k end
+                end
+            end
+        end
+        return nil
+    end
+_kMetaTable.__newindex = function(obj, key, value)
+        error("attempt to modify a table of constants",2)
+        return nil
+    end
+_kMetaTable.__pairs = function(obj) return pairs(_kMetaTable._k[obj]) end
+_kMetaTable.__tostring = function(obj)
+        local result = ""
+        if _kMetaTable._k[obj] then
+            local width = 0
+            for k,v in pairs(_kMetaTable._k[obj]) do width = width < #k and #k or width end
+            for k,v in require("hs.fnutils").sortByKeys(_kMetaTable._k[obj]) do
+                result = result..string.format("%-"..tostring(width).."s %s\n", k, tostring(v))
+            end
+        else
+            result = "constants table missing"
+        end
+        return result
+    end
+_kMetaTable.__metatable = _kMetaTable -- go ahead and look, but don't unset this
+
+local _makeConstantsTable = function(theTable)
+    local results = setmetatable({}, _kMetaTable)
+    _kMetaTable._k[results] = theTable
+    return results
+end
 
 -- private variables and methods -----------------------------------------
 
+-- functions provide by the C library which should not be treated as attributes when
+-- creating a new notification (see hs.notify.new below)
 local protected_functions = {
     show = true,
     release = true,
@@ -16,119 +71,241 @@ local protected_functions = {
     __gc = true,
 }
 
+local emptyFunctionPlaceholder = "__emptyFunctionPlaceHolder"
+
 -- Public interface ------------------------------------------------------
+
+module.activationTypes = _makeConstantsTable(module.activationTypes)
 
 --- hs.notify.new([fn,][attributes]) -> notification
 --- Constructor
 --- Creates a new notification object
 ---
 --- Parameters:
----  * fn - An optional function, which will be called when the user interacts with notifications. The notification object will be passed as an argument to the function.
+---  * fn - An optional function or function-tag, which will be called when the user interacts with notifications. The notification object will be passed as an argument to the function.  If you leave this parameter out or specify nil, then no callback will be attached to the notification.
 ---  * attributes - An optional table for applying attributes to the notification. Possible keys are:
----   * title
----   * subTitle
----   * informativeText
----   * soundName
----   * alwaysPresent
----   * autoWithdraw
----   * actionButtonTitle (only available if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences)
----   * otherButtonTitle (only available if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences)
----   * hasActionButton (only available if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences)
+---
+---   * alwaysPresent   - see `hs.notify:alwaysPresent`
+---   * autoWithdraw    - see `hs.notify:autoWithdraw`
+---   * contentImage    - see `hs.notify:contentImage` (only supported in 10.9 and later)
+---   * informativeText - see `hs.notify:informativeText`
+---   * soundName       - see `hs.notify:soundName`
+---   * subTitle        - see `hs.notify:subTitle`
+---   * title           - see `hs.notify:title`
+---
+---  The following can also be set, but will only have an apparent effect on the notification when the user has set Hammerspoon's notification style to "Alert" in the Notification Center panel of System Preferences:
+---
+---   * actionButtonTitle - see `hs.notify:actionButtonTitle`
+---   * hasActionButton   - see `hs.notify:hasActionButton`
+---   * otherButtonTitle  - see `hs.notify:otherButtonTitle`
 ---
 --- Returns:
 ---  * A notification object
 ---
 --- Notes:
----  * If a notification does not have a `title` attribute set, OS X will not display it. Either use the `title` key in the attributes table, or call `hs.notify:title()` before displaying the notification
+---  * A function-tag is a string key which corresponds to a function stored in the `hs.notify.registry` table with the `hs.notify.register()` function.
+---  * If a notification does not have a `title` attribute set, OS X will not display it, so by default it will be set to "Notification".  You can use the `title` key in the attributes table, or call `hs.notify:title()` before displaying the notification to change this.
 module.new = function(fn, attributes)
     if type(fn) == "table" then
         attributes = fn
         fn = nil
     end
-    fn = fn or function() end
-    attributes = attributes or { title="Notification" }
+    fn = fn or emptyFunctionPlaceholder
+    if fn == "" then fn = emptyFunctionPlaceholder end
+
+    if type(fn) == "function" then
+        local tmpTag = host.globallyUniqueString()
+        module.register(tmpTag, fn)
+        fn = tmpTag
+    end
+
+    attributes = attributes or { }
+    if not attributes.title then attributes.title = "Notification" end
 
     local note = module._new(fn)
     for i,v in pairs(attributes) do
-        if getmetatable(note)[i] and not protected_functions[i] then
+        if note[i] and not protected_functions[i] then
             note[i](note, v)
         end
     end
     return note
 end
 
--- ----- What follows is to mimic hs.notify and actually could replace it if this module is added to core as something else.
-
-local function callback(tag)
-  for k, v in pairs(module.registry) do
-    if k ~= "n" and v ~= nil then
-      local fntag, fn = v[1], v[2]
-      if tag == fntag then
-        fn()
-      end
+module._tag_handler = function(tag, notification)
+    local found = false
+    for k,v in pairs(module.registry) do
+        if k ~= "n" and v ~= nil then
+            if v[1] == tag then
+                v[2](notification)
+                found = true
+                break
+            end
+        end
     end
-  end
+    if not found then print("-- hs.notify: function tag '"..tag.."' not found") end
 end
 
---- hs.notify._DEPRECATED
---- Deprecated
---- Previous versions of Hammerspoon, Mjolnir and Hydra included a much less rich notification API. This old API is still available in Hammerspoon, but you should migrate all of your usage of the following APIs, to the newer ones documented below, as soon as possible.
+--- hs.notify.show(title, subtitle, information, tag) -> notfication
+--- Constructor
+--- Shorthand constructor to create and show simple notifications
 ---
---- * hs.notify.show(title, subtitle, information, tag) -> notfication
----  * Constructor
----  * Convienence function to mimic Hydra's notify.show. Shows an Apple notification. Tag is a unique string that identifies this notification; any function registered for the given tag will be called if the notification is clicked. None of the strings are optional, though they may each be blank.
+--- Parameters:
+---  * title       - the title for the notification
+---  * subtitle    - the subtitle, or second line, of the notification
+---  * information - the main textual body of the notification.
+---  * tag         - a function tag corresponding to a function registered with `hs.notify.register`
 ---
---- * hs.notify.registry[]
----  * Variable
----  * This table contains the list of registered tags and their functions.  It should not be modified directly, but instead by the hs.notify.register(tag, fn) and hs.notify.unregister(id) functions.
+--- Returns:
+---  * a notification object
 ---
---- * hs.notify.register(tag, fn) -> id
----  * Function
----  * Registers a function to be called when an Apple notification with the given tag is clicked.
----
---- * hs.notify.unregister(id)
----  * Function
----  * Unregisters a function to no longer be called when an Apple notification with the given tag is clicked.  Note that this uses the `id` returned by `hs.notify.notification.register`.
----
---- * hs.notify.notification.unregisterall()
----  * Function
----  * Unregisters all functions registered for notification-clicks.
+--- Notes:
+---  * All four parameters are required, though they can be empty strings.
+---  * This function is really a shorthand for `hs.notify.new(...):send()`
 module.show = function(title, subtitle, information, tag)
     if type(title) ~= "string" or type(subtitle) ~= "string" or
         type(information) ~= "string" or type(tag) ~= "string" then
         error("All four arguments to hs.notify.show must be present and must be strings.",2)
         return nil
     else
-        return module.new(function(note)
-                callback(tag)
-                note:withdraw()
-            end, {
+        return module.new(tag, {
                 title = title,
                 subtitle = subtitle,
                 informativeText = information,
+                autoWithdraw = true,
             }):send()
     end
 end
 
-module.registry = {}
-module.registry.n = 0
-
+--- hs.notify.register(tag, fn) -> id
+--- Function
+--- Registers a function callback with the specified tag for a notification.  The callback function will be invoked when the user clicks on or interacts with a notification.
+---
+--- Parameters:
+---  * tag - a string tag to identify the registered callback function.  Use this as the function tag in `hs.notify.new` and `hs.notify.show`
+---  * fn  - the function which should be invoked when a notification with this tag is interacted with.
+---
+--- Returns:
+---  * a numerical id representing the entry in `hs.notify.registry` for this function.  This number can be used with `hs.notify.unregister` to unregister a function later if you wish.
+---
+--- Notes:
+---  * If a function is already registered with the specified tag, it is replaced by with the new one.
 module.register = function(tag, fn)
-  local id = module.registry.n + 1
-  module.registry[id] = {tag, fn}
-  module.registry.n = id
+  local found = false
+  local id
+  for k,v in pairs(module.registry) do
+      if k ~= "n" and v ~= nil then
+          if v[1] == tag then
+              id = i
+              v[2] = fn
+              found = true
+              break
+          end
+      end
+  end
+  if not found then
+      id = module.registry.n + 1
+      module.registry[id] = {tag, fn}
+      module.registry.n = id
+  end
   return id
 end
 
+--- hs.notify.unregister(id|tag)
+--- Function
+--- Unregisters a function callback so that it is no longer available as a callback when notifications corresponding to the specified entry are interacted with.
+---
+--- Parameters:
+---  * id or tag - the numerical id provided by `hs.notify.register` or string tag representing the callback function to be removed
+---
+--- Returns:
+---  * None
 module.unregister = function(id)
-  module.registry[id] = nil
+    local found = false
+    for i = 1, module.registry.n, 1 do
+        if module.registry[i] then
+              if type(module.registry[i][1]) == type(id) and module.registry[i][1] == id then
+                  found = i
+                  break
+              end
+        end
+    end
+    if not found then
+        module.registry[id] = nil
+    else
+        module.registry[found] = nil
+    end
 end
 
+--- hs.notify.notification.unregisterall()
+--- Function
+--- Unregisters all functions registered as callbacks.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * None
+---
+--- Notes:
+---  * This does not remove the notifications from the User Notification Center, it just removes their callback function for when the user interacts with them.  To remove all notifications, see `hs.notify.withdrawAll` and `hs.notify.withdrawAllScheduled`
 module.unregisterall = function()
-  module.registry = {}
-  module.registry.n = 0
+--- hs.notify.registry[]
+--- Variable
+--- A table containing the registered callback functions and their tags.
+---
+--- Notes:
+---  * This table should not be modified directly.  Use the `hs.notify.register(tag, fn)` and `hs.notify.unregister(id)` functions.
+---  * This table has a __tostring metamethod so you can see the list of registered function tags in the console by typing `hs.notify.registry`
+---  * If a notification attempts to perform a callback to a function tag which is not present in this table, a warning will be printed in the console.
+  module.registry = setmetatable({ { emptyFunctionPlaceholder, function(_) end } }, {
+      __tostring = function(_)
+          local result = ""
+          for k,v in pairs(_) do
+              if k ~= "n" and v ~= nil then result = result..v[1].."\n" end
+          end
+          return result
+      end,
+  })
+  module.registry.n = 1
+end
+
+--- hs.notify:contentImage([image]) -> notificationObject | current-setting
+--- Method
+--- Get or set a notification's content image.
+---
+--- Parameters:
+---  * image - An optional hs.image parameter containing the image to display. Defaults to nil.  If no parameter is provided, then the current setting is returned.
+---
+--- Returns:
+---  * The notification object, if image is provided; otherwise the current setting.
+---
+--- Notes:
+---  * See hs.image for details on how to specify or define an image
+---  * This method is only supported in OS X 10.9 or greater.  A warning will be displayed in the console and the method will be treated as a no-op if used on an unsupported system.
+hs.getObjectMetatable("hs.notify").contentImage = function(...)
+    local args = table.pack(...)
+    local object = args[1]
+    if args.n == 1 then
+        return object:_contentImage()
+    else
+        local imagePath = args[2]
+        local tmpImage = nil
+
+        if type(imagePath) == "userdata" then
+            tmpImage = imagePath
+        elseif type(imagePath) == "string" then
+            if string.sub(imagePath, 1, 6) == "ASCII:" then
+                tmpImage = imagemod.imageFromASCII(string.sub(imagePath, 7, -1))
+            else
+                tmpImage = imagemod.imageFromPath(imagePath)
+            end
+        end
+
+        return object:_contentImage(tmpImage)
+    end
 end
 
 -- Return Module Object --------------------------------------------------
 
+module.unregisterall() -- make sure placeholder is in effect and nothing else
 return module

--- a/extensions/notify/internal.m
+++ b/extensions/notify/internal.m
@@ -1,36 +1,13 @@
-#import <Foundation/Foundation.h>
 #import <Cocoa/Cocoa.h>
-#import <Carbon/Carbon.h>
+// #import <Carbon/Carbon.h>
 #import <LuaSkin/LuaSkin.h>
 #import "../hammerspoon.h"
-
-// Common Code
+// #import "objectconversion.h"
 
 #define USERDATA_TAG    "hs.notify"
 int refTable;
 
-static int store_udhandler(lua_State* L, NSMutableIndexSet* theHandler, int idx) {
-    LuaSkin *skin = [LuaSkin shared];
-
-    lua_pushvalue(L, idx);
-    int x = [skin luaRef:refTable];
-    [theHandler addIndex: x];
-    return x;
-}
-
-static int remove_udhandler(lua_State* L, NSMutableIndexSet* theHandler, int x) {
-    LuaSkin *skin = [LuaSkin shared];
-
-    [skin luaUnref:refTable ref:x];
-    [theHandler removeIndex: x];
-    return LUA_NOREF;
-}
-
-// Not so common code
-
-static NSMutableIndexSet* notificationHandlers;
-
-// // Hammerspoon's notification interface (from MJUserNotificationManager.h and MJUserNotificationUser.m)
+// NOTE: Hammerspoon's internal notification delegate (from MJUserNotificationManager.h and MJUserNotificationUser.m)
 
 @interface MJUserNotificationManager : NSObject
 + (MJUserNotificationManager*) sharedManager;
@@ -41,216 +18,192 @@ static NSMutableIndexSet* notificationHandlers;
 @property NSMutableDictionary* callbacks;
 @end
 
-// // New Delegate for notifications
-
-// // our delegate header
+// NOTE: Our internals and replacement delegate
 
 @interface ourNotificationManager : NSObject
-+ (ourNotificationManager*) sharedManagerForLua:(lua_State*)L;
-// - (void) sendNotification:(NSString*)title handler:(dispatch_block_t)handler;
-- (void) sendNotification:(NSUserNotification*)note;
-- (void) releaseNotification:(NSUserNotification*)note;
-- (void *) withdrawNotification:(NSUserNotification*)note;
++ (ourNotificationManager*) sharedManager;
 @end
 
-// // our delegate code
-
 @interface ourNotificationManager () <NSUserNotificationCenterDelegate>
-@property (retain) NSMutableDictionary* activeCallbacks;
 @end
 
 static id <NSUserNotificationCenterDelegate>    old_delegate ;
-static ourNotificationManager*                  sharedManager;
+// static ourNotificationManager*                  sharedManager;
 
 typedef struct _notification_t {
-    bool    delivered;
-    bool    autoWithdraw;
-    bool    alwaysPresent;
-    int     fn;
-    void*   note;
-    int     registryHandle;
-} notification_t;
+    BOOL    locked ;      // flag to indicate if changes should no longer be allowed (it's been sent)
+    BOOL    delivered ;   // flag to indicate if notification has been delivered to the User Notification Center
+    void*   note ;        // user notification object itself
+    void*   gus ;         // globally unique identifier for use when verifying/recreating userdata
+} notification_t ;
+
+// #define USERDATA_TAG        "hs.module"
+int refTable ;
 
 @implementation ourNotificationManager
 
-+ (ourNotificationManager*) sharedManagerForLua:(lua_State*)L {
-//CLS_NSLOG(@"sharedManagerForLua") ;
-//    static ourNotificationManager* sharedManager;
-    if (!sharedManager) {
++ (instancetype) sharedManager {
+    static ourNotificationManager* sharedManager;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         sharedManager = [[ourNotificationManager alloc] init];
-        sharedManager.activeCallbacks = [NSMutableDictionary dictionary];
-        [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:sharedManager];
-    }
-
+    });
     return sharedManager;
 }
 
-- (void) sendNotification:(NSUserNotification*)note {
-//CLS_NSLOG(@"sendNotification") ;
-    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification: note];
-}
+// Checks to see if userdata exists and is appropriate type at location referenced in userInfo
+// dictionary and creates it if it doesn't exist -- this is necessary for notifications which
+// are delivered or activated after Hammerspoon has been reloaded.
+//
+// Need to add unique identifier in notification_t and userInfo dict to verify correct matchup
+// after reload.
 
-- (void) releaseNotification:(NSUserNotification*)note {
-//CLS_NSLOG(@"releaseNotification") ;
-    NSNumber* value = [[note userInfo] objectForKey:@"handler"];
-    if (value) {
-        [self.activeCallbacks removeObjectForKey:[[note userInfo] objectForKey:@"handler"]];
-        note.userInfo = @{};
+- (notification_t *)getOrCreateUserdata:(NSUserNotification *)notification {
+    LuaSkin *skin = [LuaSkin shared];
+    NSMutableDictionary *noteInfoDict = [notification.userInfo mutableCopy];
+    BOOL rebuild = NO ;
+
+    int myHandle = [[noteInfoDict valueForKey:@"userdata"] intValue] ;
+    notification_t *thisNote ;
+
+    [skin pushLuaRef:refTable ref:myHandle];
+
+    if (lua_type(skin.L, -1) == LUA_TUSERDATA && luaL_testudata(skin.L, -1, USERDATA_TAG)) {
+        thisNote = lua_touserdata(skin.L, -1);
+        if ([[noteInfoDict valueForKey:@"gus"] isEqualToString:(__bridge NSString *)thisNote->gus]) {
+
+            // Because the notification object changes behind the scenes, we need to clear the userdata's
+            // cached version and replace it with the current one at the end.
+            NSUserNotification *tmpHolder = (__bridge_transfer NSUserNotification *) thisNote->note ;
+            tmpHolder = nil ;
+        } else {
+            rebuild = YES ;
+        }
     } else {
-        CLS_NSLOG(@"no tagged handler -- already released?");
+        rebuild = YES ;
     }
+
+    if (rebuild) {
+        CLS_NSLOG(@"hs.notify: creating new userdata for orphaned notification") ;
+    // If notification userdata does not exist, then we've been reloaded
+    // and the reference is bad.  Make a new one.
+        thisNote = lua_newuserdata(skin.L, sizeof(notification_t)) ;
+        memset(thisNote, 0, sizeof(notification_t)) ;
+        luaL_getmetatable(skin.L, USERDATA_TAG);
+        lua_setmetatable(skin.L, -2);
+    // this function is only called for an orphaned notification, so it's safe to assume it's
+    // either being delivered or activated right now (i.e. previously delivered)
+        thisNote->delivered = YES;
+        thisNote->locked    = YES ;
+        thisNote->gus       = (__bridge_retained void *)[noteInfoDict valueForKey:@"gus"] ;
+
+        [noteInfoDict setValue:[NSNumber numberWithInt:[skin luaRef:refTable]]
+                        forKey:@"userdata"];
+        notification.userInfo = noteInfoDict ;
+    }
+
+    lua_pop(skin.L, 1) ;  // Clear the stack of our userdata, retrieved or new
+
+    thisNote->note = (__bridge_retained void *) notification;
+    return thisNote ;
 }
 
-- (void *) withdrawNotification:(NSUserNotification*)note {
-//CLS_NSLOG(@"withdrawNotification") ;
-
-    [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification: note];
-    return (__bridge_retained void *) [note copy] ;
-//    [[NSUserNotificationCenter defaultUserNotificationCenter] removeScheduledNotification: note];
-}
+// + (ourNotificationManager*) sharedManager {
+//         if (!sharedManager) {
+//             sharedManager = [[ourNotificationManager alloc] init];
+//             [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:sharedManager];
+//         }
+//         return sharedManager;
+//     }
 
 // Notification delivered to Notification Center
 - (void)userNotificationCenter:(NSUserNotificationCenter __unused *)center
-    didDeliverNotification:(NSUserNotification *)notification {
-//CLS_NSLOG(@"didDeliverNotification") ;
-        NSNumber* value = [[notification userInfo] objectForKey:@"handler"];
-        if (value) {
-            LuaSkin *skin = [LuaSkin shared];
+        didDeliverNotification:(NSUserNotification *)notification {
 
-            [self.activeCallbacks setObject:@1 forKey:value];
-//CLS_NSLOG(@"uservalue = %@", value) ;
-            int myHandle = [value intValue];
-            lua_State* L = skin.L;
-            [skin pushLuaRef:refTable ref:myHandle];
+    // CLS_NSLOG(@"in didDeliverNotification") ;
 
-            notification_t* thisNote = lua_touserdata(L, -1);
-            if (thisNote) {
-                thisNote->note = nil ;
-                thisNote->note = (__bridge_retained void *) [notification copy];
-                lua_pop(L,1);
-                if (thisNote) {
-                    thisNote->delivered = YES;
-                } else {
-                    CLS_NSLOG(@"userdata NULL");
-                }
-            } else {
-                CLS_NSLOG(@"userdata already released");
-            }
-        } else {
-            CLS_NSLOG(@"no tagged handler -- not ours?");
-        }
+        NSString *fnTag = [notification.userInfo valueForKey:@"tag"] ;
+
+        if (fnTag) {
+            notification_t *thisNote = [self getOrCreateUserdata:notification] ;  // necessary in case of reload
+            thisNote->delivered = YES ;
+        } // not one of ours, and MJUserNotificationManager doesn't use this, so do nothing else
     }
 
 // User clicked on notification...
 - (void)userNotificationCenter:(NSUserNotificationCenter *)center
-    didActivateNotification:(NSUserNotification *)notification {
-//CLS_NSLOG(@"didActivateNotification") ;
-        NSNumber* value = [[notification userInfo] objectForKey:@"handler"];
-        if (value) {
-            if ([self.activeCallbacks objectForKey:value]) {
-                if (value) {
-//CLS_NSLOG(@"uservalue = %@", value) ;
-                    LuaSkin *skin = [LuaSkin shared];
+       didActivateNotification:(NSUserNotification *)notification {
 
-                    int myHandle = [value intValue];
-                    lua_State* L = skin.L;
-                    if (L && (lua_status(L) == LUA_OK)) {
-                        [skin pushLuaRef:refTable ref:myHandle];
+    // CLS_NSLOG(@"in didActivateNotification") ;
 
-                        notification_t* thisNote = lua_touserdata(L, -1);
-                        if (thisNote) {
-                            thisNote->note = nil ;
-                            thisNote->note = (__bridge_retained void *) [notification copy];
-                            if (thisNote->autoWithdraw) {
-                                [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification: notification];
-                            }
-                            if (thisNote) {
-                                lua_getglobal(L, "debug"); lua_getfield(L, -1, "traceback"); lua_remove(L, -2);
-                                [skin pushLuaRef:refTable ref:thisNote->fn];
+        NSString *fnTag = [notification.userInfo valueForKey:@"tag"] ;
 
-                                lua_pushvalue(L, -3);
-                                if (lua_pcall(L, 1, 0, -3) != LUA_OK) {
-                                    CLS_NSLOG(@"%s", lua_tostring(L, -1));
-                                    lua_getglobal(L, "hs"); lua_getfield(L, -1, "showerror"); lua_remove(L, -2);
-                                    lua_pushvalue(L, -2);
-                                    lua_pcall(L, 1, 0, 0);
-                                }
-                            } else {
-                                CLS_NSLOG(@"userdata NULL");
-                            }
-                        } else {
-                            CLS_NSLOG(@"userdata already released");
-                        }
-                    } else {
-                        CLS_NSLOG(@"undefined lua_State -- ours went away, didn't it?") ;
-                    }
-                }
-            } else {
-                CLS_NSLOG(@"handler not Active");
+        if (fnTag) {
+            LuaSkin *skin = [LuaSkin shared];
+
+        // maybe a little more overhead than just assuming its there and putting logic in init.lua to
+        // make sure hs.notify is in the right place, but this is more portable and doesn't rely on
+        // assumptions.  And luaL_requiref requires knowing the open function name...
+            lua_getglobal(skin.L, "require") ;
+            lua_pushstring(skin.L, "hs.notify") ;
+            if (![skin protectedCallAndTraceback:1 nresults:1]) {
+                const char *errorMsg = lua_tostring(skin.L, -1);
+                CLS_NSLOG(@"hs.notify: unable to load module to invoke callback handler: %s", errorMsg) ;
+                showError(skin.L, (char *)errorMsg);
+                return;
+            }
+            lua_getfield(skin.L, -1, "_tag_handler") ;
+        // now we know the function hs.notify._tag_handler is on the stack...
+
+            lua_pushstring(skin.L, [fnTag UTF8String]) ;
+
+            notification_t __unused *thisNote = [self getOrCreateUserdata:notification] ; // necessary in case of reload
+            [skin pushLuaRef:refTable ref:[[notification.userInfo valueForKey:@"userdata"] intValue]];
+
+    // CLS_NSLOG(@"invoking callback handler") ;
+
+            if(![skin protectedCallAndTraceback:2 nresults:0]) {
+                const char *errorMsg = lua_tostring(skin.L, -1);
+                CLS_NSLOG(@"hs.notify callback error: %s", errorMsg);
+                showError(skin.L, (char *)errorMsg);
+                return;
+            }
+
+            BOOL shouldWithdraw = [[notification.userInfo valueForKey:@"autoWithdraw"] boolValue] ;
+            if (notification.deliveryRepeatInterval != nil) shouldWithdraw = YES ;
+
+            if (shouldWithdraw) {
+                [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification:notification];
+                [[NSUserNotificationCenter defaultUserNotificationCenter] removeScheduledNotification:notification];
             }
         } else {
-            CLS_NSLOG(@"no tagged handler -- passing along");
+    // CLS_NSLOG(@"hs.notify passing off to original handler") ;
             [old_delegate userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:notification];
         }
     }
 
 // Should notification show, even if we're the foremost application?
 - (BOOL)userNotificationCenter:(NSUserNotificationCenter __unused *)center
-    shouldPresentNotification:(NSUserNotification *)notification {
-//CLS_NSLOG(@"shouldPresentNotification") ;
-        NSNumber* value = [[notification userInfo] objectForKey:@"handler"];
-        if (value) {
-//CLS_NSLOG(@"uservalue = %@", value) ;
-            LuaSkin *skin = [LuaSkin shared];
+     shouldPresentNotification:(NSUserNotification *)notification {
 
-            int myHandle = [value intValue];
-            lua_State* L = skin.L;
-            [skin pushLuaRef:refTable ref:myHandle];
+    // CLS_NSLOG(@"in shouldPresentNotification") ;
 
-            notification_t* thisNote = lua_touserdata(L, -1);
-            if (thisNote) {
-                thisNote->note = nil ;
-                thisNote->note = (__bridge_retained void *) [notification copy];
-                lua_pop(L,1);
-                if (thisNote) {
-                    return thisNote->alwaysPresent;
-                } else {
-                    CLS_NSLOG(@"userdata NULL");
-                   return YES;
-                }
-            } else {
-                CLS_NSLOG(@"userdata already released");
-                return YES;
-            }
-        } else {
-            CLS_NSLOG(@"no tagged handler -- not ours?");
-           return YES;
-        }
+        NSNumber *shouldPresent = [notification.userInfo valueForKey:@"alwaysPresent"] ;
+        if (shouldPresent != nil) {
+            notification_t __unused *thisNote = [self getOrCreateUserdata:notification] ; // necessary in case of reload
+            return (BOOL)[shouldPresent boolValue] ;
+        } else // MJNotificationManager just returns YES, so this is simpler.
+            return YES ;
     }
+
 @end
 
-// // End of new delegate code
+// NOTE: hs.notify functions that interface with Lua
 
-static int notification_delegate_setup(lua_State* L) {
-    // Get and store old (core app) delegate.  If it hasn't been setup yet, do so.
-    old_delegate = [[NSUserNotificationCenter defaultUserNotificationCenter] delegate];
-    if (!old_delegate) {
-        [MJUserNotificationManager sharedManager];
-        old_delegate = [[NSUserNotificationCenter defaultUserNotificationCenter] delegate];
-    }
-    // Create our delegate
-    [ourNotificationManager sharedManagerForLua:L];
-
-    if (!notificationHandlers) notificationHandlers = [NSMutableIndexSet indexSet];
-
-    return 0;
-}
-
-// // Module Lua Interface // //
-
-/// hs.notify.withdraw_all()
+static int notification_withdraw_all(lua_State* __unused L) {
+/// hs.notify.withdrawAll()
 /// Function
-/// Withdraw all notifications from Hammerspoon
+/// Withdraw all delivered notifications from Hammerspoon
 ///
 /// Parameters:
 ///  * None
@@ -259,37 +212,58 @@ static int notification_delegate_setup(lua_State* L) {
 ///  * None
 ///
 /// Notes:
-///  * This will withdraw all notifications for Hammerspoon, including those not sent by us or that linger from previous loads of Hammerspoon.
-static int notification_withdraw_all(lua_State* __unused L) {
-//CLS_NSLOG(@"notification_withdraw_all");
+///  * This will withdraw all notifications for Hammerspoon, including those not sent by this module or that linger from a previous load of Hammerspoon.
     [[NSUserNotificationCenter defaultUserNotificationCenter] removeAllDeliveredNotifications];
     return 0;
 }
 
-// hs.notify._new(fn) -> notification
+static int notification_withdraw_allScheduled(lua_State* __unused L) {
+/// hs.notify.withdrawAllScheduled()
+/// Function
+/// Withdraw all scheduled notifications from Hammerspoon
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * None
+    ([NSUserNotificationCenter defaultUserNotificationCenter]).scheduledNotifications = @[];
+    return 0;
+}
+
+static int notification_new(lua_State* L) {
+// NOTE: THIS FUNCTION IS WRAPPED IN init.lua
+// hs.notify._new(fntag) -> notificationObject
 // Constructor
 // Returns a new notification object with the specified information and the assigned callback function.
-static int notification_new(lua_State* L) {
-//CLS_NSLOG(@"notification_new");
-    LuaSkin *skin = [LuaSkin shared];
+    LuaSkin *skin  = [LuaSkin shared];
+    NSString *myID = [[NSProcessInfo processInfo] globallyUniqueString] ;
 
-    luaL_checktype(L, 1, LUA_TFUNCTION);
+    NSMutableDictionary *noteInfoDict = [@{
+                              @"autoWithdraw": @(YES),
+                              @"alwaysPresent":@(YES),
+                              @"gus":          myID,
+//                            @"tag":          see below,
+//                            @"userdata":     see below,
+    } mutableCopy];
 
     notification_t* notification = lua_newuserdata(L, sizeof(notification_t)) ;
     memset(notification, 0, sizeof(notification_t)) ;
 
-    lua_pushvalue(L, 1);
-    notification->fn = [skin luaRef:refTable];
-
-    notification->delivered = NO;
-    notification->alwaysPresent = YES;
-    notification->autoWithdraw = YES;
-    notification->registryHandle = store_udhandler(L, notificationHandlers, -1);
+    [noteInfoDict setValue:[NSString stringWithUTF8String:luaL_checkstring(L, 1)]
+                     forKey:@"tag"] ;
+    lua_pushvalue(L, -1) ;
+    [noteInfoDict setValue:[NSNumber numberWithInt:[skin luaRef:refTable]]
+                     forKey:@"userdata"];
 
     NSUserNotification* note = [[NSUserNotification alloc] init];
-    note.userInfo           = @{@"handler": [NSNumber numberWithInt: notification->registryHandle]};
+    note.userInfo            = noteInfoDict ;
+
+    notification->delivered = NO ;
+    notification->locked    = NO ;
 
     notification->note = (__bridge_retained void *)note;
+    notification->gus  = (__bridge_retained void *)myID;
 
     luaL_getmetatable(L, USERDATA_TAG);
     lua_setmetatable(L, -2);
@@ -297,30 +271,10 @@ static int notification_new(lua_State* L) {
     return 1;
 }
 
-/// hs.notify:send() -> self
-/// Method
-/// Delivers the notification to the Notification Center.
-///
-/// Parameters:
-///  * None
-///
-/// Returns:
-///  * The notification object
-///
-/// Notes:
-///  * If a notification has been modified, then this will resend it, setting the delivered status again.
-///  * You can invoke this multiple times if you wish to repeat the same notification.
 static int notification_send(lua_State* L) {
-//CLS_NSLOG(@"notification_send");
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    lua_settop(L,1);
-    [[ourNotificationManager sharedManagerForLua:L] sendNotification:(__bridge NSUserNotification*)notification->note];
-    return 1;
-}
-
-/// hs.notify:release() -> self
+/// hs.notify:send() -> notificationObject
 /// Method
-/// Disables the callback function for a notification.
+/// Delivers the notification immediately to the users Notification Center.
 ///
 /// Parameters:
 ///  * None
@@ -329,21 +283,105 @@ static int notification_send(lua_State* L) {
 ///  * The notification object
 ///
 /// Notes:
-///  * This is automatically invoked during garbage collection and when Hammerspoon reloads its config 
-static int notification_release(lua_State* L) {
-//CLS_NSLOG(@"notification_release");
-    LuaSkin *skin = [LuaSkin shared];
-
+///  * See also hs.notify:schedule()
+///  * If a notification has been modified, then this will resend it.
+///  * You can invoke this multiple times if you wish to repeat the same notification.
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+    notification->locked = YES ;
     lua_settop(L,1);
-    [[ourNotificationManager sharedManagerForLua:L] releaseNotification:(__bridge NSUserNotification*)notification->note];
-
-    notification->fn = [skin luaUnref:refTable ref:notification->fn];
-    notification->registryHandle = remove_udhandler(L, notificationHandlers, notification->registryHandle);
+    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:(__bridge NSUserNotification*)notification->note];
     return 1;
 }
 
-/// hs.notify:withdraw() -> self
+static NSDate* date_from_string(NSString* dateString) {
+    // rfc3339 (Internet Date/Time) formated date.  More or less.
+    NSDateFormatter *rfc3339DateFormatter = [[NSDateFormatter alloc] init];
+    NSLocale *enUSPOSIXLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    [rfc3339DateFormatter setLocale:enUSPOSIXLocale];
+    [rfc3339DateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"];
+    [rfc3339DateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+
+    NSDate *date = [rfc3339DateFormatter dateFromString:dateString];
+    return date;
+}
+
+static int notification_scheduleNotification(lua_State* L) {
+/// hs.notify:schedule(date) -> notificationObject
+/// Method
+/// Schedules a notification for delivery in the future.
+///
+/// Parameters:
+///  * date - the date the notification should be delivered to the users Notification Center specified as the number of seconds since 1970-01-01 00:00:00Z or as a string in rfc3339 format: "YYYY-MM-DD[T]HH:MM:SS[Z]".
+///
+/// Returns:
+///  * The notification object
+///
+/// Notes:
+///  * See also hs.notify:send()
+///  * hs.settings.dateFormat specifies a lua format string which can be used with `os.date()` to properly present the date and time as a string for use with this method.
+    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+    NSDate* myDate = lua_isnumber(L, 2) ? [[NSDate alloc] initWithTimeIntervalSince1970:(NSTimeInterval) lua_tonumber(L,2)] :
+                     lua_isstring(L, 2) ? date_from_string([NSString stringWithUTF8String:lua_tostring(L, 2)]) : nil ;
+    if (myDate) {
+        ((__bridge NSUserNotification *) notification->note).deliveryDate = myDate ;
+    } else {
+        return luaL_error(L, "-- hs.notify:schedule: improper date specified: must be a number (# of seconds since 1970-01-01 00:00:00Z) or string in the format of 'YYYY-MM-DD[T]HH:MM:SS[Z]' (rfc3339)") ;
+    }
+
+    notification->locked    = YES ;
+    [[NSUserNotificationCenter defaultUserNotificationCenter] scheduleNotification:(__bridge NSUserNotification*)notification->note];
+
+    lua_settop(L,1);
+    return 1;
+}
+
+// Too easy to create runaway repeaters that persist through reboots.  Default Hammerspoon delegate and this one would stop it if
+// activated (user clicks on it) but only if Hammerspoon is available and running.  Also possible to "recapture" userdata in a callback
+// by swapping it out after a reload of Hammerspoon and using that to withdraw, but that's more complex then I want to describe in
+// the core docs.  Better to put this into an external module so only those who really want it have to deal with the possible messes.
+//
+// static int notification_deliveryRepeatInterval(lua_State* L) {
+// /// hs.notify:repeatInterval([seconds]) -> notificationObject | current-setting
+// /// Method
+// /// Get or set the repeat interval for a notification which is to be scheduled.
+// ///
+// /// Parameters:
+// ///  * seconds - An optional number specifying how often in seconds the scheduled notification should repeat.  If no parameter is provided, then the current setting is returned.
+// ///
+// /// Returns:
+// ///  * The notification object, if seconds is present; otherwise the current setting.
+// ///
+// /// Notes:
+// ///  * For a notification to be repeated, it must be delivered by `hs.notify:schedule()`.  If you use `hs.notify:send()`, this setting is ignored.
+// ///  * A repeating notification will autoWithdraw when activated. Setting this to anything but 0 will cause the notification to ignore `hs.notify:autoWithdraw()`.
+// ///  * The interval must be at least 60 seconds (1 minute).
+// ///  * Specify an interval of 0 if the notification should not repeat.
+//     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+//     if (lua_isnone(L, 2)) {
+//         NSDateComponents *interval = ((__bridge NSUserNotification *) notification->note).deliveryRepeatInterval ;
+//         lua_pushinteger(L, interval.second) ;
+//    } else if (!notification->locked) {
+//         luaL_checktype(L, 2, LUA_TNUMBER) ;
+//         lua_Integer seconds = lua_tointeger(L, 2) ;
+//         if (seconds == 0) {
+//             ((__bridge NSUserNotification *) notification->note).deliveryRepeatInterval = nil ;
+//         } else if (seconds < 60) {
+//             return luaL_error(L, "notification repeat interval must be 60 seconds or greater") ;
+//         } else {
+//             NSDateComponents *interval = [[NSDateComponents alloc] init];
+//             [interval setSecond:seconds];
+//             ((__bridge NSUserNotification *) notification->note).deliveryRepeatInterval = interval ;
+//         }
+//         notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+//         lua_settop(L, 1) ;
+//     } else {
+//         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
+//     }
+//     return 1;
+// }
+
+static int notification_withdraw(lua_State* L) {
+/// hs.notify:withdraw() -> notificationObject
 /// Method
 /// Withdraws a delivered notification from the Notification Center.
 ///
@@ -352,190 +390,252 @@ static int notification_release(lua_State* L) {
 ///
 /// Returns:
 ///  * The notification object
-///
-/// Notes:
-///  * If you modify a delivered note, even with `hs.notify:release()`, then it is no longer considered delivered and this method will do nothing.  To fully remove a notification, invoke this method and then invoke `hs.notify:release()`, not the other way around.
-static int notification_withdraw(lua_State* L) {
-//CLS_NSLOG(@"notification_withdraw");
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    lua_settop(L,1);
-    notification->note = [[ourNotificationManager sharedManagerForLua:L] withdrawNotification:(__bridge NSUserNotification*)notification->note];
-//    lua_pushcfunction(L, notification_release) ; lua_pushvalue(L,1); lua_call(L, 1, 1);
+    [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification: (__bridge NSUserNotification*)notification->note];
+    [[NSUserNotificationCenter defaultUserNotificationCenter] removeScheduledNotification: (__bridge NSUserNotification*)notification->note];
+    notification->locked    = NO ;
+
+    lua_settop(L, 1) ;
     return 1;
 }
 
-/// hs.notify:title([titleText]) -> string
-/// Method
-/// Set the title of a notification
-///
-/// Parameters:
-///  * titleText - An optional string containing the title to be set on the notification object. This can be an empty string, but if `nil` is passed, the title will not be changed and the current title will be returned. The default value is "Notification".
-///
-/// Returns:
-///  * A string containing the title of the notification
 static int notification_title(lua_State* L) {
+/// hs.notify:title([titleText]) -> notificationObject | current-setting
+/// Method
+/// Get or set the title of a notification
+///
+/// Parameters:
+///  * titleText - An optional string containing the title to be set on the notification object.  The default value is "Notification".  If `nil` is passed, then the title is set to the empty string.  If no parameter is provided, then the current setting is returned.
+///
+/// Returns:
+///  * The notification object, if titleText is present; otherwise the current setting.
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (!lua_isnone(L, 2)) {
-        ((__bridge NSUserNotification *) notification->note).title = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
+    if (lua_isnone(L,2)) {
+        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).title UTF8String]);
+    } else if (!notification->locked) {
+        if (lua_isnil(L,2)) {
+            ((__bridge NSUserNotification *) notification->note).title = @"";
+        } else {
+            ((__bridge NSUserNotification *) notification->note).title = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
+        }
+        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+        lua_settop(L, 1) ;
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).title UTF8String]);
     return 1;
 }
 
-/// hs.notify:subtitle([subtitleText]) -> string
+static int notification_subtitle(lua_State* L) {
+/// hs.notify:subTitle([subtitleText]) -> notificationObject | current-setting
 /// Method
-/// Set the subtitle of a notification
+/// Get or set the subtitle of a notification
 ///
 /// Parameters:
-///  * subtitleText - An optional string containing the subtitle to be set on the notification object. This can be an empty string. If `nil` is passed, any existing subtitle will be removed.
+///  * subtitleText - An optional string containing the subtitle to be set on the notification object. This can be an empty string. If `nil` is passed, any existing subtitle will be removed.  If no parameter is provided, then the current setting is returned.
 ///
 /// Returns:
-///  * A string containing the subtitle of the notification
-static int notification_subtitle(lua_State* L) {
+///  * The notification object, if subtitleText is present; otherwise the current setting.
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (!lua_isnone(L, 2)) {
+    if (lua_isnone(L, 2)) {
+        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).subtitle UTF8String]);
+    } else if (!notification->locked) {
         if (lua_isnil(L,2)) {
             ((__bridge NSUserNotification *) notification->note).subtitle = nil;
         } else {
             ((__bridge NSUserNotification *) notification->note).subtitle = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
         }
+        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+        lua_settop(L, 1) ;
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).subtitle UTF8String]);
     return 1;
 }
 
-/// hs.notify:informativeText([informativeText]) -> string
+static int notification_informativeText(lua_State* L) {
+/// hs.notify:informativeText([informativeText]) -> notificationObject | current-setting
 /// Method
-/// Set the informative text of a notification
+/// Get or set the informative text of a notification
 ///
 /// Parameters:
-///  * informativeText - An optional string containing the informative text to be set on the notification object. This can be an empty string. If `nil` is passed, any existing informative text will be removed.
+///  * informativeText - An optional string containing the informative text to be set on the notification object. This can be an empty string. If `nil` is passed, any existing informative text will be removed.  If no parameter is provided, then the current setting is returned.
 ///
 /// Returns:
-///  * A string containing the informative text of the notification
-static int notification_informativeText(lua_State* L) {
+///  * The notification object, if informativeText is present; otherwise the current setting.
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (!lua_isnone(L, 2)) {
+    if (lua_isnone(L, 2)) {
+        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).informativeText UTF8String]);
+    } else if (!notification->locked) {
         if (lua_isnil(L,2)) {
             ((__bridge NSUserNotification *) notification->note).informativeText = nil;
         } else {
             ((__bridge NSUserNotification *) notification->note).informativeText = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
         }
+        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+        lua_settop(L, 1) ;
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).informativeText UTF8String]);
     return 1;
 }
 
-/// hs.notify:actionButtonTitle([buttonTitle]) -> string
+static int notification_actionButtonTitle(lua_State* L) {
+/// hs.notify:actionButtonTitle([buttonTitle]) -> notificationObject | current-setting
 /// Method
-/// Set the title of a notification's action button
+/// Get or set the label of a notification's action button
 ///
 /// Parameters:
-///  * buttonTitle - An optional string containing the title for the notification's action button
+///  * buttonTitle - An optional string containing the title for the notification's action button.  If no parameter is provided, then the current setting is returned.
 ///
 /// Returns:
-///  * A string containing the title of the action button
-static int notification_actionButtonTitle(lua_State* L) {
+///  * The notification object, if buttonTitle is present; otherwise the current setting.
+///
+/// Notes:
+///  * The affects of this method only apply if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (!lua_isnone(L, 2)) {
+    if (lua_isnone(L, 2)) {
+        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).actionButtonTitle UTF8String]);
+    } else if (!notification->locked) {
         if (lua_isnil(L,2)) {
             ((__bridge NSUserNotification *) notification->note).actionButtonTitle = @"";
         } else {
             ((__bridge NSUserNotification *) notification->note).actionButtonTitle = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
         }
+        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+        lua_settop(L, 1) ;
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).actionButtonTitle UTF8String]);
     return 1;
 }
 
-/// hs.notify:otherButtonTitle([buttonTitle]) -> string
+static int notification_otherButtonTitle(lua_State* L) {
+/// hs.notify:otherButtonTitle([buttonTitle]) -> notificationObject | current-setting
 /// Method
-/// Set the title of a notification's other button
+/// Get or set the label of a notification's other button
 ///
 /// Parameters:
-///  * buttonTitle - An optional string containing the title for the notification's other button
+///  * buttonTitle - An optional string containing the title for the notification's other button.  If no parameter is provided, then the current setting is returned.
 ///
 /// Returns:
-///  * A string containing the title of the other button
-static int notification_otherButtonTitle(lua_State* L) {
+///  * The notification object, if buttonTitle is present; otherwise the current setting.
+///
+/// Notes:
+///  * The affects of this method only apply if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (!lua_isnone(L, 2)) {
+    if (lua_isnone(L, 2)) {
+        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).otherButtonTitle UTF8String]);
+    } else if (!notification->locked) {
         if (lua_isnil(L,2)) {
             ((__bridge NSUserNotification *) notification->note).otherButtonTitle = @"";
         } else {
             ((__bridge NSUserNotification *) notification->note).otherButtonTitle = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
         }
+        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+        lua_settop(L, 1) ;
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).otherButtonTitle UTF8String]);
     return 1;
 }
 
-/// hs.notify:hasActionButton([hasButton]) -> bool
-/// Method
-/// Controls the presence of an action button in a notification
-///
-/// Parameters:
-///  * hasButton - An optional boolean indicating whether an action button should be present
-///
-/// Returns:
-///  * A boolean indicating whether an action button is present
 static int notification_hasActionButton(lua_State* L) {
+/// hs.notify:hasActionButton([hasButton]) -> notificationObject | current-setting
+/// Method
+/// Get or set the presence of an action button in a notification
+///
+/// Parameters:
+///  * hasButton - An optional boolean indicating whether an action button should be present.  If no parameter is provided, then the current setting is returned.
+///
+/// Returns:
+///  * The notification object, if hasButton is present; otherwise the current setting.
+///
+/// Notes:
+///  * The affects of this method only apply if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (!lua_isnone(L, 2)) {
-        ((__bridge NSUserNotification *) notification->note).hasActionButton = lua_toboolean(L, 2);
+    if (lua_isnone(L, 2)) {
+        lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note).hasActionButton);
+    } else if (!notification->locked) {
+        ((__bridge NSUserNotification *) notification->note).hasActionButton = (BOOL) lua_toboolean(L, 2);
+        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+        lua_settop(L, 1) ;
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note).hasActionButton);
     return 1;
 }
 
-/// hs.notify:alwaysPresent([isAlwaysPresent]) -> bool
+static int notification_alwaysPresent(lua_State* L) {
+/// hs.notify:alwaysPresent([alwaysPresent]) -> notificationObject | current-setting
 /// Method
-/// Controls whether a notification should be presented, overriding Notification Center's decisions otherwise
+/// Get or set whether a notification should be presented even if this overrides Notification Center's decision process.
 ///
 /// Parameters:
-///  * isAlwaysPresent - An optional boolean indicating whether the notification should override Notification Center's settings. Defaults to true
+///  * alwaysPresent - An optional boolean parameter indicating whether the notification should override Notification Center's decision about whether to present the notification or not. Defaults to true.  If no parameter is provided, then the current setting is returned.
 ///
 /// Returns:
-///  * A boolean indicating whether the notification will override Notification Center's settings
+///  * The notification object, if alwaysPresent is provided; otherwise the current setting.
 ///
 /// Notes:
 ///  * This does not affect the return value of `hs.notify:presented()` -- that will still reflect the decision of the Notification Center
-static int notification_alwaysPresent(lua_State* L) {
+///  * Examples of why the users Notification Center would choose not to display a notification would be if Hammerspoon is the currently focussed application, being attached to a projector, or the user having set Do Not Disturb.
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (!lua_isnone(L, 2)) {
-        notification->alwaysPresent = lua_toboolean(L, 2);
+    if (lua_isnone(L, 2)) {
+        BOOL alwaysPresent = [(NSNumber *)[((__bridge NSUserNotification *) notification->note).userInfo valueForKey:@"alwaysPresent"] boolValue];
+        lua_pushboolean(L, alwaysPresent);
+    } else if (!notification->locked) {
+        NSMutableDictionary *noteInfoDict = [((__bridge NSUserNotification *) notification->note).userInfo mutableCopy];
+        [noteInfoDict setValue:@((BOOL)lua_toboolean(L, 2)) forKey:@"alwaysPresent"] ;
+        ((__bridge NSUserNotification *) notification->note).userInfo = noteInfoDict ;
+        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+        lua_settop(L, 1) ;
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    lua_pushboolean(L, notification->alwaysPresent);
     return 1;
 }
 
-/// hs.notify:autoWithdraw([shouldWithdraw]) -> bool
-/// Method
-/// Controls whether a notification should automatically withdraw once activated
-///
-/// Parameters:
-///  * shouldWithdraw - An optional boolean indicating whether the notification should automatically withdraw. Defaults to true.
-///
-/// Returns:
-///  * A boolean indicating whether the notification will automatically withdraw
 static int notification_autoWithdraw(lua_State* L) {
+/// hs.notify:autoWithdraw([shouldWithdraw]) -> notificationObject | current-setting
+/// Method
+/// Get or set whether a notification should automatically withdraw once activated
+///
+/// Parameters:
+///  * shouldWithdraw - An optional boolean indicating whether the notification should automatically withdraw. Defaults to true.  If no parameter is provided, then the current setting is returned.
+///
+/// Returns:
+///  * The notification object, if shouldWithdraw is present; otherwise the current setting.
+///
+/// Note:
+///  * This method has no effect if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences: clicking on either the action or other button will clear the notification automatically.
+///  * If a notification which was created before your last reload (or restart) of Hammerspoon and is clicked upon before hs.notify has been loaded into memory, this setting will not be honored because the initial application delegate is not aware of this option and is set to automatically withdraw all notifications which are acted upon.
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (!lua_isnone(L, 2)) {
-        notification->autoWithdraw = lua_toboolean(L, 2);
+    if (lua_isnone(L, 2)) {
+        BOOL autoWithdraw = [(NSNumber *)[((__bridge NSUserNotification *) notification->note).userInfo valueForKey:@"autoWithdraw"] boolValue];
+        lua_pushboolean(L, autoWithdraw);
+    } else if (!notification->locked) {
+        NSMutableDictionary *noteInfoDict = [((__bridge NSUserNotification *) notification->note).userInfo mutableCopy];
+        [noteInfoDict setValue:@((BOOL)lua_toboolean(L, 2)) forKey:@"autoWithdraw"] ;
+        ((__bridge NSUserNotification *) notification->note).userInfo = noteInfoDict ;
+        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+        lua_settop(L, 1) ;
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    lua_pushboolean(L, notification->autoWithdraw);
     return 1;
 }
 
-/// hs.notify:soundName([soundName]) -> string or nil
+static int notification_soundName(lua_State* L) {
+/// hs.notify:soundName([soundName]) -> notificationObject | current-setting
 /// Method
-/// Set the sound for a notification
+/// Get or set the sound for a notification
 ///
 /// Parameters:
-///  * soundName - An optional string containing the name of a sound to play with the notification. If `nil`, no sound will be played. Defaults to `nil`
+///  * soundName - An optional string containing the name of a sound to play with the notification. If `nil`, no sound will be played. Defaults to `nil`.  If no parameter is provided, then the current setting is returned.
 ///
 /// Returns:
-///  * A string containing the name of the sound that will be played, or nil if no sound will be played
+///  * The notification object, if soundName is present; otherwise the current setting.
 ///
 /// Notes:
 ///  * Sounds will first be matched against the names of system sounds. If no matches can be found, they will then be searched for in the following paths, in order:
@@ -543,38 +643,76 @@ static int notification_autoWithdraw(lua_State* L) {
 ///   * `/Library/Sounds`
 ///   * `/Network/Sounds`
 ///   * `/System/Library/Sounds`
-static int notification_soundName(lua_State* L) {
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (!lua_isnone(L, 2)) {
+    if (lua_isnone(L, 2)) {
+        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).soundName UTF8String]);
+    } else if (!notification->locked) {
         if (lua_isnil(L,2)) {
             ((__bridge NSUserNotification *) notification->note).soundName = nil;
         } else {
             ((__bridge NSUserNotification *) notification->note).soundName = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
         }
+        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+        lua_settop(L, 1) ;
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).soundName UTF8String]);
     return 1;
 }
 
+static int notification_contentImage(lua_State *L) {
+// NOTE: THIS FUNCTION IS WRAPPED IN init.lua
+    NSImage *contentImage;
+    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+
+    if (lua_isnone(L, 2)) {
+        if ([((__bridge NSUserNotification *) notification->note) respondsToSelector:@selector(contentImage)]) {
+            contentImage = ((__bridge NSUserNotification *) notification->note).contentImage ;
+            store_image_as_hsimage(L, contentImage);
+        } else {
+            lua_pushnil(L) ;
+        }
+    } else if (!notification->locked) {
+        if ([((__bridge NSUserNotification *) notification->note) respondsToSelector:@selector(contentImage)]) {
+            contentImage = get_image_from_hsimage(L, 2);
+            if (!contentImage) {
+                return luaL_error(L, "invalid image specified");
+            } else {
+                contentImage = ((__bridge NSUserNotification *) notification->note).contentImage = contentImage ;
+                notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+                lua_settop(L, 1) ;
+            }
+        } else {
+            printToConsole(L, "-- hs.notify: contentImage is only supported in OS X 10.9 and newer.") ;
+            lua_settop(L, 1) ;
+        }
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
+    }
+    return 1 ;
+}
+
+// Get status of a notification
+
+static int notification_presented(lua_State* L) {
 /// hs.notify:presented() -> bool
 /// Method
-/// Returns whether Notification Center decided to display the notification
+/// Returns whether the users Notification Center decided to display the notification
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
-///  * A boolean indicating whether Notification Center decided to display the notification
+///  * A boolean indicating whether the users Notification Center decided to display the notification
 ///
 /// Notes:
-///  * A typical example of why Notification Center would choose not to display a notification would be if Hammerspoon is the currently focussed application. Others may include being attached to a projector, or the user having set Do Not Disturb
-static int notification_presented(lua_State* L) {
-//CLS_NSLOG(@"notification_presented");
+///  * Examples of why the users Notification Center would choose not to display a notification would be if Hammerspoon is the currently focussed application, being attached to a projector, or the user having set Do Not Disturb.
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
     lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note).presented);
     return 1;
 }
 
+static int notification_delivered(lua_State* L) {
 /// hs.notify:delivered() -> bool
 /// Method
 /// Returns whether the notification has been delivered to the Notification Center
@@ -583,32 +721,46 @@ static int notification_presented(lua_State* L) {
 ///  * None
 ///
 /// Returns:
-///  * A boolean indicating whether the notification has been delivered to Notification Center
-static int notification_delivered(lua_State* L) {
-//CLS_NSLOG(@"notification_delivered");
+///  * A boolean indicating whether the notification has been delivered to the users Notification Center
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
     lua_pushboolean(L, notification->delivered);
     return 1;
 }
 
-// hs.notify:remote() -> bool
-// Method
-// Returns whether the notification was generated by a push notification (remotely).  Currently unused, but perhaps not forever.
-static int notification_remote(lua_State* L) {
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note).remote);
-    return 1;
-}
+// static int notification_remote(lua_State* L) {
+// /// hs.notify:remote() -> bool
+// /// Method
+// /// Returns whether the notification was generated by a push notification (remotely).
+// ///
+// /// Parameters:
+// ///  * None
+// ///
+// /// Returns:
+// ///  * True if the notification was generated by a push or false if it was generated locally.
+// ///
+// /// Notes:
+// ///  * Currently Hammerspoon only supports locally generated notifications, not push notifications, so this method will always return false.
+//     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+//     lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note).remote);
+//     return 1;
+// }
 
-// hs.notify:activationType() -> number
-// Method
-// Returns whether the notification was generated by a push notification (remotely).  Currently unused, but perhaps not forever.
 static int notification_activationType(lua_State* L) {
+/// hs.notify:activationType() -> number
+/// Method
+/// Returns how the notification was activated by the user.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the integer value corresponding to how the notification was activated by the user.  See the table `hs.notify.activationTypes[]` for more information.
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
     lua_pushinteger(L, ((__bridge NSUserNotification *) notification->note).activationType);
     return 1;
 }
 
+static int notification_actualDeliveryDate(lua_State* L) {
 /// hs.notify:actualDeliveryDate() -> number
 /// Method
 /// Returns the date and time when a notification was delivered
@@ -620,122 +772,150 @@ static int notification_activationType(lua_State* L) {
 ///  * A number containing the delivery date/time of the notification, in seconds since the epoch (i.e. 1970-01-01 00:00:00 +0000)
 ///
 /// Notes:
-///  * You can turn epoch times into a useful table of date information with: `os.date("*t", epochTime)`
-static int notification_actualDeliveryDate(lua_State* L) {
+///  * You can turn epoch times into a human readable string or a table of date elements with the `os.date()` function.
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    lua_pushnumber(L, [((__bridge NSUserNotification *) notification->note).actualDeliveryDate timeIntervalSince1970]);
+    lua_pushinteger(L, lround([((__bridge NSUserNotification *) notification->note).actualDeliveryDate timeIntervalSince1970]));
     return 1;
 }
 
-// hs.notify.activationType[]
-// Constant
-// Convenience array of the possible activation types for a notification, and their reverse for reference.
-// * None - The user has not interacted with the notification.
-// * ContentsClicked - User clicked on notification
-// * ActionButtonClicked - User clicked on Action button
-static void notification_activationTypeTable(lua_State *L) {
+static int notification_activationTypesTable(lua_State *L) {
+/// hs.notify.activationTypes[]
+/// Constant
+/// Convenience array of the possible activation types for a notification, and their reverse for reference.
+/// * None - The user has not interacted with the notification.
+/// * ContentsClicked - User clicked on notification
+/// * ActionButtonClicked - User clicked on Action button
+// /// * Replied - User used Reply button (10.9) (not implemented yet)
+// /// * AdditionalActionClicked - Additional Action selected (10.10) (not implemented yet)
     lua_newtable(L) ;
     lua_pushinteger(L, NSUserNotificationActivationTypeNone);
-        lua_setfield(L, -2, "None") ;
+        lua_setfield(L, -2, "none") ;
     lua_pushinteger(L, NSUserNotificationActivationTypeContentsClicked);
-        lua_setfield(L, -2, "ContentsClicked") ;
+        lua_setfield(L, -2, "contentsClicked") ;
     lua_pushinteger(L, NSUserNotificationActivationTypeActionButtonClicked);
-        lua_setfield(L, -2, "ActionButtonClicked") ;
-// /     Replied                     User used Reply button (10.9) (not implemented yet)
-// /     AdditionalActionClicked     Additional Action selected (10.10) (not implemented yet)
+        lua_setfield(L, -2, "actionButtonClicked") ;
 //     lua_pushinteger(L, NSUserNotificationActivationTypeReplied);
-//         lua_setfield(L, -2, "Replied") ;
+//         lua_setfield(L, -2, "replied") ;
 //     lua_pushinteger(L, NSUserNotificationActivationTypeAdditionalActionClicked);
-//         lua_setfield(L, -2, "AdditionalActionClicked") ;
-    lua_pushstring(L, "None") ;
-        lua_rawseti(L, -2, NSUserNotificationActivationTypeNone);
-    lua_pushstring(L, "ContentsClicked") ;
-        lua_rawseti(L, -2, NSUserNotificationActivationTypeContentsClicked);
-    lua_pushstring(L, "ActionButtonClicked") ;
-        lua_rawseti(L, -2, NSUserNotificationActivationTypeActionButtonClicked);
-//     lua_pushstring(L, "Replied") ;
-//         lua_rawseti(L, -2, NSUserNotificationActivationTypeReplied);
-//     lua_pushstring(L, "AdditionalActionClicked") ;
-//         lua_rawseti(L, -2, NSUserNotificationActivationTypeAdditionalActionClicked);
+//         lua_setfield(L, -2, "additionalActionClicked") ;
+
+    return 1 ;
 }
 
-static int notification_gc(lua_State* L) {
-//CLS_NSLOG(@"notification_gc");
+// NOTE: Metamethods and module setup/teardown
+
+static int notification_delegate_setup(lua_State* __unused L) {
+    // Get and store old (core app) delegate.  If it hasn't been setup yet, do so.
+    old_delegate = [[NSUserNotificationCenter defaultUserNotificationCenter] delegate];
+    if (!old_delegate) {
+        [MJUserNotificationManager sharedManager];
+        old_delegate = [[NSUserNotificationCenter defaultUserNotificationCenter] delegate];
+    }
+    // Create our delegate
+    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:[ourNotificationManager sharedManager]];
+//     [ourNotificationManager sharedManager];
+    return 0;
+}
+
+// static int showMyDict(lua_State* L) {
+//     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+//     lua_pushNSObject(L, [((__bridge NSUserNotification *) notification->note) userInfo]) ;
+//     return 1 ;
+// }
+
+static int userdata_tostring(lua_State* L) {
     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+    NSString* title = ((__bridge NSUserNotification *) notification->note).title ;
 
-    lua_pushcfunction(L, notification_release) ; lua_pushvalue(L,1); lua_call(L, 1, 1);
-    notification->note = nil;
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, title, lua_topointer(L, 1)] UTF8String]) ;
+
+    return 1 ;
+}
+
+static int userdata_gc(lua_State* L) {
+    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+    NSUserNotification *holding = (__bridge_transfer NSUserNotification *) notification->note ;
+    notification->note = nil ; holding = nil ;
+
+    NSString *myID = (__bridge_transfer NSString *) notification->gus ;
+    myID = nil ; notification->gus = nil ;
+
     return 0;
 }
 
+// Metamethods for the module
 static int meta_gc(lua_State* __unused L) {
-//CLS_NSLOG(@"meta_gc");
-    [notificationHandlers removeAllIndexes];
-    notificationHandlers = nil;
-
     [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:(id <NSUserNotificationCenterDelegate>)old_delegate];
-    sharedManager = nil;
+//     sharedManager = nil;
     return 0;
 }
 
-// Everything so far is 10.8 compliant -- I list the 10.9 and 10.10 stuff in the labels above and
-// below as a reminder to perhaps add a companion module later for those who can use them.
+// Metatable for userdata objects
+static const luaL_Reg userdata_metaLib[] = {
+    {"send",                notification_send},
+    {"schedule",            notification_scheduleNotification},
+    {"withdraw",            notification_withdraw},
+    {"title",               notification_title},
+    {"subTitle",            notification_subtitle},
+    {"informativeText",     notification_informativeText},
+    {"actionButtonTitle",   notification_actionButtonTitle},
+    {"otherButtonTitle",    notification_otherButtonTitle},
+    {"hasActionButton",     notification_hasActionButton},
+    {"soundName",           notification_soundName},
+    {"alwaysPresent",       notification_alwaysPresent},
+    {"autoWithdraw",        notification_autoWithdraw},
+    {"_contentImage",       notification_contentImage},
 
-// Metatable for created objects when _new invoked
-static const luaL_Reg notification_metalib[] = {                        // Notification Methods
-    {"send",                        notification_send},                     // Send to notification center
-    {"release",                     notification_release},                  // Leave in NC, but detach callback
-    {"withdraw",                    notification_withdraw},                 // Remove from the notification center
-    {"title",                       notification_title},                // Attribute Methods
-    {"subTitle",                    notification_subtitle},
-    {"informativeText",             notification_informativeText},
-    {"actionButtonTitle",           notification_actionButtonTitle},
-    {"otherButtonTitle",            notification_otherButtonTitle},
-    {"hasActionButton",             notification_hasActionButton},
-    {"soundName",                   notification_soundName},
-    {"alwaysPresent",               notification_alwaysPresent},
-    {"autoWithdraw",                notification_autoWithdraw},
-//    {"deliveryDate",                notification_deliveryDate},             // requires scheduleNotification
-//    {"deliveryRepeatInterval",      notification_deliveryRepeatInterval},   // requires scheduleNotification
-//    {"deliveryTimeZone",            notification_deliveryTimeZone},         // requires scheduleNotification
-//    {"identifier",                  NULL},                                  // 10.9
-//    {"contentImage",                NULL},                                  // 10.9
-//    {"responsePlaceholder",         NULL},                                  // 10.9
-//    {"hasReplyButton",              NULL},                                  // 10.9
-//    {"additionalActions",           NULL},                                  // 10.10
-    {"presented",                   notification_presented},            // Result methods
-    {"delivered",                   notification_delivered},
-    {"remote",                      notification_remote},
-    {"activationType",              notification_activationType},
-    {"actualDeliveryDate",          notification_actualDeliveryDate},
-//    {"response",                    NULL},                                  // 10.9
-//    {"additionalActivationAction",  NULL},                                  // 10.10
-    {"__gc",                        notification_gc},                   // GC: basically release, so it stays in NC
-    {NULL,                          NULL}
+    {"presented",           notification_presented},
+    {"delivered",           notification_delivered},
+    {"activationType",      notification_activationType},
+    {"actualDeliveryDate",  notification_actualDeliveryDate},
+
+// Maybe add in the future, if there is interest...
+//
+//     {"repeatInterval",              notification_deliveryRepeatInterval},
+//     {"responsePlaceholder",         NULL},                                  // 10.9
+//     {"hasReplyButton",              NULL},                                  // 10.9
+//     {"additionalActions",           NULL},                                  // 10.10
+
+//     {"remote",                      notification_remote},
+//     {"response",                    NULL},                                  // 10.9
+//     {"additionalActivationAction",  NULL},                                  // 10.10
+
+// debugging
+//     {"showMyDict", showMyDict},
+
+    {"__tostring",          userdata_tostring},
+    {"__gc",                userdata_gc},
+    {NULL,                  NULL}
 };
 
 // Functions for returned object when module loads
-static const luaL_Reg notificationLib[] = {
-    {"_new",            notification_new},
-    {"withdraw_all",    notification_withdraw_all},
-    {NULL,              NULL}
+static luaL_Reg moduleLib[] = {
+    {"_new",                  notification_new},
+    {"withdrawAll",           notification_withdraw_all},
+    {"withdrawAllScheduled",  notification_withdraw_allScheduled},
+    {NULL,                    NULL}
 };
 
-// Metatable for returned object when module loads
-static const luaL_Reg meta_gcLib[] = {
-    {"__gc",    meta_gc},
-    {NULL,      NULL}
+// Metatable for module, if needed
+static const luaL_Reg module_metaLib[] = {
+    {"__gc", meta_gc},
+    {NULL,   NULL}
 };
 
 int luaopen_hs_notify_internal(lua_State* L) {
-    LuaSkin *skin = [LuaSkin shared];
 
     notification_delegate_setup(L);
 
-    refTable = [skin registerLibraryWithObject:USERDATA_TAG functions:notificationLib metaFunctions:meta_gcLib objectFunctions:notification_metalib];
+    LuaSkin *skin = [LuaSkin shared];
+    refTable = [skin registerLibraryWithObject:USERDATA_TAG
+                                     functions:moduleLib
+                                 metaFunctions:module_metaLib
+                               objectFunctions:userdata_metaLib];
 
-    notification_activationTypeTable(L) ;
-    lua_setfield(L, -2, "activationType") ;
+    notification_activationTypesTable(L) ;
+    lua_setfield(L, -2, "activationTypes") ;
 
 /// hs.notify.defaultNotificationSound
 /// Constant


### PR DESCRIPTION
I'm putting this up for anyone who wants to take a look at it -- I'm still testing it, so won't be pushing it into core for a bit, but it's worked flawlessly for me for the last half day if anyone wants to check it out.

Changes:
* complete rewrite of custom NSUserNotificationCenterDelegate to utilize a single callback through LuaSkin for stability and standardization
* added support for customImage in notification (10.9 and later)
* un-deprecated show and related functions -- show is now a shorthand for simple immediate notifications, and register is used for registering callback tags (see below for reasoning)
* expanded documentation for formerly deprecated functions
* added support for scheduled notifications (to be displayed after time has passed)

The reasoning behind moving to a single callback and un-deprecating the register/unregister of tags instead of a single function per notification is two fold: simplicity and it provides a path for allowing notifications which are scheduled to be displayed when Hammerspoon is not running, or which are still in the notification center after a reload of your Hammerspoon configuration to "re-attach" to their callbacks.  For this to work, you do have to make sure your init.lua requires hs.notify (to install our delegate) and registers the tagged callback functions again with the same tag name, but it works.

A future update (I'm not ready to tackle it yet) will be to modify Hammerspoon's NSApplicationDelegate so that it can hold notifications which cause a launch of Hammerspoon to be eventually handed over to the appropriate delegate in hs.notify after the application has finished loading. Currently, if Hammerspoon is not running and you click on a notification, all it will do is launch Hammerspoon -- the first notification is not passed through because the NSUserNotificationDelegate doesn't exist yet.