### PR TITLE
WIP: Adding chaining for methods and __tostring for userdata to remaining modules

### DIFF
--- a/extensions/application/watcher.m
+++ b/extensions/application/watcher.m
@@ -286,6 +286,11 @@ static int app_watcher_gc(lua_State* L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 static int meta_gc(lua_State* __unused L) {
     return 0;
 }
@@ -311,6 +316,7 @@ static void add_event_enum(lua_State* L) {
 static const luaL_Reg metaLib[] = {
     {"start",   app_watcher_start},
     {"stop",    app_watcher_stop},
+    {"__tostring", userdata_tostring},
     {"__gc",    app_watcher_gc},
     {NULL,      NULL}
 };

--- a/extensions/audiodevice/internal.m
+++ b/extensions/audiodevice/internal.m
@@ -608,7 +608,7 @@ static int userdata_tostring(lua_State* L) {
     if (result) {
         deviceNameNS = @"(un-named audiodevice)" ;
     } else {
-        *deviceNameNS = (__bridge_transfer NSString *)deviceName;
+        deviceNameNS = (__bridge_transfer NSString *)deviceName;
     }
 
     lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, deviceNameNS, lua_topointer(L, 1)] UTF8String]) ;

--- a/extensions/battery/watcher.m
+++ b/extensions/battery/watcher.m
@@ -127,11 +127,17 @@ static int meta_gc(lua_State* __unused L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 // Metatable for created objects when _new invoked
 static const luaL_Reg battery_metalib[] = {
     {"start",   battery_watcher_start},
     {"stop",    battery_watcher_stop},
     {"__gc",    battery_watcher_gc},
+    {"__tostring", userdata_tostring},
     {NULL,      NULL}
 };
 

--- a/extensions/caffeinate/watcher.m
+++ b/extensions/caffeinate/watcher.m
@@ -174,17 +174,17 @@ static void unregister_observer(CaffeinateWatcher* observer) {
 ///  * None
 ///
 /// Returns:
-///  * None
+///  * An `hs.caffeinate.watcher` object
 static int app_watcher_start(lua_State* L) {
     caffeinatewatcher_t* caffeinateWatcher = luaL_checkudata(L, 1, USERDATA_TAG);
     lua_settop(L, 1);
 
     if (caffeinateWatcher->running)
-        return 0;
+        return 1;
 
     caffeinateWatcher->running = YES;
     register_observer((__bridge CaffeinateWatcher*)caffeinateWatcher->obj);
-    return 0;
+    return 1;
 }
 
 /// hs.caffeinate.watcher:stop()
@@ -195,17 +195,17 @@ static int app_watcher_start(lua_State* L) {
 ///  * None
 ///
 /// Returns:
-///  * None
+///  * An `hs.caffeinate.watcher` object
 static int app_watcher_stop(lua_State* L) {
     caffeinatewatcher_t* caffeinateWatcher = luaL_checkudata(L, 1, USERDATA_TAG);
     lua_settop(L, 1);
 
     if (!caffeinateWatcher->running)
-        return 0;
+        return 1;
 
     caffeinateWatcher->running = NO;
     unregister_observer((__bridge id)caffeinateWatcher->obj);
-    return 0;
+    return 1;
 }
 
 // Perform cleanup if the CaffeinateWatcher is not required anymore.
@@ -221,6 +221,11 @@ static int app_watcher_gc(lua_State* L) {
     CaffeinateWatcher* object = (__bridge_transfer CaffeinateWatcher*)caffeinateWatcher->obj;
     object = nil;
     return 0;
+}
+
+static int userdata_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
 }
 
 static int meta_gc(lua_State* __unused L) {
@@ -247,6 +252,7 @@ static const luaL_Reg metaLib[] = {
     {"start",   app_watcher_start},
     {"stop",    app_watcher_stop},
     {"__gc",    app_watcher_gc},
+    {"__tostring", userdata_tostring},
     {NULL,      NULL}
 };
 
@@ -268,6 +274,6 @@ int luaopen_hs_caffeinate_watcher(lua_State* L __unused) {
     refTable = [skin registerLibraryWithObject:USERDATA_TAG functions:appLib metaFunctions:metaGcLib objectFunctions:metaLib];
 
     add_event_enum(skin.L);
-    
+
     return 1;
 }

--- a/extensions/eventtap/event.m
+++ b/extensions/eventtap/event.m
@@ -219,7 +219,8 @@ static int eventtap_event_setKeyCode(lua_State* L) {
 ///  * app - An optional `hs.application` object. If specified, the event will only be sent to that application
 ///
 /// Returns:
-///  * None
+///  * The `hs.eventtap.event` object
+//  * None
 static int eventtap_event_post(lua_State* L) {
     CGEventRef event = *(CGEventRef*)luaL_checkudata(L, 1, EVENT_USERDATA_TAG);
 
@@ -240,7 +241,9 @@ static int eventtap_event_post(lua_State* L) {
         CGEventPost(kCGSessionEventTap, event);
     }
 
-    return 0;
+    lua_settop(L, 1) ;
+//     return 0;
+    return 1 ;
 }
 
 /// hs.eventtap.event:getType() -> number
@@ -883,6 +886,14 @@ static void pushpropertiestable(lua_State* L) {
     lua_pushstring(L, "scrollWheelEventIsContinuous") ;                     lua_rawseti(L, -2, kCGScrollWheelEventIsContinuous);
 }
 
+static int userdata_tostring(lua_State* L) {
+    CGEventRef event = *(CGEventRef*)luaL_checkudata(L, 1, EVENT_USERDATA_TAG);
+    int eventType = CGEventGetType(event) ;
+
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: Event type: %d (%p)", EVENT_USERDATA_TAG, eventType, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 // static int meta_gc(lua_State* __unused L) {
 //     [eventtapeventHandlers removeAllIndexes];
 //     eventtapeventHandlers = nil;
@@ -904,6 +915,7 @@ static const luaL_Reg eventtapevent_metalib[] = {
     {"getRawEventData", eventtap_event_getRawEventData},
     {"getCharacters",   eventtap_event_getCharacters},
     {"systemKey",       eventtap_event_systemKey},
+    {"__tostring",      userdata_tostring},
     {"__gc",            eventtap_event_gc},
     {NULL,              NULL}
 };

--- a/extensions/eventtap/internal.m
+++ b/extensions/eventtap/internal.m
@@ -366,11 +366,19 @@ static int meta_gc(lua_State* __unused L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    eventtap_t* e = luaL_checkudata(L, 1, USERDATA_TAG);
+
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: Eventtap Mask: 0x%llx (%p)", USERDATA_TAG, e->mask, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 // Metatable for created objects when _new invoked
 static const luaL_Reg eventtap_metalib[] = {
     {"start",     eventtap_start},
     {"stop",      eventtap_stop},
     {"isEnabled", eventtap_isEnabled},
+    {"__tostring", userdata_tostring},
     {"__gc",      eventtap_gc},
     {NULL,        NULL}
 };

--- a/extensions/hints/internal.m
+++ b/extensions/hints/internal.m
@@ -201,6 +201,11 @@ static int hints_new(lua_State* L) {
     return 1;
 }
 
+static int userdata_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 static const luaL_Reg hintslib[] = {
     {"test", hints_test},
     {"new", hints_new},
@@ -211,6 +216,7 @@ static const luaL_Reg hintslib[] = {
 static const luaL_Reg hints_metalib[] = {
     {"__eq", hint_eq},
     {"__gc", hint_close},
+    {"__tostring", userdata_tostring},
     {"close", hint_close},
 
     {NULL, NULL}

--- a/extensions/hotkey/internal.m
+++ b/extensions/hotkey/internal.m
@@ -326,7 +326,7 @@ static int meta_gc(lua_State* L __unused) {
 static int userdata_tostring(lua_State* L) {
     hotkey_t* hotkey = luaL_checkudata(L, 1, USERDATA_TAG);
 
-    lua_pushstring(L, [[NSString stringWithFormat:@"%s: keycode: %d, mods: 0x%04x(%p)", USERDATA_TAG, hotkey->keycode, hotkey->mods, lua_topointer(L, 1)] UTF8String]) ;
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: keycode: %d, mods: 0x%04x (%p)", USERDATA_TAG, hotkey->keycode, hotkey->mods, lua_topointer(L, 1)] UTF8String]) ;
     return 1 ;
 }
 

--- a/extensions/hotkey/internal.m
+++ b/extensions/hotkey/internal.m
@@ -323,6 +323,13 @@ static int meta_gc(lua_State* L __unused) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    hotkey_t* hotkey = luaL_checkudata(L, 1, USERDATA_TAG);
+
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: keycode: %d, mods: 0x%04x(%p)", USERDATA_TAG, hotkey->keycode, hotkey->mods, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 static const luaL_Reg hotkeylib[] = {
     {"_new", hotkey_new},
 
@@ -337,6 +344,7 @@ static const luaL_Reg metalib[] = {
 static const luaL_Reg hotkey_objectlib[] = {
     {"enable", hotkey_enable},
     {"disable", hotkey_disable},
+    {"__tostring", userdata_tostring},
     {"__gc", hotkey_gc},
     {NULL, NULL}
 };
@@ -354,7 +362,7 @@ int luaopen_hs_hotkey_internal(lua_State* L __unused) {
         {kEventClassKeyboard, kEventHotKeyPressed},
         {kEventClassKeyboard, kEventHotKeyReleased},
     };
-    
+
     InstallEventHandler(GetEventDispatcherTarget(),
                         hotkey_callback,
                         sizeof(hotKeyPressedSpec) / sizeof(EventTypeSpec),

--- a/extensions/httpserver/internal.m
+++ b/extensions/httpserver/internal.m
@@ -161,7 +161,7 @@ int refTable;
 - (void)startConnection
 {
     // Override me to do any custom work before the connection starts.
-    // 
+    //
     // Be sure to invoke [super startConnection] when you're done.
 
     //HTTPLogTrace();
@@ -445,6 +445,17 @@ static int httpserver_objectGC(lua_State *L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    HSHTTPServer *server = getUserData(L, 1);
+    NSString *theName = [server name] ;
+    int thePort = [server listeningPort] ;
+
+    if (!theName) theName = @"unnamed" ;
+
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@:%d (%p)", USERDATA_TAG, theName, thePort, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 static const luaL_Reg httpserverLib[] = {
     {"new", httpserver_new},
 
@@ -461,6 +472,7 @@ static const luaL_Reg httpserverObjectLib[] = {
     {"setCallback", httpserver_setCallback},
     {"setPassword", httpserver_setPassword},
 
+    {"__tostring", userdata_tostring},
     {"__gc", httpserver_objectGC},
     {NULL, NULL}
 };

--- a/extensions/keycodes/internal.m
+++ b/extensions/keycodes/internal.m
@@ -229,6 +229,11 @@ static int keycodes_newcallback(lua_State* L) {
     return 1;
 }
 
+static int userdata_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 static int keycodes_callback_gc(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
 
@@ -251,6 +256,7 @@ static const luaL_Reg callbacklib[] = {
     {"_stop", keycodes_callback_stop},
 
     // metamethods
+    {"__tostring", userdata_tostring},
     {"__gc", keycodes_callback_gc},
 
     {NULL, NULL}

--- a/extensions/milight/internal.m
+++ b/extensions/milight/internal.m
@@ -190,6 +190,13 @@ static int milight_metagc(lua_State *L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    bridge_t *bridge = luaL_checkudata(L, 1, USERDATA_TAG);
+
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %s:%d (%p)", USERDATA_TAG, bridge->ip, bridge->port, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 static const luaL_Reg milightlib[] = {
     {"_cacheCommands", milight_cacheCommands},
     {"new", milight_new},
@@ -200,6 +207,7 @@ static const luaL_Reg milightlib[] = {
 static const luaL_Reg milight_objectlib[] = {
     {"delete", milight_del},
     {"send", milight_send},
+    {"__tostring", userdata_tostring},
 
     {NULL, NULL}
 };

--- a/extensions/pathwatcher/internal.m
+++ b/extensions/pathwatcher/internal.m
@@ -125,11 +125,20 @@ static int meta_gc(lua_State* __unused L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    watcher_path_t* watcher_path = luaL_checkudata(L, 1, USERDATA_TAG);
+    NSArray *thePaths = (__bridge_transfer NSArray *) FSEventStreamCopyPathsBeingWatched (watcher_path->stream);
+
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, thePaths, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 // Metatable for created objects when _new invoked
 static const luaL_Reg path_metalib[] = {
     {"start",   watcher_path_start},
     {"stop",    watcher_path_stop},
     {"__gc",    watcher_path_gc},
+    {"__tostring", userdata_tostring},
     {NULL,      NULL}
 };
 

--- a/extensions/pathwatcher/internal.m
+++ b/extensions/pathwatcher/internal.m
@@ -128,8 +128,10 @@ static int meta_gc(lua_State* __unused L) {
 static int userdata_tostring(lua_State* L) {
     watcher_path_t* watcher_path = luaL_checkudata(L, 1, USERDATA_TAG);
     NSArray *thePaths = (__bridge_transfer NSArray *) FSEventStreamCopyPathsBeingWatched (watcher_path->stream);
+    NSString *thePath = [thePaths objectAtIndex:0] ;
+    if (!thePath) thePath = @"(unknown path)" ;
 
-    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, thePaths, lua_topointer(L, 1)] UTF8String]) ;
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, thePath, lua_topointer(L, 1)] UTF8String]) ;
     return 1 ;
 }
 

--- a/extensions/screen/internal.m
+++ b/extensions/screen/internal.m
@@ -801,6 +801,22 @@ static int screens_gc(lua_State* L __unused) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    NSScreen *screen = get_screen_arg(L, 1);
+    CGDirectDisplayID screen_id = [[[screen deviceDescription] objectForKey:@"NSScreenNumber"] intValue];
+
+    CFDictionaryRef deviceInfo = IODisplayCreateInfoDictionary(CGDisplayIOServicePort(screen_id), kIODisplayOnlyPreferredName);
+    NSDictionary *localizedNames = [(__bridge NSDictionary *)deviceInfo objectForKey:[NSString stringWithUTF8String:kDisplayProductName]];
+    NSString *theName ;
+    if ([localizedNames count])
+        theName = [localizedNames objectForKey:[[localizedNames allKeys] objectAtIndex:0]] ;
+    else
+        theName = @"(un-named screen)" ;
+
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, theName, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 static const luaL_Reg screenlib[] = {
     {"allScreens", screen_allScreens},
     {"mainScreen", screen_mainScreen},

--- a/extensions/screen/internal.m
+++ b/extensions/screen/internal.m
@@ -839,6 +839,7 @@ static const luaL_Reg screen_objectlib[] = {
     {"setMode", screen_setMode},
     {"snapshot", screen_snapshot},
 
+    {"__tostring", userdata_tostring},
     {"__gc", screen_gc},
     {"__eq", screen_eq},
 

--- a/extensions/screen/watcher.m
+++ b/extensions/screen/watcher.m
@@ -55,7 +55,13 @@ typedef struct _screenwatcher_t {
 
 /// hs.screen.watcher.new(fn) -> watcher
 /// Constructor
-/// Creates a new screen-watcher that can be started; fn will be called when your screen layout changes in any way, whether by adding, removing, or moving a display device.
+/// Creates a new screen-watcher.
+///
+/// Parameters:
+///  * The function to be called when a change in the screen layout occurs.  This function should take no arguments.
+///
+/// Returns:
+///  * the screen watcher object
 static int screen_watcher_new(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
 
@@ -82,6 +88,12 @@ static int screen_watcher_new(lua_State* L) {
 /// hs.screen.watcher:start() -> watcher
 /// Function
 /// Starts the screen watcher, making it so fn is called each time the screen arrangement changes.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the screen watcher object
 static int screen_watcher_start(lua_State* L) {
     screenwatcher_t* screenwatcher = luaL_checkudata(L, 1, USERDATA_TAG);
     lua_settop(L,1) ;
@@ -100,6 +112,12 @@ static int screen_watcher_start(lua_State* L) {
 /// hs.screen.watcher:stop() -> watcher
 /// Function
 /// Stops the screen watcher's fn from getting called until started again.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the screen watcher object
 static int screen_watcher_stop(lua_State* L) {
     screenwatcher_t* screenwatcher = luaL_checkudata(L, 1, USERDATA_TAG);
     lua_settop(L,1) ;
@@ -133,10 +151,16 @@ static int meta_gc(lua_State* __unused L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 // Metatable for created objects when _new invoked
 static const luaL_Reg screen_metalib[] = {
     {"start",   screen_watcher_start},
     {"stop",    screen_watcher_stop},
+    {"__tostring", userdata_tostring},
     {"__gc",    screen_watcher_gc},
     {NULL,      NULL}
 };

--- a/extensions/sound/internal.m
+++ b/extensions/sound/internal.m
@@ -442,7 +442,7 @@ static int sound_soundUnfilteredFileTypes(lua_State* L) {
 ///  * A boolean, true if the sound is currently playing, otherwise false
 ///
 /// Notes:
-///  * This method is only available in OS X 10.9 (Mavericks) and earlier
+///  * This method is officially only available in OS X 10.9 (Mavericks) and earlier, so its use may be unreliable with future updates.
 static int sound_isPlaying(lua_State* L) {
     sound_t* sound = luaL_checkudata(L, 1, USERDATA_TAG);
     lua_pushboolean(L, [(__bridge NSSound*) sound->soundObject isPlaying]);
@@ -470,6 +470,15 @@ static int meta_gc(lua_State* __unused L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    sound_t* sound = luaL_checkudata(L, 1, USERDATA_TAG);
+    NSString *theName = [(__bridge NSSound*) sound->soundObject name] ;
+    if (!theName) theName = @"(unnamed sound)" ;
+
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, theName, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 // Metatable for created objects when _new invoked
 static const luaL_Reg sound_metalib[] = {
     {"play",            sound_play},
@@ -485,7 +494,8 @@ static const luaL_Reg sound_metalib[] = {
     {"stopOnReload",    sound_stopOnRelease},
     {"callback",        sound_callback},
     {"isPlaying",       sound_isPlaying}, // Not in 10.10... can we replicate another way?
-    {"__gc",	        sound_gc},
+    {"__tostring",      userdata_tostring},
+    {"__gc",            sound_gc},
     {NULL,              NULL}
 };
 

--- a/extensions/spaces/watcher.m
+++ b/extensions/spaces/watcher.m
@@ -164,6 +164,11 @@ static int space_watcher_gc(lua_State* L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 static const luaL_Reg watcherlib[] = {
     {"new", space_watcher_new},
     {NULL, NULL}
@@ -172,7 +177,7 @@ static const luaL_Reg watcherlib[] = {
 static const luaL_Reg watcher_objectlib[] = {
     {"start", space_watcher_start},
     {"stop", space_watcher_stop},
-
+    {"__tostring", userdata_tostring},
     {"__gc", space_watcher_gc},
     {NULL, NULL}
 };

--- a/extensions/uielement/init.lua
+++ b/extensions/uielement/init.lua
@@ -103,14 +103,19 @@ local function handleEvent(callback, element, event, watcher, userData)
 end
 
 --- hs.uielement:newWatcher(handler[, userData]) -> hs.uielement.watcher
---- Method
---- Creates a new watcher for the element represented by self.
+--- Constructor
+--- Creates a new watcher for the element represented by self (the object the method is being invoked for).
 ---
---- You must pass a handler function. The args passed are as follows:
---- * element: The element the event occurred on. Note this is not always the element being watched.
---- * event: The name of the event that occurred.
---- * watcher: The watcher object being created.
---- * userData: The userData you included, if any.
+--- Parameters:
+---  * a function to be called when a watched event occurs.  The argument will be passed the following arguments:
+---    * element: The element the event occurred on. Note this is not always the element being watched.
+---    * event: The name of the event that occurred.
+---    * watcher: The watcher object being created.
+---    * userData: The userData you included, if any.
+---  * an optional userData object which will be included as the final argument to the callback function when it is called.
+---
+--- Returns:
+---  * hs.uielement.watcher
 function uielement:newWatcher(callback, ...)
     if type(callback) ~= "function" then
         hs.showError("hs.uielement:newWatcher() called with incorrect arguments. The first argument must be a function")
@@ -123,13 +128,19 @@ function uielement:newWatcher(callback, ...)
     return obj
 end
 
---- hs.uielement.watcher:start(events)
+--- hs.uielement.watcher:start(events) -> hs.uielement.watcher
 --- Method
---- Tells the watcher to start watching the given list of events.
+--- Tells the watcher to start watching for the given list of events.
 ---
---- See hs.uielement.watcher for a list of events. You may also specify arbitrary event names as strings.
+--- Parameters:
+---  * An array of events to be watched for.
 ---
---- Does nothing if the watcher has already been started. To start with different events, stop it first.
+--- Returns:
+---  * hs.uielement.watcher
+---
+--- Notes:
+---  * See hs.uielement.watcher for a list of events. You may also specify arbitrary event names as strings.
+---  * Does nothing if the watcher has already been started. To start with different events, stop it first.
 function uielement.watcher:start(events)
     -- Track all watchers in appWatchers.
     local pid = self._pid
@@ -151,10 +162,18 @@ function uielement.watcher:start(events)
     return self:_start(events)
 end
 
---- hs.uielement.watcher:stop()
+--- hs.uielement.watcher:stop() -> hs.uielement.watcher
 --- Method
 --- Tells the watcher to stop listening for events.
---- This is automatically called if the element is destroyed.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * hs.uielement.watcher
+---
+--- Notes:
+---  * This is automatically called if the element is destroyed.
 function uielement.watcher:stop()
     -- Remove self from appWatchers.
     local pid = self._pid
@@ -168,9 +187,15 @@ function uielement.watcher:stop()
     return self:_stop()
 end
 
---- hs.uielement.watcher:element()
+--- hs.uielement.watcher:element() -> object
 --- Method
 --- Returns the element the watcher is watching.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The element the watcher is watching.
 function uielement.watcher:element()
     return self._element
 end

--- a/extensions/uielement/internal.m
+++ b/extensions/uielement/internal.m
@@ -308,16 +308,6 @@ static int uielement_focusedElement(lua_State* L) {
     return 1;
 }
 
-static int userdata1_tostring(lua_State* L) {
-    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", userdataTag, lua_topointer(L, 1)] UTF8String]) ;
-    return 1 ;
-}
-
-static int userdata2_tostring(lua_State* L) {
-    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", watcherUserdataTag, lua_topointer(L, 1)] UTF8String]) ;
-    return 1 ;
-}
-
 // Perform cleanup if the watcher is not required anymore.
 static int watcher_gc(lua_State* L) {
     watcher_t* watcher = get_watcher(L, 1);
@@ -338,14 +328,12 @@ static const luaL_Reg uielementlib[] = {
     {"_newWatcher", uielement_newWatcher},
     {"focusedElement", uielement_focusedElement},
     {"selectedText", uielement_selectedText},
-    {"__tostring", userdata1_tostring},
     {NULL, NULL}
 };
 
 static const luaL_Reg watcherlib[] = {
     {"_start", watcher_start},
     {"_stop", watcher_stop},
-    {"__tostring", userdata2_tostring},
     {NULL, NULL}
 };
 

--- a/extensions/uielement/internal.m
+++ b/extensions/uielement/internal.m
@@ -308,6 +308,16 @@ static int uielement_focusedElement(lua_State* L) {
     return 1;
 }
 
+static int userdata1_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", userdataTag, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
+static int userdata2_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", watcherUserdataTag, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 // Perform cleanup if the watcher is not required anymore.
 static int watcher_gc(lua_State* L) {
     watcher_t* watcher = get_watcher(L, 1);
@@ -328,12 +338,14 @@ static const luaL_Reg uielementlib[] = {
     {"_newWatcher", uielement_newWatcher},
     {"focusedElement", uielement_focusedElement},
     {"selectedText", uielement_selectedText},
+    {"__tostring", userdata1_tostring},
     {NULL, NULL}
 };
 
 static const luaL_Reg watcherlib[] = {
     {"_start", watcher_start},
     {"_stop", watcher_stop},
+    {"__tostring", userdata2_tostring},
     {NULL, NULL}
 };
 

--- a/extensions/usb/watcher.m
+++ b/extensions/usb/watcher.m
@@ -275,10 +275,16 @@ static int meta_gc(lua_State* __unused L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 // Metatable for created objects when _new invoked
 static const luaL_Reg usb_metalib[] = {
     {"start",   usb_watcher_start},
     {"stop",    usb_watcher_stop},
+    {"__tostring", userdata_tostring},
     {"__gc",    usb_watcher_gc},
     {NULL,      NULL}
 };

--- a/extensions/wifi/watcher.m
+++ b/extensions/wifi/watcher.m
@@ -156,6 +156,11 @@ static int wifi_watcher_gc(lua_State* L) {
     return 0;
 }
 
+static int userdata_tostring(lua_State* L) {
+    lua_pushstring(L, [[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, lua_topointer(L, 1)] UTF8String]) ;
+    return 1 ;
+}
+
 static int meta_gc(lua_State* __unused L) {
     return 0;
 }
@@ -164,6 +169,7 @@ static int meta_gc(lua_State* __unused L) {
 static const luaL_Reg wifi_metalib[] = {
     {"start",   wifi_watcher_start},
     {"stop",    wifi_watcher_stop},
+    {"__tostring", userdata_tostring},
     {"__gc",    wifi_watcher_gc},
     {NULL,      NULL}
 };


### PR DESCRIPTION
Adding chaining of methods to:
* [x] eventtap.event.post()
* [x] caffeinate
* [ ] sound

Updating docs for:
* [x] uielement
* [x] screen

Adding __tostring for userdata for:
* [x] application/watcher.m
* [x] audiodevice/internal.m
* [x] battery/watcher.m
* [x] caffeinate/watcher.m
* [x] eventtap/event.m
* [x] eventtap/internal.m
* [x] hints/internal.m
* [x] hotkey/internal.m
* [x] httpserver/internal.m
* [x] keycodes/internal.m
* [x] milight/internal.m
* [x] pathwatcher/internal.m
* [x] screen/internal.m
* [x] screen/watcher.m
* [x] sound/internal.m
* [x] spaces/watcher.m
* [ ] uielement/internal.m
* [x] usb/watcher.m
* [x] wifi/watcher.m

The sound methods are kind of a low priority... don't think anyone particularly cares if they chain, so I'll get to it for consistency at some point, but it shouldn't hold this up.

Uielement is going to take some thought... it looks like there are 3 different userdata types in use, but none are actually stored in the LUA_REGISTRY table?  It may be that __tostring methods don't make sense for it... or maybe belong on the enclosing tables... don't know, need to sleep first.

At any rate, if this meets with no objections, I'd like to add it into core in the next few days.