### PR TITLE
[READY] small improvements for hs.window

### DIFF
--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -188,12 +188,28 @@ end
 ---  * unitrect - an hs.geometry unit rect, or arguments to construct one
 ---
 --- Returns:
----  * an hs.geometry rect describing the given frame in absolute coordinates
+---  * an hs.geometry rect describing the given unit rect in absolute coordinates
 ---
 --- Notes:
----  * this method is just a convenience wrapper for `hs.geometry.fromUnitRect(unitrect,this_screen:fullFrame())`
+---  * this method is just a convenience wrapper for `hs.geometry.fromUnitRect(unitrect,this_screen:frame())`
 function screenObject:fromUnitRect(unit,...)
   return geometry(unit,...):fromUnitRect(self:frame()):floor()
+end
+
+--- hs.screen:toUnitRect(rect) -> hs.geometry unitrect
+--- Method
+--- Returns the unit rect of a given rect, relative to this screen
+---
+--- Parameters:
+---  * rect - an hs.geometry rect, or arguments to construct one
+---
+--- Returns:
+---  * an hs.geometry unit rect describing the given rect relative to this screen's frame
+---
+--- Notes:
+---  * this method is just a convenience wrapper for `hs.geometry.toUnitRect(rect,this_screen:frame())`
+function screenObject:toUnitRect(rect,...)
+  return geometry(rect,...):toUnitRect(self:frame())
 end
 
 --- hs.screen:next() -> screen

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -158,10 +158,8 @@ end
 
 
 local animations, animTimer = {}
-
-
-local function animate()
-  --[[
+local DISTANT_FUTURE=315360000 -- 10 years (roughly)
+--[[
   local function quad(x,s,len)
     local l=max(0,min(2,(x-s)*2/len))
     if l<1 then return l*l/2
@@ -171,10 +169,11 @@ local function animate()
     end
   end
 --]]
-  local function quadOut(x,s,len)
-    local l=1-max(0,min(1,(x-s)/len))
-    return 1-l*l
-  end
+local function quadOut(x,s,len)
+  local l=1-max(0,min(1,(x-s)/len))
+  return 1-l*l
+end
+local function animate()
   local time = timer.secondsSinceEpoch()
   for id,anim in pairs(animations) do
     local r = quadOut(time,anim.time,anim.duration)
@@ -189,9 +188,10 @@ local function animate()
     end
     anim.window:_setFrame(f)
   end
-  if not next(animations) then animTimer:stop() end
+  if not next(animations) then animTimer:setNextTrigger(DISTANT_FUTURE) end
 end
-animTimer = timer.new(0.017, animate)
+animTimer = timer.new(0.017,animate)
+animTimer:start() --keep this split
 
 
 local function getAnimationFrame(win)
@@ -204,7 +204,7 @@ local function stopAnimation(win,snap,id)
   local anim = animations[id]
   if not anim then return end
   animations[id] = nil
-  if not next(animations) then animTimer:stop() end
+  if not next(animations) then animTimer:setNextTrigger(DISTANT_FUTURE) end
   if snap then win:_setFrame(anim.endFrame) end
 end
 
@@ -254,7 +254,7 @@ function window:setFrame(f, duration)
   local anim = animations[id]
   anim.time=timer.secondsSinceEpoch() anim.duration=duration
   anim.startFrame=frame anim.endFrame=f
-  animTimer:start()
+  animTimer:setNextTrigger(0.01)
   return self
 end
 

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -651,7 +651,7 @@ end
 --- Notes:
 ---  * An example, which would make a window fill the top-left quarter of the screen: `win:moveToUnit'[0,0,50,50]'`
 function window:moveToUnit(unit, duration)
-  return self:setFrame(geometry.fromUnitRect(unit,self:screen():frame()),duration)
+  return self:setFrame(self:screen():fromUnitRect(unit),duration)
 end
 
 --- hs.window:moveToScreen(screen[, duration]) -> hs.window object
@@ -666,8 +666,8 @@ end
 ---  * The `hs.window` object
 function window:moveToScreen(toScreen, duration)
   toScreen=screen.find(toScreen)
-  if not toScreen then return self end --TODO log?
-  return self:setFrame(geometry(self:frame()):toUnitRect(self:screen():frame()):fromUnitRect(toScreen:frame()),duration)
+  if not toScreen then print('window:moveToScreen(): screen not found: '..toScreen) return self end
+  return self:setFrame(toScreen:fromUnitRect(self:screen():toUnitRect(self:frame())),duration)
 end
 
 --- hs.window:move(rect[, screen][, ensureInScreenBounds][, duration]) --> hs.window object
@@ -697,8 +697,10 @@ function window:move(rect,toScreen,duration)
   if rtype=='point' then frame=geometry(self:frame()):move(rect)
   elseif rtype=='rect' then frame=rect
   elseif rtype=='unitrect' then
-    if toScreen then toScreen=screen.find(toScreen) end --TODO log when failed
-    toScreen=toScreen or self:screen()
+    if toScreen then
+      toScreen=screen.find(toScreen)
+      if not toScreen then print('window:move(): screen not found: '..toScreen) return self end
+    else toScreen=self:screen() end
     frame=rect:fromUnitRect(toScreen:frame())
   else error('rect must be a point, rect, or unit rect',2) end
   if inBounds then return self:setFrameInScreenBounds(frame)

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -133,7 +133,7 @@ function window.find(hint,exact,wins)
   if hint==nil then return end
   local typ,r=type(hint),{}
   wins=wins or window.allWindows()
-  if typ=='number' then for _,w in ipairs(wins) do if w:id()==hint then return w end end
+  if typ=='number' then for _,w in ipairs(wins) do if w:id()==hint then return w end end return
   elseif typ~='string' then error('hint must be a number or string',2) end
   if exact then for _,w in ipairs(wins) do if w:title()==hint then r[#r+1]=w end end
   else hint=hint:lower() for _,w in ipairs(wins) do if w:title():lower():find(hint) then r[#r+1]=w end end end


### PR DESCRIPTION
fix docs; add ensureInScreenBounds arg to :move(); alias :setFrameInScreenBounds() for :ensureIsInScreenBounds(); add optional frame arg to :setFrameInScreenBounds()

Handles cases like #499 (use `:setFrameInScreenBounds()` instead of `:setFrame()` to make sure things don't explode)