### PR TITLE
Fixed bug that prevents hammerspoon from changing the layout of windows.

### DIFF
--- a/extensions/layout/init.lua
+++ b/extensions/layout/init.lua
@@ -159,9 +159,9 @@ function layout.apply(layout)
         -- Find the matching windows, if any
         if _row[2] then
             if app then
-                wins = fnutils.filter(app:allWindows(), function(win) return string.match(win:title(), _row[2]) end)
+                wins = fnutils.filter(app:allWindows(), function(win) return win:title() == _row[2] end)
             else
-                wins = fnutils.filter(window:allWindows(), function(win) return string.match(win:title(), _row[2]) end)
+                wins = fnutils.filter(window:allWindows(), function(win) return win:title() == _row[2] end)
             end
         elseif app then
             wins = app:allWindows()


### PR DESCRIPTION
I found a little bug that prevents hammerspoon layout extension from changing the layout of windows. In hs.layout window titles are matched against each other. This matching of strings is done by using `string.match()`. `String.match()` is used to match a string against a pattern, so when a window title contains a pattern token like a parentheses ‘(‘ or a bracket ‘[‘ it will not match.

To reproduce this bug you should create a file called: test(123).txt and open it in TextEdit. Then try to change the layout and you will see that nothing happens. However, if you change the file to test[123].txt you will get an error: `malformed pattern (missing ']')`.
Another way to reproduce it is to open up a pdf file (with multiple pages) in Preview. Preview uses the window title to indicate which page you are on, this page count is wrapped in parentheses. For example: document.pdf (page 3 of 10). 

I fixed it by replacing `string.match()` with `==`.