### PR TITLE
[READY] improve window, application

### DIFF
--- a/extensions/appfinder/init.lua
+++ b/extensions/appfinder/init.lua
@@ -27,7 +27,7 @@ appfinder.appFromName=application.get
 -- Returns:
 --  * An hs.application object if one can be found, otherwise nil
 function appfinder.appFromWindowTitle(title)
-    local w=window.get(title) if w then return w:application() end
+  local w=window.get(title) if w then return w:application() end
 end
 
 -- hs.appfinder.appFromWindowTitlePattern(pattern) -> app or nil
@@ -43,7 +43,7 @@ end
 -- Notes:
 --  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
 function appfinder.appFromWindowTitlePattern(pattern)
-    local w=window.find(title) if w then return w:application() end
+  local w=window.find(pattern) if w then return w:application() end
 end
 
 -- hs.appfinder.windowFromWindowTitle(title) -> win or nil

--- a/extensions/appfinder/init.lua
+++ b/extensions/appfinder/init.lua
@@ -3,24 +3,8 @@
 -- Easily find ```hs.application``` and ```hs.window``` objects
 
 local appfinder = {}
-local fnutils = require "hs.fnutils"
 local application = require "hs.application"
 local window = require "hs.window"
-
--- Internal function to search all windows using a matching function
-local function find_window_from_function(fn)
-    return fnutils.find(window.allWindows(), fn)
-end
-
--- Internal function to turn a matching function into an application object
-local function find_application_from_window(fn)
-    local w = find_window_from_function(fn)
-    if w then
-        return w:application()
-    else
-        return nil
-    end
-end
 
 -- hs.appfinder.appFromName(name) -> app or nil
 -- Function
@@ -31,7 +15,7 @@ end
 --
 -- Returns:
 --  * An hs.application object if one can be found, otherwise nil
-appfinder.appFromName=application.find
+appfinder.appFromName=application.get
 
 -- hs.appfinder.appFromWindowTitle(title) -> app or nil
 -- Function
@@ -43,7 +27,7 @@ appfinder.appFromName=application.find
 -- Returns:
 --  * An hs.application object if one can be found, otherwise nil
 function appfinder.appFromWindowTitle(title)
-    return find_application_from_window(function(win) return win:title() == title end)
+    local w=window.get(title) if w then return w:application() end
 end
 
 -- hs.appfinder.appFromWindowTitlePattern(pattern) -> app or nil
@@ -59,7 +43,7 @@ end
 -- Notes:
 --  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
 function appfinder.appFromWindowTitlePattern(pattern)
-    return find_application_from_window(function(win) return string.match(win:title(), pattern) end)
+    local w=window.find(title) if w then return w:application() end
 end
 
 -- hs.appfinder.windowFromWindowTitle(title) -> win or nil
@@ -71,10 +55,8 @@ end
 --
 -- Returns:
 --  * An hs.window object if one can be found, otherwise nil
-function appfinder.windowFromWindowTitle(title)
-    return window.find(title,true)
-end
---
+appfinder.windowFromWindowTitle=window.get
+
 -- hs.appfinder.windowFromWindowTitlePattern(pattern) -> app or nil
 -- Function
 -- Finds a window by Lua pattern in its title (e.g."Inbox %(%d+ messages.*)")

--- a/extensions/appfinder/init.lua
+++ b/extensions/appfinder/init.lua
@@ -1,6 +1,6 @@
---- === hs.appfinder ===
----
---- Easily find ```hs.application``` and ```hs.window``` objects
+-- === hs.appfinder ===
+--
+-- Easily find ```hs.application``` and ```hs.window``` objects
 
 local appfinder = {}
 local fnutils = require "hs.fnutils"
@@ -22,75 +22,71 @@ local function find_application_from_window(fn)
     end
 end
 
---- hs.appfinder.appFromName(name) -> app or nil
---- Function
---- Finds an application by its name (e.g. "Safari")
----
---- Parameters:
----  * name - A string containing the name of the application to search for
----
---- Returns:
----  * An hs.application object if one can be found, otherwise nil
-function appfinder.appFromName(name)
-    return fnutils.find(application.runningApplications(), function(app) return app:title() == name end)
-end
+-- hs.appfinder.appFromName(name) -> app or nil
+-- Function
+-- Finds an application by its name (e.g. "Safari")
+--
+-- Parameters:
+--  * name - A string containing the name of the application to search for
+--
+-- Returns:
+--  * An hs.application object if one can be found, otherwise nil
+appfinder.appFromName=application.find
 
---- hs.appfinder.appFromWindowTitle(title) -> app or nil
---- Function
---- Finds an application by its window title (e.g. "Activity Monitor (All Processes)")
----
---- Parameters:
----  * title - A string containing a window title of the application to search for
----
---- Returns:
----  * An hs.application object if one can be found, otherwise nil
+-- hs.appfinder.appFromWindowTitle(title) -> app or nil
+-- Function
+-- Finds an application by its window title (e.g. "Activity Monitor (All Processes)")
+--
+-- Parameters:
+--  * title - A string containing a window title of the application to search for
+--
+-- Returns:
+--  * An hs.application object if one can be found, otherwise nil
 function appfinder.appFromWindowTitle(title)
     return find_application_from_window(function(win) return win:title() == title end)
 end
 
---- hs.appfinder.appFromWindowTitlePattern(pattern) -> app or nil
---- Function
---- Finds an application by Lua pattern in its window title (e.g."Inbox %(%d+ messages.*)")
----
---- Parameters:
----  * pattern - a Lua pattern describing a window title of the application to search for
----
---- Returns:
----  * An hs.application object if one can be found, otherwise nil
----
---- Notes:
----  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
+-- hs.appfinder.appFromWindowTitlePattern(pattern) -> app or nil
+-- Function
+-- Finds an application by Lua pattern in its window title (e.g."Inbox %(%d+ messages.*)")
+--
+-- Parameters:
+--  * pattern - a Lua pattern describing a window title of the application to search for
+--
+-- Returns:
+--  * An hs.application object if one can be found, otherwise nil
+--
+-- Notes:
+--  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
 function appfinder.appFromWindowTitlePattern(pattern)
     return find_application_from_window(function(win) return string.match(win:title(), pattern) end)
 end
 
---- hs.appfinder.windowFromWindowTitle(title) -> win or nil
---- Function
---- Finds a window by its title (e.g. "Activity Monitor (All Processes)")
----
---- Parameters:
----  * title - A string containing the title of the window to search for
----
---- Returns:
----  * An hs.window object if one can be found, otherwise nil
+-- hs.appfinder.windowFromWindowTitle(title) -> win or nil
+-- Function
+-- Finds a window by its title (e.g. "Activity Monitor (All Processes)")
+--
+-- Parameters:
+--  * title - A string containing the title of the window to search for
+--
+-- Returns:
+--  * An hs.window object if one can be found, otherwise nil
 function appfinder.windowFromWindowTitle(title)
-    return find_window_from_function(function(win) return win:title() == title end)
+    return window.find(title,true)
 end
 --
---- hs.appfinder.windowFromWindowTitlePattern(pattern) -> app or nil
---- Function
---- Finds a window by Lua pattern in its title (e.g."Inbox %(%d+ messages.*)")
----
---- Parameters:
----  * pattern - a Lua pattern describing a window title of the window to search for
----
---- Returns:
----  * An hs.window object if one can be found, otherwise nil
----
---- Notes:
----  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
-function appfinder.windowFromWindowTitlePattern(pattern)
-    return find_window_from_function(function(win) return string.match(win:title(), pattern) end)
-end
+-- hs.appfinder.windowFromWindowTitlePattern(pattern) -> app or nil
+-- Function
+-- Finds a window by Lua pattern in its title (e.g."Inbox %(%d+ messages.*)")
+--
+-- Parameters:
+--  * pattern - a Lua pattern describing a window title of the window to search for
+--
+-- Returns:
+--  * An hs.window object if one can be found, otherwise nil
+--
+-- Notes:
+--  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
+appfinder.windowFromWindowTitlePattern=window.find
 
 return appfinder

--- a/extensions/appfinder/init.lua
+++ b/extensions/appfinder/init.lua
@@ -1,74 +1,77 @@
--- === hs.appfinder ===
---
--- Easily find ```hs.application``` and ```hs.window``` objects
+--- === hs.appfinder ===
+---
+--- Easily find ```hs.application``` and ```hs.window``` objects
+---
+--- This module is *deprecated*; you can use `hs.window.find()`, `hs.window.get()`, `hs.application.find()`,
+--- `hs.application.get()`, `hs.application:findWindow()` and `hs.application:getWindow()` instead.
 
 local appfinder = {}
 local application = require "hs.application"
 local window = require "hs.window"
 
--- hs.appfinder.appFromName(name) -> app or nil
--- Function
--- Finds an application by its name (e.g. "Safari")
---
--- Parameters:
---  * name - A string containing the name of the application to search for
---
--- Returns:
---  * An hs.application object if one can be found, otherwise nil
+--- hs.appfinder.appFromName(name) -> app or nil
+--- Function
+--- Finds an application by its name (e.g. "Safari")
+---
+--- Parameters:
+---  * name - A string containing the name of the application to search for
+---
+--- Returns:
+---  * An hs.application object if one can be found, otherwise nil
 appfinder.appFromName=application.get
 
--- hs.appfinder.appFromWindowTitle(title) -> app or nil
--- Function
--- Finds an application by its window title (e.g. "Activity Monitor (All Processes)")
---
--- Parameters:
---  * title - A string containing a window title of the application to search for
---
--- Returns:
---  * An hs.application object if one can be found, otherwise nil
+--- hs.appfinder.appFromWindowTitle(title) -> app or nil
+--- Function
+--- Finds an application by its window title (e.g. "Activity Monitor (All Processes)")
+---
+--- Parameters:
+---  * title - A string containing a window title of the application to search for
+---
+--- Returns:
+---  * An hs.application object if one can be found, otherwise nil
 function appfinder.appFromWindowTitle(title)
   local w=window.get(title) if w then return w:application() end
 end
 
--- hs.appfinder.appFromWindowTitlePattern(pattern) -> app or nil
--- Function
--- Finds an application by Lua pattern in its window title (e.g."Inbox %(%d+ messages.*)")
---
--- Parameters:
---  * pattern - a Lua pattern describing a window title of the application to search for
---
--- Returns:
---  * An hs.application object if one can be found, otherwise nil
---
--- Notes:
---  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
+--- hs.appfinder.appFromWindowTitlePattern(pattern) -> app or nil
+--- Function
+--- Finds an application by Lua pattern in its window title (e.g."Inbox %(%d+ messages.*)")
+---
+--- Parameters:
+---  * pattern - a Lua pattern describing a window title of the application to search for
+---
+--- Returns:
+---  * An hs.application object if one can be found, otherwise nil
+---
+--- Notes:
+---  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
 function appfinder.appFromWindowTitlePattern(pattern)
   local w=window.find(pattern) if w then return w:application() end
 end
 
--- hs.appfinder.windowFromWindowTitle(title) -> win or nil
--- Function
--- Finds a window by its title (e.g. "Activity Monitor (All Processes)")
---
--- Parameters:
---  * title - A string containing the title of the window to search for
---
--- Returns:
---  * An hs.window object if one can be found, otherwise nil
+--- hs.appfinder.windowFromWindowTitle(title) -> win or nil
+--- Function
+--- Finds a window by its title (e.g. "Activity Monitor (All Processes)")
+---
+--- Parameters:
+---  * title - A string containing the title of the window to search for
+---
+--- Returns:
+---  * An hs.window object if one can be found, otherwise nil
 appfinder.windowFromWindowTitle=window.get
 
--- hs.appfinder.windowFromWindowTitlePattern(pattern) -> app or nil
--- Function
--- Finds a window by Lua pattern in its title (e.g."Inbox %(%d+ messages.*)")
---
--- Parameters:
---  * pattern - a Lua pattern describing a window title of the window to search for
---
--- Returns:
---  * An hs.window object if one can be found, otherwise nil
---
--- Notes:
---  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
+--- hs.appfinder.windowFromWindowTitlePattern(pattern) -> app or nil
+--- Function
+--- Finds a window by Lua pattern in its title (e.g."Inbox %(%d+ messages.*)")
+---
+--- Parameters:
+---  * pattern - a Lua pattern describing a window title of the window to search for
+---
+--- Returns:
+---  * An hs.window object if one can be found, otherwise nil
+---
+--- Notes:
+---  * For more about Lua patterns, see http://lua-users.org/wiki/PatternsTutorial and http://www.lua.org/manual/5.2/manual.html#6.4.1
 appfinder.windowFromWindowTitlePattern=window.find
 
 return appfinder

--- a/extensions/application/init.lua
+++ b/extensions/application/init.lua
@@ -21,7 +21,6 @@ local tunpack,tpack,tsort=table.unpack,table.pack,table.sort
 --- Returns:
 ---  * A table containing zero or more hs.window objects
 function application:visibleWindows()
-  --  return moses.filter(self:allWindows(), window.isVisible)
   local r={}
   if self:isHidden() then return r -- do not check :isHidden for every window
   else for _,w in ipairs(self:allWindows()) do if not w:isMinimized() then r[#r+1]=w end end end
@@ -166,7 +165,7 @@ end
 ---  * the `hs.application` object for the launched or activated application; `nil` if not found
 ---
 --- Notes:
----  * the `wait` parameter will *halt the entire script* in order to return the application object "synchronously"; only use it if you
+---  * the `wait` parameter will *block all Hammerspoon activity* in order to return the application object "synchronously"; only use it if you
 ---    a) have no time-critical event processing happening elsewhere in your `init.lua` and b) need to act on the *application* object right away - if you need
 ---    a window this won't help, because in the instant you get back the hs.application object for a launching app it'll likely have no windows yet;
 ---    for this and other similar scenarios you should use hs.window.filter instead.

--- a/extensions/application/init.lua
+++ b/extensions/application/init.lua
@@ -159,21 +159,23 @@ end
 ---    - the application's name as per `hs.application:name()`
 ---    - the full path to an application on disk (including the `.app` suffix)
 ---    - the application's bundle ID as per `hs.application:bundleID()`
----  * wait - (optional) the maximum number of seconds to wait for the app to get into "launching" state, if not already running; if omitted, defaults to 0.1;
+---  * wait - (optional) the maximum number of seconds to wait for the app to get into "launching" state, if not already running; if omitted, defaults to 0;
 ---           if the app takes longer than this to launch, this function will return `nil`, but the app will still launch
 ---
 --- Returns:
 ---  * the `hs.application` object for the launched or activated application; `nil` if not found
 ---
 --- Notes:
----  * the `wait` parameter will *halt the entire script* in order to return the application object "synchronously"; only use it if you a) need
----    to act on the application object right away and b) have no time-critical event processing happening elsewhere in your `init.lua`
+---  * the `wait` parameter will *halt the entire script* in order to return the application object "synchronously"; only use it if you
+---    a) have no time-critical event processing happening elsewhere in your `init.lua` and b) need to act on the *application* object right away - if you need
+---    a window this won't help, because in the instant you get back the hs.application object for a launching app it'll likely have no windows yet;
+---    for this and other similar scenarios you should use hs.window.filter instead.
 function application.open(app,wait)
   if type(app)~='string' then error('app must be a string',2) end
   if wait and type(wait)~='number' then error('wait must be a number',2) end
   local r=application.launchOrFocus(app) or application.launchOrFocusByBundleID(app)
   if not r then return end
-  wait=(wait or 0.1)*1000000
+  wait=(wait or 0)*1000000
   local CHECK_INTERVAL=200000
   repeat
     r=application.get(app) if r then return r end

--- a/extensions/application/init.lua
+++ b/extensions/application/init.lua
@@ -94,6 +94,25 @@ function application.find(hint,exact)
   if #r>0 then return tunpack(moses(r):map(function(_,w)return w:application()end):unique():value()) end
 end
 
+
+--- hs.application.open(app) -> hs.application object
+--- Constructor
+--- Launches an application, or activates it if it's already running
+---
+--- Parameters:
+---  * app - a string describing the application to open; it can be:
+---    - the application's name as per `hs.application:name()`
+---    - the full path to an application on disk (including the `.app` suffix)
+---    - the application's bundle ID as per `hs.application:bundleID()`
+---
+--- Returns:
+---  * the `hs.application` object of the launched or activated application; `nil` if not found
+function application.open(app)
+  if type(app)~='string' then error('app must be a string',2) end
+  if application.launchOrFocus(app) then return application.find(app,true) end
+  if application.launchOrFocusByBundleID(app) then return application.find(app,true) end
+end
+
 do
   local mt=getmetatable(application)
   if not mt.__call then mt.__call=function(t,...)if t.find then return t.find(...) else error('cannot call uielement',2) end end end

--- a/extensions/application/init.lua
+++ b/extensions/application/init.lua
@@ -8,8 +8,8 @@ application.watcher = require "hs.application.watcher"
 local window = require "hs.window"
 local moses = require "hs.moses"
 
-local type=type
-local tunpack,tpack=table.unpack,table.pack
+local type,ipairs=type,ipairs
+local tunpack,tpack,tinsert=table.unpack,table.pack,table.insert
 
 --- hs.application:visibleWindows() -> win[]
 --- Method
@@ -21,7 +21,11 @@ local tunpack,tpack=table.unpack,table.pack
 --- Returns:
 ---  * A table containing zero or more hs.window objects
 function application:visibleWindows()
-  return moses.filter(self:allWindows(), window.isVisible)
+  --  return moses.filter(self:allWindows(), window.isVisible)
+  local r={}
+  if self:isHidden() then return r
+  else for _,w in ipairs(self:allWindows()) do if not w:isMinimized() then tinsert(r,w) end end end -- (barely) faster
+  return r
 end
 
 --- hs.application:activate([allWindows]) -> bool

--- a/extensions/layout/init.lua
+++ b/extensions/layout/init.lua
@@ -6,10 +6,10 @@
 
 local layout = {}
 local geometry = require("hs.geometry")
-local appfinder = require("hs.appfinder")
 local fnutils = require("hs.fnutils")
 local screen = require("hs.screen")
 local window = require("hs.window")
+local application = require("hs.application")
 
 --- hs.layout.left25
 --- Constant
@@ -127,7 +127,7 @@ function layout.apply(layout)
 
         -- Find the application's object, if wanted
         if _row[1] then
-            app = appfinder.appFromName(_row[1])
+            app = application.get(_row[1])
             if not app then
                 print("Unable to find app: " .. _row[1])
             end

--- a/extensions/mjomatic/init.lua
+++ b/extensions/mjomatic/init.lua
@@ -5,7 +5,7 @@
 local mjomatic = {}
 
 local alert = require 'hs.alert'
-local appfinder = require 'hs.appfinder'
+local application = require 'hs.application'
 local screen = require 'hs.screen'
 
 local gridh
@@ -141,8 +141,8 @@ function mjomatic.go(cfg)
         if not windows[key] then
             error(string.format('no window found for application %s (%s)', title, key))
         end
-        local app = appfinder.appFromName(title)
-        local window = app:mainWindow()
+        local app = application.get(title)
+        local window = app and app:mainWindow()
         -- alert.show(string.format('application title for %q is %q, main window %q', title, app:title(), window:title()))
         if window then
             resizetogrid(window, windows[key])

--- a/extensions/tabs/init.lua
+++ b/extensions/tabs/init.lua
@@ -10,7 +10,6 @@ local fnutils = require "hs.fnutils"
 local timer = require "hs.timer"
 local application = require "hs.application"
 local appwatcher = application.watcher
-local appfinder = require "hs.appfinder"
 
 tabs.leftPad = 10
 tabs.topPad = 2
@@ -156,7 +155,7 @@ function tabs.enableForApp(appName)
   appWatches[appName] = true
 
   -- might already be running
-  local runningApp = appfinder.appFromName(appName)
+  local runningApp = application.get(appName)
   if runningApp then
     watchApp(runningApp)
   end

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -752,7 +752,8 @@ end
 ---  * Calling this method will immediately fast-forward to the end of any ongoing animation on the window
 function window:ensureIsInScreenBounds()
   stopAnimation(self,true)
-  return self:moveToScreen(self:screen(),0)
+  local frame,screenFrame=geometry(self:frame()),self:screen():frame()
+  self:setFrame(frame:move((frame:intersect(screenFrame).center-frame.center)*2):intersect(screenFrame),0)
 end
 
 package.loaded[...]=window

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -381,6 +381,12 @@ function window:screen()
     local a=frame:intersect(s:fullFrame()).area
     if a>maxa then maxa,maxs=a,s end
   end
+  if maxs then return maxs end
+  local mind=99999 -- if (impossibly) a window is totally out of bounds, get the closest screen
+  for _,s in ipairs(screens) do
+    local d=frame:vector(s:frame()).length
+    if d<mind then mind,maxs=d,s end
+  end
   return maxs
 end
 --[[ -- moses version

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -10,7 +10,7 @@ local window = require "hs.window.internal"
 local application = require "hs.application.internal"
 local fnutils = require "hs.fnutils"
 local geometry = require "hs.geometry"
-local hs_screen = require "hs.screen"
+local screen = require "hs.screen"
 local timer = require "hs.timer"
 local pairs,ipairs,next,min,max,type = pairs,ipairs,next,math.min,math.max,type
 local tinsert,tsort = table.insert,table.sort
@@ -35,7 +35,12 @@ window.animationDuration = 0.2
 --- Returns:
 ---  * A table of `hs.window` objects representing all open windows
 function window.allWindows()
-  return fnutils.mapCat(application.runningApplications(), application.allWindows)
+  --  return fnutils.mapCat(application.runningApplications(), application.allWindows) -- nope
+  local r={}
+  for _,app in ipairs(application.runningApplications()) do
+    if app:kind()>0 then for _,w in ipairs(app:allWindows()) do r[#r+1]=w end end -- major speedup by excluding non-gui apps
+  end
+  return r
 end
 
 --- hs.window.windowForID(id) -> win or nil
@@ -332,14 +337,14 @@ function window:screen()
   local lastvolume = 0
   local lastscreen = nil
 
-  for _, screen in pairs(hs_screen.allScreens()) do
-    local screenframe = screen:fullFrame()
+  for _, s in pairs(screen.allScreens()) do
+    local screenframe = s:fullFrame()
     local r = intersection(windowframe, screenframe)
     local volume = r.w * r.h
 
     if volume > lastvolume then
       lastvolume = volume
-      lastscreen = screen
+      lastscreen = s
     end
   end
 

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -176,7 +176,7 @@ local function getAnimationFrame(win)
   if animations[id] then return animations[id].endFrame end
 end
 
-local function stopAnimation(win,id,snap)
+local function stopAnimation(win,snap,id)
   if not id then id = win:id() end
   local anim = animations[id]
   if not anim then return end
@@ -222,7 +222,7 @@ function window:setFrame(f, duration)
   if duration==nil then duration = window.animationDuration end
   if type(duration)~='number' then duration = 0 end
   local id = self:id()
-  stopAnimation(self,id)
+  stopAnimation(self,false,id)
   if duration<=0 or not id then return self:_setFrame(f) end
   local frame = self:_frame()
   if not animations[id] then animations[id] = {window=self} end
@@ -254,7 +254,7 @@ function window:minimize()
   return self:_minimize()
 end
 function window:unminimize()
-  stopAnimation(self) -- ?
+  stopAnimation(self,true) -- ?
   return self:_unminimize()
 end
 function window:toggleZoom()

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -206,13 +206,13 @@ end
 
 -- get actual window frame
 function window:_frame()
-  local tl,s = self:_topLeft(),self:_size()
-  return {x = tl.x, y = tl.y, w = s.w, h = s.h}
+  return geometry(self:_topLeft(),self:_size())
+    --  local tl,s = self:_topLeft(),self:_size()
+    --  return {x = tl.x, y = tl.y, w = s.w, h = s.h}
 end
 -- set window frame instantly
 function window:_setFrame(f)
-  self:_setSize(f) self:_setTopLeft(f) self:_setSize(f)
-  return self
+  self:_setSize(f) self:_setTopLeft(f) return self:_setSize(f)
 end
 
 --- hs.window:frame() -> rect
@@ -240,6 +240,7 @@ end
 function window:setFrame(f, duration)
   if duration==nil then duration = window.animationDuration end
   if type(duration)~='number' then duration = 0 end
+  f=geometry(f)
   local id = self:id()
   stopAnimation(self,false,id)
   if duration<=0 or not id then return self:_setFrame(f) end
@@ -255,18 +256,20 @@ end
 
 -- wrapping these Lua-side for dealing with animations cache
 function window:size()
-  return getAnimationFrame(self) or self:_size()
+  local f=getAnimationFrame(self)
+  return f and f.size or geometry(self:_size())
 end
 function window:topLeft()
-  return getAnimationFrame(self) or self:_topLeft()
+  local f=getAnimationFrame(self)
+  return f and f.xy or geometry(self:_topLeft())
 end
 function window:setSize(size)
-  stopAnimation(self)
-  return self:_setSize(size)
+  stopAnimation(self,true)
+  return self:_setSize(geometry(size))
 end
 function window:setTopLeft(point)
-  stopAnimation(self)
-  return self:_setTopLeft(point)
+  stopAnimation(self,true)
+  return self:_setTopLeft(geometry(point))
 end
 function window:minimize()
   stopAnimation(self,true)

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -38,7 +38,7 @@ function window.allWindows()
   --  return fnutils.mapCat(application.runningApplications(), application.allWindows) -- nope
   local r={}
   for _,app in ipairs(application.runningApplications()) do
-    if app:kind()>0 then for _,w in ipairs(app:allWindows()) do r[#r+1]=w end end -- major speedup by excluding non-gui apps
+    if app:kind()>0 then for _,w in ipairs(app:allWindows()) do tinsert(r,w) end end -- major speedup by excluding non-gui apps
   end
   return r
 end
@@ -56,7 +56,7 @@ function window.visibleWindows()
   --  return fnutils.filter(window.allWindows(), window.isVisible) -- nope
   local r={}
   for _,app in ipairs(application.runningApplications()) do
-    if app:kind()>0 and not app:isHidden() then for _,w in ipairs(app:visibleWindows()) do r[#r+1]=w end end -- speedup by excluding hidden apps
+    if app:kind()>0 and not app:isHidden() then for _,w in ipairs(app:visibleWindows()) do tinsert(r,w) end end -- speedup by excluding hidden apps
   end
   return r
 end

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -670,6 +670,34 @@ function window:moveToScreen(toScreen, duration)
   return self:setFrame(geometry(self:frame()):toUnitRect(self:screen():frame()):fromUnitRect(toScreen:frame()),duration)
 end
 
+--- hs.window:move(rect[, screen][, duration]) --> hs.window object
+--- Method
+--- Moves the window
+---
+--- Parameters:
+---  * rect - It can be:
+---    - an `hs.geometry` point, or argument to construct one; will move the screen by this delta, keeping its size constant; `screen` is ignored
+---    - an `hs.geometry` rect, or argument to construct one; will set the window frame to this rect, in absolute coordinates; `screen` is ignored
+---    - an `hs.geometry` unit rect, or argument to construct one; will set the window frame to this rect relative to the desired screen;
+---      if `screen` is nil or omitted, use the screen the window is currently on
+---  * screen - (optional) An `hs.screen` object or argument for `hs.screen.find`; only valid if `rect` is a unit rect
+---  * duration - (optional) A number containing the number of seconds to animate the transition. Defaults to the value of `hs.window.animationDuration`
+---
+--- Returns:
+---  * The `hs.window` object
+function window:move(rect,toScreen,duration)
+  rect=geometry(rect)
+  local rtype=rect:type()
+  if type(toScreen)=='number' and toScreen<20 and duration==nil then duration=toScreen toScreen=nil end
+  if rtype=='point' then return self:setFrame(geometry(self:frame()):move(rect),duration)
+  elseif rtype=='rect' then return self:setFrame(rect,duration)
+  elseif rtype=='unitrect' then
+    if toScreen then toScreen=screen.find(toScreen) if not toScreen then return self end --TODO log?
+    else toScreen=self:screen() end
+    return self:setFrame(rect:fromUnitRect(toScreen:frame()),duration)
+  else error('rect must be a point, rect, or unit rect',2) end
+end
+
 --- hs.window:moveOneScreenWest([duration]) -> hs.window object
 --- Method
 --- Moves the window one screen west (i.e. left)

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -25,15 +25,15 @@ local atan,cos,abs = math.atan,math.cos,math.abs
 --- hs.window.animationDuration = 3 -- if you have time on your hands
 window.animationDuration = 0.2
 
---- hs.window.allWindows() -> win[]
---- Function
+--- hs.window.allWindows() -> list of hs.window objects
+--- Constructor
 --- Returns all windows
 ---
 --- Parameters:
 ---  * None
 ---
 --- Returns:
----  * A table of `hs.window` objects representing all open windows
+---  * A list of `hs.window` objects representing all open windows
 function window.allWindows()
   --  return fnutils.mapCat(application.runningApplications(), application.allWindows) -- nope
   local r={}
@@ -43,12 +43,50 @@ function window.allWindows()
   return r
 end
 
---- hs.window.windowForID(id) -> win or nil
---- Function
+--- hs.window.visibleWindows() -> list of hs.window objects
+--- Constructor
+--- Gets all visible windows
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * A list containing `hs.window` objects representing all windows that are visible as per `hs.window:isVisible()`
+function window.visibleWindows()
+  return fnutils.filter(window:allWindows(), window.isVisible)
+end
+
+--- hs.window.orderedWindows() -> list of hs.window objects
+--- Constructor
+--- Returns all visible windows, ordered from front to back
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * A list of `hs.window` objects representing all visible windows, ordered from front to back
+function window.orderedWindows()
+  local orderedwins = {}
+  local orderedwinids = window._orderedwinids()
+  local windows = window.visibleWindows()
+
+  for _, orderedwinid in pairs(orderedwinids) do
+    for _, win in pairs(windows) do
+      if orderedwinid == win:id() then
+        tinsert(orderedwins, win)
+        break
+      end
+    end
+  end
+  return orderedwins
+end
+
+--- hs.window.windowForID(id) -> hs.window object
+--- Constructor
 --- Returns the window for a given id
 ---
 --- Parameters:
----  * id - A window ID (see `hs.window:id()`)
+---  * id - A window ID as per `hs.window:id()`
 ---
 --- Returns:
 ---  * An `hs.window` object, or nil if the window can't be found
@@ -235,6 +273,8 @@ function window:otherWindowsAllScreens()
   return fnutils.filter(window.visibleWindows(), function(win) return self ~= win end)
 end
 
+
+
 --- hs.window:focus() -> window
 --- Method
 --- Focuses the window
@@ -248,44 +288,6 @@ function window:focus()
   self:becomeMain()
   self:application():_bringtofront()
   return self
-end
-
---- hs.window.visibleWindows() -> win[]
---- Function
---- Gets all visible windows
----
---- Parameters:
----  * None
----
---- Returns:
----  * A table containing `hs.window` objects representing all windows that are visible (see `hs.window:isVisible()` for information about what constitutes a visible window)
-function window.visibleWindows()
-  return fnutils.filter(window:allWindows(), window.isVisible)
-end
-
---- hs.window.orderedWindows() -> win[]
---- Function
---- Returns all visible windows, ordered from front to back
----
---- Parameters:
----  * None
----
---- Returns:
----  * A table of `hs.window` objects representing all visible windows, ordered from front to back
-function window.orderedWindows()
-  local orderedwins = {}
-  local orderedwinids = window._orderedwinids()
-  local windows = window.visibleWindows()
-
-  for _, orderedwinid in pairs(orderedwinids) do
-    for _, win in pairs(windows) do
-      if orderedwinid == win:id() then
-        tinsert(orderedwins, win)
-        break
-      end
-    end
-  end
-  return orderedwins
 end
 
 --- hs.window:maximize([duration]) -> window

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -774,6 +774,10 @@ end
 package.loaded[...]=window
 window.filter = require "hs.window.filter"
 --window.layout = require "hs.window.layout"
+do
+  local mt=getmetatable(window)
+  if not mt.__call then mt.__call=function(t,...)if t.find then return t.find(...) else error('cannot call uielement',2) end end end
+end
 
-getmetatable(window).__call=function(_,...)return window.find(...)end
+--getmetatable(window).__call=function(_,...)return window.find(...)end
 return window

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -745,17 +745,21 @@ function window:moveOneScreenSouth(duration)
   return self
 end
 
---- hs.window:ensureIsInScreenBounds([duration]) -> window
+--- hs.window:ensureIsInScreenBounds() -> window
 --- Method
 --- Movies and resizes the window to ensure it is inside the screen
 ---
 --- Parameters:
----  * duration - An optional number containing the number of seconds to animate the transition. Defaults to the value of `hs.window.animationDuration`
+---  * None
 ---
 --- Returns:
 ---  * The `hs.window` object
+---
+--- Notes:
+---  * Calling this method will immediately fast-forward to the end of any ongoing animation on the window
 function window:ensureIsInScreenBounds(duration)
-  local frame = self:frame()
+  stopAnimation(self,true)
+  local frame = self:_frame()
   local screenFrame = self:screen():frame()
   if frame.x < screenFrame.x then frame.x = screenFrame.x end
   if frame.y < screenFrame.y then frame.y = screenFrame.y end
@@ -767,7 +771,7 @@ function window:ensureIsInScreenBounds(duration)
   if frame.y + frame.h > screenFrame.y + screenFrame.h then
     frame.y = (screenFrame.y + screenFrame.h) - frame.h
   end
-  if frame ~= self:frame() then self:setFrame(frame, duration) end
+  self:_setFrame(frame)
   return self
 end
 


### PR DESCRIPTION
- added `hs.window.find()`, `hs.application.find()` (similar to #501, which is a prerequisite of this PR for `win:moveToScreen'dell'`) - `hs.appfinder` isn't needed anymore
- `hs.window.get()` and `hs.application.get()` are "strict" variants for `find`
- `hs.application:findWindow()` and `hs.application:getWindow()`
- added `hs.application.open()` (wraps the two launchOrFocus methods)
- `hs.application:title()->hs.application:name()` (users shouldn't have to suffer just because it derives from uielement)
- geometrified `hs.window` for cleaner code (#471, prerequisite), and to enable...
- `hs.window:move()` one-stop-shop for window movement; takes a point (moves by x,y), a rect (does setFrame) or a unit rect+screen (basically does :moveToScreen+:moveToUnit in one go) 
- unfnfied everything for correctness (there was a potential heisenbug in find_windows_in_direction), readability, maintainability and performance; in particular, **the occasional 3 to 5 seconds delay** when doing `hs.window.allWindows()` and derivatives (including stuff like #497) **seems now gone**; it used to happen quite often here, and I haven't seen it yet
- fixed some minor bugs, docs
- ensureIsInScreenBounds doesn't care about animations (fixes #478)
- also needs the windowfilter->window.filter PR (#513) ~~which apparently I haven't opened yet :/~~