### PR TITLE
Luaskin enhancements

### DIFF
--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -190,6 +190,8 @@ typedef struct tableHelpers {
  */
 - (void)checkArgs:(int)firstArg, ...;
 
+#pragma mark - Conversion from NSObjects into Lua objects
+
 /** Pushes an NSObject to the lua stack
 
  @note This method takes an NSObject and checks its class against registered classes and then against the built in defaults
@@ -244,6 +246,8 @@ typedef struct tableHelpers {
  @returns The number of items on the lua stack - this is always 1 but is returned to simplify its use in Hammerspoon modules.
  */
 - (int)pushNSSize:(NSSize)theSize ;
+
+#pragma mark - Conversion from lua objects into NSObjects
 
 /** Return an NSObject containing the best representation of the lua data structure at the specified index.
 
@@ -310,13 +314,24 @@ typedef struct tableHelpers {
  */
 - (NSSize)tableToSizeAtIndex:(int)idx ;
 
+#pragma mark - Other helpers
+
 /** Determines if the string in the lua stack is valid UTF8 or not.
 
  @note This method is used internally to determine if a string should be treated as an NSString or an NSData object.  It is included as a public method because it has uses outside of this as well.
+ @note This method uses lua_tolstring, which will convert a number on the stack to a string.  As described in the Lua documentation, this will causes problems if you're using lua_next with the same index location.
  @param idx - the index on lua stack which contains the string to check.
- @returns YES if the string can be treated as a valid UTF8 string of characters or NO if it cannot.
+ @returns YES if the string can be treated as a valid UTF8 string of characters or NO if it is not a string or if it contains invalid UTF8 byte sequences.
  */
 - (BOOL)isValidUTF8AtIndex:(int)idx ;
+
+/** Loads a module and places its return value (usually a table of functions) on the stack.
+
+ @note This method performs the equivalent of the lua command `require(...)` and places the return value (usually a table of functions) on the stack, or an error string on the stack if it was unable to load the specified module.
+ @param moduleName - the name of the module to load.
+ @returns YES if the module loaded successfully or NO if it does not.
+ */
+- (BOOL)requireModule:(char *)moduleName ;
 
 @end
 

--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -23,6 +23,18 @@
 #define LS_TUSERDATA      1 << 8
 #define LS_TNONE          1 << 9
 
+typedef int (*pushNSHelperFunction) (lua_State *L, id obj);
+typedef struct pushNSHelpers {
+  const char            *name;
+  pushNSHelperFunction  func;
+} pushNSHelpers;
+
+typedef id (*tableHelperFunction) (lua_State *L, int idx) ;
+typedef struct tableHelpers {
+  const char          *name ;
+  tableHelperFunction func ;
+} tableHelpers ;
+
 @interface LuaSkin : NSObject {
     lua_State *_L;
 }
@@ -65,19 +77,19 @@
  @code
  // First push a reference to the Lua function you want to call
  lua_rawgeti(L, LUA_REGISTRYINDEX, fnRef);
- 
+
  // Then push the parameters for that function, in order
  lua_pushnumber(L, 1);
- 
+
  // Finally, call protectedCallAndTraceback, telling it how
  // many arguments you pushed, and how many results you expect
  BOOL result = [luaSkin protectedCallAndTraceback:1 nresults:0];
- 
+
  // The boolean return tells you whether the Lua code threw
  // an exception or not
  if (!result) handleSomeError();
  @endcode
- 
+
  @return NO if the Lua code threw an exception, otherwise YES
  @param nargs An integer specifying how many function arguments you have pushed onto the stack
  @param nresults An integer specifying how many return values the Lua function will push onto the stack
@@ -110,7 +122,7 @@
 /** Defines a Lua library that creates objects, which have methods
  @code
  char *libraryName = "shinyLibrary";
- 
+
  static const luaL_Reg myShinyLibrary[] = {
  {"newObject", function_createObject},
  {NULL, NULL} // Library arrays must always end with this
@@ -138,7 +150,7 @@
 - (int)registerLibraryWithObject:(char *)libraryName functions:(const luaL_Reg *)functions metaFunctions:(const luaL_Reg *)metaFunctions objectFunctions:(const luaL_Reg *)objectFunctions;
 
 /** Stores a reference to the object at the top of the Lua stack, in the supplied table, and pops the object off the stack
- 
+
  @note This method is functionally analogous to luaL_ref(), it just takes care of pushing the supplied table ref onto the stack, and removes it afterwards
 
  @param refTable - An integer reference to a table (e.g. the result of a previous luaRef on a table object)
@@ -147,9 +159,9 @@
 - (int)luaRef:(int)refTable;
 
 /** Removes a reference from the supplied table
- 
+
  @note This method is functionally analogous to luaL_unref(), it just takes care of pushing the supplied table ref onto the Lua stack, and removes it afterwards
- 
+
  @param refTable - An integer reference to a table (e.g the result of a previous luaRef on a table object)
  @param ref - An integer reference for an object that should be removed from the refTable table
  @return An integer, always LUA_NOREF (you are advised to store this value in the variable containing the ref parameter, so it does not become a stale reference)
@@ -157,9 +169,9 @@
 - (int)luaUnref:(int)refTable ref:(int)ref;
 
 /** Pushes a stored reference onto the Lua stack
- 
+
  @note This method is functionally analogous to lua_rawgeti(), it just takes care of pushing the supplied table ref onto the Lua stack, and removes it afterwards
- 
+
  @param refTable - An integer reference to a table (e.h. the result of a previous luaRef on a table object)
  @param ref - An integer reference for an object that should be pushed onto the stack
  @return An integer containing the Lua type of the object pushed onto the stack
@@ -167,16 +179,144 @@
 - (int)pushLuaRef:(int)refTable ref:(int)ref;
 
 /** Ensures a Lua->C call has the right arguments
- 
+
  @note If the arguments are incorrect, this call will never return and the user will get a nice Lua traceback instead.
  @note Each argument can use boolean OR's to allow multiple types to be accepted (e.g. LS_TNIL | LS_TBOOLEAN).
  @note Each argument can be OR'd with LS_TOPTIONAL to indicate that the argument is optional.
  @note LS_TUSERDATA arguments should be followed by a string containing the metatable tag name (e.g. "hs.screen" for objects from hs.screen)
- 
+
  @param firstArg - An integer that defines the first acceptable Lua argument type. Possible values are LS_TNIL, LS_TBOOLEAN, LS_TNUMBER, LS_TSTRING, LS_TTABLE, LS_TFUNCTION, LS_TUSERDATA, LS_TBREAK
  @param ... - One or more integers that define the remaining acceptable Lua argument types. See the previous parameter for possible values. The final value MUST be LS_TBREAK, to indicate the end of the list.
  */
 - (void)checkArgs:(int)firstArg, ...;
 
-//TODO: Add methods for converting Lua<->objc types
+/** Pushes an NSObject to the lua stack
+
+ @note This method takes an NSObject and checks its class against registered classes and then against the built in defaults
+     to determine the best way to represent it in Lua.  This variant attempts to preserver the numerical value of NSNumber
+     when it encapsulates an unsigned long long by converting it to a lua number (real).
+ @note The default classes are (in order): NSNull, NSNumber, NSString, NSData, NSDate, NSArray, NSSet, NSDictionary, and NSObject.  This last is a catch all and will return a string of the NSObjects description method.
+ @param obj - an NSObject
+ @return The number of items on the lua stack - this is always 1 but is returned to simplify its use in Hammerspoon modules.
+ */
+- (int)pushNSObject:(id)obj ;
+
+/** Pushes an NSObject to the lua stack and optionally preserves the bits rather then the numerical value of unsigned long long NSNumbers.
+
+ @note This method takes an NSObject and checks its class against registered classes and then against the built in defaults
+     to determine the best way to represent it in Lua.  This variant can optionally preserve the bit pattern of unsigned
+     long long NSNumbers rather than the numerical value.
+ @note The default classes are (in order): NSNull, NSNumber, NSString, NSData, NSDate, NSArray, NSSet, NSDictionary, and NSObject.  This last is a catch all and will return a string of the NSObjects description method.
+ @param obj - an NSObject
+ @param bitsFlag - YES if bits are to be preserved at all costs, NO if an unsigned long long > 0x7fffffff should be treated as a number.
+ @return The number of items on the lua stack - this is always 1 but is returned to simplify its use in Hammerspoon modules.
+ */
+- (int)pushNSObject:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag ;
+
+/** Register a helper function for converting an NSObject to its lua equivalant.
+
+ @note This method allows registering a new NSObject class for conversion by allowing a module to register a helper function.
+ @param helperFN - a function of the type 'int (*pushNSHelperFunction) (lua_State *L, id obj)'  If this parameter is nil, any existing helper for the specified class is removed.
+ @param className - a string containing the class name of the NSObject type this function can convert.
+ */
+- (void)registerPushNSHelper:(pushNSHelperFunction)helperFN forClass:(char *)className ;
+
+/** Push an NSRect onto the lua stack as a lua geometry object (table with x,y,h, and w keys)
+
+ @note This is included as a separate method because NSRect is a structure, not an NSObject.
+ @param theRect - the rectangle to push onto the lua stack.
+ @returns The number of items on the lua stack - this is always 1 but is returned to simplify its use in Hammerspoon modules.
+ */
+- (int)pushNSRect:(NSRect)theRect ;
+
+/** Push an NSPoint onto the lua stack as a lua geometry object (table with x and y keys)
+
+ @note This is included as a separate method because NSPoint is a structure, not an NSObject.
+ @param thePoint - the point to push onto the lua stack.
+ @returns The number of items on the lua stack - this is always 1 but is returned to simplify its use in Hammerspoon modules.
+ */
+- (int)pushNSPoint:(NSPoint)thePoint ;
+
+/** Push an NSSize onto the lua stack as a lua geometry object (table with w and h keys)
+
+ @note This is included as a separate method because NSSize is a structure, not an NSObject.
+ @param theSize - the point to push onto the lua stack.
+ @returns The number of items on the lua stack - this is always 1 but is returned to simplify its use in Hammerspoon modules.
+ */
+- (int)pushNSSize:(NSSize)theSize ;
+
+/** Return an NSObject containing the best representation of the lua data structure at the specified index.
+
+ @note In general, it is probably best to use the lua C-API for getting the specific data you require - this method is provided for cases where acceptable data types are more easily vetted by the receiver than in a modules code.  Examples include hs.settings and hs.json.
+ @note This variant does not support self-referential tables (i.e. tables which contain themselves as a reference).
+ @note If a table contians only consecutive numerical indexes which start at 1, the table is converted to an NSArray; otherwise it is converted into an NSDictionary.
+ @note If a string contains only bytes representing valid UTF8 characters, it is converted to an NSString; otherwise it is converted into an NSData.
+ @param idx - the index on lua stack which contains the data to convert.
+ @returns An NSObject of the appropriate type depending upon the data on the lua stack.
+ */
+- (id)toNSObjectAtIndex:(int)idx ;
+
+/** Return an NSObject containing the best representation of the lua data structure at the specified index.
+
+ @note In general, it is probably best to use the lua C-API for getting the specific data you require - this method is provided for cases where acceptable data types are more easily vetted by the receiver than in a modules code.  Examples include hs.settings and hs.json.
+ @note This variant does not support self-referential tables (i.e. tables which contain themselves as a reference).
+ @note If a table contians only consecutive numerical indexes which start at 1, the table is converted to an NSArray; otherwise it is converted into an NSDictionary.
+ @note If a string contains only bytes representing valid UTF8 characters, it is converted to an NSString; otherwise it is converted into an NSData.
+ @param idx - the index on lua stack which contains the data to convert.
+ @param allow - YES indicates that self-referential tables (i.e. tables which contain themselves as a reference) are allowed; NO if they are not.
+ @returns An NSObject of the appropriate type depending upon the data on the lua stack.
+ */
+- (id)toNSObjectAtIndex:(int)idx allowSelfReference:(BOOL)allow ;
+
+
+/** Return an NSObject containing the best representation of the lua table at the specified index.
+
+ @note This method uses registerd converter functions provided by the Hammerspoon modules to convert the specified table into a recognizable NSObject.  No converters are included within the LuaSkin.  This method relies upon functions registered with the registerTableHelper:forClass: method for the conversions.
+ @param idx - the index on lua stack which contains the table to convert.
+ @param className - a string containing the class name of the NSObject type to return.  If no converter function is currently registered for this type, nil is returned.
+ @returns An NSObject of the appropriate type depending upon the data on the lua stack and the functions currently registered.
+ */
+- (id)tableAtIndex:(int)idx toClass:(char *)className ;
+
+/** Register a tableAtIndex:toClass: conversion helper function for the specified class.
+
+ @note This method registers a converter functions for use with the tableAtIndex:toClass: method for converting lua tables into NSObjects.
+ @param helperFN - a function of the type 'id (*tableHelperFunction) (lua_State *L, int idx)'  If this parameter is nil, any existing helper for the specified class is removed.
+ @param className - a string containing the class name of the NSObject type this function can convert.
+ */
+- (void)registerTableHelper:(tableHelperFunction)helperFN forClass:(char *)className ;
+
+/** Convert a lua geometry object (table with x,y,h, and w keys) into an NSRect
+
+ @note This is included as a separate method because NSRect is a structure, not an NSObject.
+ @param idx - the index on lua stack which contains the table to convert.
+ @returns An NSRect created from the specified table.
+ */
+- (NSRect)tableToRectAtIndex:(int)idx ;
+
+/** Convert a lua geometry object (table with x and y keys) into an NSPoint
+
+ @note This is included as a separate method because NSPoint is a structure, not an NSObject.
+ @param idx - the index on lua stack which contains the table to convert.
+ @returns An NSPoint created from the specified table.
+ */
+- (NSPoint)tableToPointAtIndex:(int)idx ;
+
+/** Convert a lua geometry object (table with h and w keys) into an NSSize
+
+ @note This is included as a separate method because NSSize is a structure, not an NSObject.
+ @param idx - the index on lua stack which contains the table to convert.
+ @returns An NSSize created from the specified table.
+ */
+- (NSSize)tableToSizeAtIndex:(int)idx ;
+
+/** Determines if the string in the lua stack is valid UTF8 or not.
+
+ @note This method is used internally to determine if a string should be treated as an NSString or an NSData object.  It is included as a public method because it has uses outside of this as well.
+ @param idx - the index on lua stack which contains the string to check.
+ @returns YES if the string can be treated as a valid UTF8 string of characters or NO if it cannot.
+ */
+- (BOOL)isValidUTF8AtIndex:(int)idx ;
+
 @end
+

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -8,11 +8,64 @@
 
 #import "Skin.h"
 
+// maxn   returns the largest numeric key in the table
+// countn returns the number of items of any key type in the table
+
+// Shamelessly "borrowed" and tweaked from the lua 5.1 source... see http://www.lua.org/source/5.1/ltablib.c.html
+static lua_Integer maxn (lua_State *L, int idx) {
+  lua_Integer max = 0;
+  luaL_checktype(L, idx, LUA_TTABLE);
+  lua_pushnil(L);  /* first key */
+  while (lua_next(L, idx)) {
+    lua_pop(L, 1);  /* remove value */
+    if (lua_type(L, -1) == LUA_TNUMBER && lua_isinteger(L, -1)) {
+      lua_Integer v = lua_tointeger(L, -1);
+      if (v > max) max = v;
+    }
+  }
+  return max ;
+}
+
+static lua_Integer countn (lua_State *L, int idx) {
+  lua_Integer max = 0;
+  luaL_checktype(L, idx, LUA_TTABLE);
+  lua_pushnil(L);  /* first key */
+  while (lua_next(L, idx)) {
+    lua_pop(L, 1);  /* remove value */
+    max++ ;
+  }
+  return max ;
+}
+
+// Extension to LuaSkin class for conversion support
+@interface LuaSkin (conversionSupport)
+
+// internal methods for pushNSObject
+- (int)pushNSObject:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag
+                                alreadySeenObjects:(NSMutableDictionary *)alreadySeen ;
+- (int)pushNSNumber:(id)obj preserveBits:(BOOL)bitsOverNumber ;
+- (int)pushNSArray:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag
+                               alreadySeenObjects:(NSMutableDictionary *)alreadySeen ;
+- (int)pushNSSet:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag
+                             alreadySeenObjects:(NSMutableDictionary *)alreadySeen ;
+- (int)pushNSDictionary:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag
+                                    alreadySeenObjects:(NSMutableDictionary *)alreadySeen ;
+
+// internal methods for toNSObjectAtIndex
+- (id)toNSObjectAtIndex:(int)idx alreadySeenObjects:(NSMutableDictionary *)alreadySeen
+                                   allowSelfReference:(BOOL)allow ;
+- (id)tableAtIndex:(int)idx alreadySeenObjects:(NSMutableDictionary *)alreadySeen
+                              allowSelfReference:(BOOL)allow;
+@end
+
 @implementation LuaSkin
 
 #pragma mark - Skin Properties
 
 @synthesize L = _L;
+
+NSMutableDictionary *registeredNSHelperFunctions ;
+NSMutableDictionary *registeredTableHelperFunctions ;
 
 #pragma mark - Class lifecycle
 
@@ -21,6 +74,8 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         sharedLuaSkin = [[self alloc] init];
+        registeredNSHelperFunctions = [[NSMutableDictionary alloc] init] ;
+        registeredTableHelperFunctions = [[NSMutableDictionary alloc] init] ;
     });
     if (![NSThread isMainThread]) {
         NSLog(@"GRAVE BUG: LUA EXECUTION ON NON-MAIN THREAD");
@@ -131,7 +186,7 @@
     lua_pushvalue(_L, -1);
     lua_setfield(_L, -2, "__index");
     lua_setfield(_L, LUA_REGISTRYINDEX, libraryName);
-    
+
     int moduleRefTable = [self registerLibrary:functions metaFunctions:metaFunctions];
 
     return moduleRefTable;
@@ -256,6 +311,415 @@ nextarg:
     if (idx != numArgs) {
         luaL_error(_L, "ERROR: incorrect number of arguments. Expected %d, got %d", idx, numArgs);
     }
+}
+
+#pragma mark - Methods for pushing NSObjects to the Lua Stack
+
+- (int)pushNSObject:(id)obj { return [self pushNSObject:obj preserveBitsInNSNumber:NO] ; }
+
+- (int)pushNSObject:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag {
+    NSMutableDictionary *alreadySeen = [[NSMutableDictionary alloc] init] ;
+
+    [self pushNSObject:obj preserveBitsInNSNumber:bitsFlag
+                               alreadySeenObjects:alreadySeen];
+
+    for (id entry in alreadySeen) {
+        luaL_unref(_L, LUA_REGISTRYINDEX, [[alreadySeen objectForKey:entry] intValue]) ;
+    }
+    return 1 ;
+}
+
+- (void)registerPushNSHelper:(pushNSHelperFunction)helperFN forClass:(char*)className {
+
+    if (className)
+        [registeredNSHelperFunctions setObject:[NSValue valueWithPointer:(void *)helperFN]
+                                        forKey:[NSString stringWithUTF8String:className]] ;
+    else
+        [registeredNSHelperFunctions removeObjectForKey:[NSString stringWithUTF8String:className]] ;
+}
+
+- (int)pushNSRect:(NSRect)theRect {
+    lua_newtable(_L) ;
+    lua_pushnumber(_L, theRect.origin.x) ; lua_setfield(_L, -2, "x") ;
+    lua_pushnumber(_L, theRect.origin.y) ; lua_setfield(_L, -2, "y") ;
+    lua_pushnumber(_L, theRect.size.height) ; lua_setfield(_L, -2, "w") ;
+    lua_pushnumber(_L, theRect.size.width) ; lua_setfield(_L, -2, "h") ;
+    return 1;
+}
+
+- (int)pushNSPoint:(NSPoint)thePoint {
+    lua_newtable(_L) ;
+    lua_pushnumber(_L, thePoint.x) ; lua_setfield(_L, -2, "x") ;
+    lua_pushnumber(_L, thePoint.y) ; lua_setfield(_L, -2, "y") ;
+    return 1;
+}
+
+- (int)pushNSSize:(NSSize)theSize {
+    lua_newtable(_L) ;
+    lua_pushnumber(_L, theSize.height) ; lua_setfield(_L, -2, "w") ;
+    lua_pushnumber(_L, theSize.width) ; lua_setfield(_L, -2, "h") ;
+    return 1;
+}
+
+#pragma mark - Methods for converting Lua objects on the stack to NSObjects
+
+- (id)toNSObjectAtIndex:(int)idx { return [self toNSObjectAtIndex:idx allowSelfReference:NO] ; }
+
+- (id)toNSObjectAtIndex:(int)idx allowSelfReference:(BOOL)allow {
+    NSMutableDictionary *alreadySeen = [[NSMutableDictionary alloc] init] ;
+
+    return [self toNSObjectAtIndex:idx alreadySeenObjects:alreadySeen allowSelfReference:allow] ;
+}
+
+- (id)tableAtIndex:(int)idx toClass:(char *)className {
+    NSString *theClass = [NSString stringWithUTF8String:(const char *)className] ;
+
+    for (id key in registeredTableHelperFunctions) {
+        if ([theClass isEqualToString:key]) {
+            tableHelperFunction theFunc = (tableHelperFunction)[[registeredTableHelperFunctions objectForKey:key] pointerValue] ;
+            return theFunc(_L, lua_absindex(_L, idx)) ;
+        }
+    }
+    return nil ;
+}
+
+- (void)registerTableHelper:(tableHelperFunction)helperFN forClass:(char*)className {
+
+    if (className)
+        [registeredTableHelperFunctions setObject:[NSValue valueWithPointer:(void *)helperFN]
+                                           forKey:[NSString stringWithUTF8String:className]] ;
+    else
+        [registeredTableHelperFunctions removeObjectForKey:[NSString stringWithUTF8String:className]] ;
+}
+
+- (NSRect)tableToRectAtIndex:(int)idx {
+    luaL_checktype(_L, idx, LUA_TTABLE);
+    CGFloat x = (lua_getfield(_L, idx, "x") != LUA_TNIL) ? luaL_checknumber(_L, -1) : 0.0 ;
+    CGFloat y = (lua_getfield(_L, idx, "y") != LUA_TNIL) ? luaL_checknumber(_L, -1) : 0.0 ;
+    CGFloat w = (lua_getfield(_L, idx, "w") != LUA_TNIL) ? luaL_checknumber(_L, -1) : 0.0 ;
+    CGFloat h = (lua_getfield(_L, idx, "h") != LUA_TNIL) ? luaL_checknumber(_L, -1) : 0.0 ;
+    lua_pop(_L, 4);
+    return NSMakeRect(x, y, w, h);
+}
+
+- (NSPoint)tableToPointAtIndex:(int)idx {
+    luaL_checktype(_L, idx, LUA_TTABLE);
+    CGFloat x = (lua_getfield(_L, idx, "x") != LUA_TNIL) ? luaL_checknumber(_L, -1) : 0.0 ;
+    CGFloat y = (lua_getfield(_L, idx, "y") != LUA_TNIL) ? luaL_checknumber(_L, -1) : 0.0 ;
+    lua_pop(_L, 2);
+    return NSMakePoint(x, y);
+}
+
+- (NSSize)tableToSizeAtIndex:(int)idx {
+    luaL_checktype(_L, idx, LUA_TTABLE);
+    CGFloat w = (lua_getfield(_L, idx, "w") != LUA_TNIL) ? luaL_checknumber(_L, -1) : 0.0 ;
+    CGFloat h = (lua_getfield(_L, idx, "h") != LUA_TNIL) ? luaL_checknumber(_L, -1) : 0.0 ;
+    lua_pop(_L, 2);
+    return NSMakeSize(w, h);
+}
+
+#pragma mark - Other Useful Tools
+
+- (BOOL)isValidUTF8AtIndex:(int)idx {
+    size_t len ;
+    unsigned char *str = (unsigned char *)lua_tolstring(_L, idx, &len) ;
+
+    size_t i = 0;
+
+    while (i < len) {
+        if (str[i] <= 0x7F) { /* 00..7F */
+            i += 1;
+        } else if (str[i] >= 0xC2 && str[i] <= 0xDF) { /* C2..DF 80..BF */
+            if (i + 1 < len) { /* Expect a 2nd byte */
+                if (str[i + 1] < 0x80 || str[i + 1] > 0xBF) return NO;
+            } else
+                return NO;
+            i += 2;
+        } else if (str[i] == 0xE0) { /* E0 A0..BF 80..BF */
+            if (i + 2 < len) { /* Expect a 2nd and 3rd byte */
+                if (str[i + 1] < 0xA0 || str[i + 1] > 0xBF) return NO;
+                if (str[i + 2] < 0x80 || str[i + 2] > 0xBF) return NO;
+            } else
+                return NO;
+            i += 3;
+        } else if (str[i] >= 0xE1 && str[i] <= 0xEC) { /* E1..EC 80..BF 80..BF */
+            if (i + 2 < len) { /* Expect a 2nd and 3rd byte */
+                if (str[i + 1] < 0x80 || str[i + 1] > 0xBF) return NO;
+                if (str[i + 2] < 0x80 || str[i + 2] > 0xBF) return NO;
+            } else
+                return NO;
+            i += 3;
+        } else if (str[i] == 0xED) { /* ED 80..9F 80..BF */
+            if (i + 2 < len) { /* Expect a 2nd and 3rd byte */
+                if (str[i + 1] < 0x80 || str[i + 1] > 0x9F) return NO;
+                if (str[i + 2] < 0x80 || str[i + 2] > 0xBF) return NO;
+            } else
+                return NO;
+            i += 3;
+        } else if (str[i] >= 0xEE && str[i] <= 0xEF) { /* EE..EF 80..BF 80..BF */
+            if (i + 2 < len) { /* Expect a 2nd and 3rd byte */
+                if (str[i + 1] < 0x80 || str[i + 1] > 0xBF) return NO;
+                if (str[i + 2] < 0x80 || str[i + 2] > 0xBF) return NO;
+            } else
+                return NO;
+            i += 3;
+        } else if (str[i] == 0xF0) { /* F0 90..BF 80..BF 80..BF */
+            if (i + 3 < len) { /* Expect a 2nd, 3rd 3th byte */
+                if (str[i + 1] < 0x90 || str[i + 1] > 0xBF) return NO;
+                if (str[i + 2] < 0x80 || str[i + 2] > 0xBF) return NO;
+                if (str[i + 3] < 0x80 || str[i + 3] > 0xBF) return NO;
+            } else
+                return NO;
+            i += 4;
+        } else if (str[i] >= 0xF1 && str[i] <= 0xF3) { /* F1..F3 80..BF 80..BF 80..BF */
+            if (i + 3 < len) { /* Expect a 2nd, 3rd 3th byte */
+                if (str[i + 1] < 0x80 || str[i + 1] > 0xBF) return NO;
+                if (str[i + 2] < 0x80 || str[i + 2] > 0xBF) return NO;
+                if (str[i + 3] < 0x80 || str[i + 3] > 0xBF) return NO;
+            } else
+                return NO;
+            i += 4;
+        } else if (str[i] == 0xF4) { /* F4 80..8F 80..BF 80..BF */
+            if (i + 3 < len) { /* Expect a 2nd, 3rd 3th byte */
+                if (str[i + 1] < 0x80 || str[i + 1] > 0x8F) return NO;
+                if (str[i + 2] < 0x80 || str[i + 2] > 0xBF) return NO;
+                if (str[i + 3] < 0x80 || str[i + 3] > 0xBF) return NO;
+            } else
+                return NO;
+            i += 4;
+        } else
+            return NO;
+    }
+    return YES;
+}
+
+#pragma mark - conversionSupport extensions to LuaSkin class
+
+- (int)pushNSObject:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag
+                                alreadySeenObjects:(NSMutableDictionary *)alreadySeen {
+
+    if (obj) {
+// NOTE: We catch self-referential loops, do we also need a recursive depth?  Will crash at depth of 512...
+        if ([alreadySeen objectForKey:obj]) {
+            lua_rawgeti(_L, LUA_REGISTRYINDEX, [[alreadySeen objectForKey:obj] intValue]) ;
+            return 1 ;
+        }
+
+        // check for registered helpers
+
+        for (id key in registeredNSHelperFunctions) {
+            if ([obj isKindOfClass: NSClassFromString(key)]) {
+                pushNSHelperFunction theFunc = (pushNSHelperFunction)[[registeredNSHelperFunctions objectForKey:key] pointerValue] ;
+                return theFunc(_L, obj) ;
+            }
+        }
+
+        // Check for built-in classes
+
+        if ([obj isKindOfClass:[NSNull class]]) {
+            lua_pushnil(_L) ;
+        } else if ([obj isKindOfClass:[NSNumber class]]) {
+            [self pushNSNumber:obj preserveBits:bitsFlag] ;
+        } else if ([obj isKindOfClass:[NSString class]]) {
+                size_t size = [(NSString *)obj lengthOfBytesUsingEncoding:NSUTF8StringEncoding] ;
+                lua_pushlstring(_L, [(NSString *)obj UTF8String], size) ;
+//             lua_pushstring(_L, [(NSString *)obj UTF8String]);
+        } else if ([obj isKindOfClass:[NSData class]]) {
+            lua_pushlstring(_L, [(NSData *)obj bytes], [(NSData *)obj length]) ;
+        } else if ([obj isKindOfClass:[NSDate class]]) {
+            lua_pushinteger(_L, lround([(NSDate *)obj timeIntervalSince1970])) ;
+        } else if ([obj isKindOfClass:[NSArray class]]) {
+            [self pushNSArray:obj preserveBitsInNSNumber:bitsFlag alreadySeenObjects:alreadySeen] ;
+        } else if ([obj isKindOfClass:[NSSet class]]) {
+            [self pushNSSet:obj preserveBitsInNSNumber:bitsFlag alreadySeenObjects:alreadySeen] ;
+        } else if ([obj isKindOfClass:[NSDictionary class]]) {
+            [self pushNSDictionary:obj preserveBitsInNSNumber:bitsFlag alreadySeenObjects:alreadySeen] ;
+        } else if ([obj isKindOfClass:[NSObject class]]) {
+            lua_pushstring(_L, [[NSString stringWithFormat:@"%@", obj] UTF8String]) ;
+        } else {
+        // shouldn't happen -- the last check, NSObject, should catch everything not yet caught, so log it.
+            NSLog(@"Uncaught NSObject type for '%@'", obj) ;
+            lua_pushstring(_L, [[NSString stringWithFormat:@"%@", obj] UTF8String]) ;
+        }
+    } else {
+        lua_pushnil(_L) ;
+    }
+    return 1 ;
+}
+
+- (int)pushNSNumber:(id)obj preserveBits:(BOOL)bitsOverNumber{
+    NSNumber    *number = obj ;
+    if (number == (id)kCFBooleanTrue)
+        lua_pushboolean(_L, YES);
+    else if (number == (id)kCFBooleanFalse)
+        lua_pushboolean(_L, NO);
+    else {
+        switch([number objCType][0]) {
+            case 'c': lua_pushinteger(_L, [number charValue]) ; break ;
+            case 'C': lua_pushinteger(_L, [number unsignedCharValue]) ; break ;
+
+            case 'i': lua_pushinteger(_L, [number intValue]) ; break ;
+            case 'I': lua_pushinteger(_L, [number unsignedIntValue]) ; break ;
+
+            case 's': lua_pushinteger(_L, [number shortValue]) ; break ;
+            case 'S': lua_pushinteger(_L, [number unsignedShortValue]) ; break ;
+
+            case 'l': lua_pushinteger(_L, [number longValue]) ; break ;
+            case 'L': lua_pushinteger(_L, (long long)[number unsignedLongValue]) ; break ;
+
+            case 'q': lua_pushinteger(_L, [number longLongValue]) ; break ;
+
+            // Lua only does signed long long, not unsigned, so we have two options
+            case 'Q': if (bitsOverNumber) {
+                          lua_pushinteger(_L, (long long)[number unsignedLongLongValue]) ;
+                      } else {
+                          if ([number unsignedLongLongValue] < 0x8000000000000000)
+                              lua_pushinteger(_L, (long long)[number unsignedLongLongValue]) ;
+                          else
+                              lua_pushnumber(_L, [number unsignedLongLongValue]) ;
+                      }
+                      break ;
+
+            case 'f': lua_pushnumber(_L,  [number floatValue]) ; break ;
+            case 'd': lua_pushnumber(_L,  [number doubleValue]) ; break ;
+
+            default:
+                NSLog(@"Unrecognized numerical type '%s' for '%@'", [number objCType], number) ;
+                lua_pushnumber(_L, [number doubleValue]) ;
+                break ;
+        }
+    }
+    return 1 ;
+}
+
+- (int)pushNSArray:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag
+                               alreadySeenObjects:(NSMutableDictionary *)alreadySeen {
+    NSArray* list = obj;
+    lua_newtable(_L);
+    [alreadySeen setObject:[NSNumber numberWithInt:luaL_ref(_L, LUA_REGISTRYINDEX)] forKey:obj] ;
+    lua_rawgeti(_L, LUA_REGISTRYINDEX, [[alreadySeen objectForKey:obj] intValue]) ; // put it back on the stack
+    for (id item in list) {
+        [self pushNSObject:item preserveBitsInNSNumber:bitsFlag
+                                    alreadySeenObjects:alreadySeen];
+        lua_rawseti(_L, -2, luaL_len(_L, -2) + 1) ;
+    }
+    return 1 ;
+}
+
+- (int)pushNSSet:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag
+                             alreadySeenObjects:(NSMutableDictionary *)alreadySeen {
+    if ([obj isKindOfClass: [NSSet class]]) {
+        NSSet* list = obj;
+        lua_newtable(_L);
+        [alreadySeen setObject:[NSNumber numberWithInt:luaL_ref(_L, LUA_REGISTRYINDEX)] forKey:obj] ;
+        lua_rawgeti(_L, LUA_REGISTRYINDEX, [[alreadySeen objectForKey:obj] intValue]) ; // put it back on the stack
+        for (id item in list) {
+            [self pushNSObject:item preserveBitsInNSNumber:bitsFlag
+                                        alreadySeenObjects:alreadySeen];
+            lua_rawseti(_L, -2, luaL_len(_L, -2) + 1) ;
+        }
+    } else {
+        lua_pushnil(_L) ; // Not an NSSet
+    }
+    return 1 ;
+}
+
+- (int)pushNSDictionary:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag
+                                    alreadySeenObjects:(NSMutableDictionary *)alreadySeen {
+    NSArray *keys = [obj allKeys];
+    NSArray *values = [obj allValues];
+    lua_newtable(_L);
+    [alreadySeen setObject:[NSNumber numberWithInt:luaL_ref(_L, LUA_REGISTRYINDEX)] forKey:obj] ;
+    lua_rawgeti(_L, LUA_REGISTRYINDEX, [[alreadySeen objectForKey:obj] intValue]) ; // put it back on the stack
+    for (unsigned long i = 0; i < [keys count]; i++) {
+        [self pushNSObject:[keys objectAtIndex:i] preserveBitsInNSNumber:bitsFlag
+                                                      alreadySeenObjects:alreadySeen];
+        [self pushNSObject:[values objectAtIndex:i] preserveBitsInNSNumber:bitsFlag
+                                                        alreadySeenObjects:alreadySeen];
+        lua_settable(_L, -3);
+    }
+    return 1 ;
+}
+
+- (id)toNSObjectAtIndex:(int)idx
+       alreadySeenObjects:(NSMutableDictionary *)alreadySeen
+       allowSelfReference:(BOOL)allow {
+
+    int realIndex = lua_absindex(_L, idx) ;
+    NSMutableArray *seenObject = [alreadySeen objectForKey:[NSValue valueWithPointer:lua_topointer(_L, idx)]] ;
+    if (seenObject) {
+        if ([[seenObject lastObject] isEqualToNumber:@(NO)] && allow == NO) {
+            luaL_error(_L, "lua table cannot contain self-references") ;
+            return nil ;
+        } else {
+            return [seenObject firstObject] ;
+        }
+    }
+    switch (lua_type(_L, realIndex)) {
+        case LUA_TNUMBER:
+            if (lua_isinteger(_L, idx))
+                return @(lua_tointeger(_L, idx)) ;
+            else
+                return @(lua_tonumber(_L, idx));
+            break ;
+        case LUA_TSTRING:
+            if ([self isValidUTF8AtIndex:idx]) {
+                size_t size ;
+                unsigned char *string = (unsigned char *)lua_tolstring(_L, idx, &size) ;
+                return [[NSString alloc] initWithData:[NSData dataWithBytes:(void *)string length:size] encoding: NSUTF8StringEncoding] ;
+//                 return [NSString stringWithUTF8String:(char *)lua_tostring(_L, idx)];
+            } else {
+                size_t size ;
+                unsigned char *junk = (unsigned char *)lua_tolstring(_L, idx, &size) ;
+                return [NSData dataWithBytes:(void *)junk length:size] ;
+            }
+            break ;
+        case LUA_TNIL:
+            return [NSNull null] ;
+            break ;
+        case LUA_TBOOLEAN:
+            return lua_toboolean(_L, idx) ? (id)kCFBooleanTrue : (id)kCFBooleanFalse;
+            break ;
+        case LUA_TTABLE:
+            return [self tableAtIndex:realIndex alreadySeenObjects:alreadySeen allowSelfReference:allow] ;
+            break ;
+        default:
+            return [NSString stringWithFormat:@"%s", luaL_tolstring(_L, idx, NULL)];
+            break ;
+    }
+}
+
+- (id)tableAtIndex:(int)idx alreadySeenObjects:(NSMutableDictionary *)alreadySeen
+                              allowSelfReference:(BOOL)allow {
+    id result ;
+
+    if (maxn(_L, lua_absindex(_L, idx)) == countn(_L, lua_absindex(_L, idx))) {
+        result = (NSMutableArray *) [[NSMutableArray alloc] init] ;
+    } else {
+        result = (NSMutableDictionary *) [[NSMutableDictionary alloc] init] ;
+    }
+    [alreadySeen setObject:@[result, @(NO)] forKey:[NSValue valueWithPointer:lua_topointer(_L, idx)]] ;
+
+    if ([result isKindOfClass: [NSArray class]]) {
+        lua_Integer tableLength = countn(_L, lua_absindex(_L, idx)) ;
+        for (lua_Integer i = 0; i < tableLength ; i++) {
+            lua_geti(_L, lua_absindex(_L, idx), i + 1) ;
+            id val = [self toNSObjectAtIndex:-1 alreadySeenObjects:alreadySeen allowSelfReference:allow] ;
+            [result addObject:val] ;
+            lua_pop(_L, 1) ;
+        }
+    } else {
+        lua_pushnil(_L);
+        while (lua_next(_L, lua_absindex(_L, idx)) != 0) {
+            id key = [self toNSObjectAtIndex:-2 alreadySeenObjects:alreadySeen allowSelfReference:allow] ;
+            id val = [self toNSObjectAtIndex:lua_gettop(_L) alreadySeenObjects:alreadySeen allowSelfReference:allow] ;
+            [result setValue:val forKey:key];
+            lua_pop(_L, 1);
+        }
+    }
+
+    [alreadySeen setObject:@[result, @(YES)] forKey:[NSValue valueWithPointer:lua_topointer(_L, idx)]] ;
+    return result ;
 }
 
 @end

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -313,7 +313,7 @@ nextarg:
     }
 }
 
-#pragma mark - Methods for pushing NSObjects to the Lua Stack
+#pragma mark - Conversion from NSObjects into Lua objects
 
 - (int)pushNSObject:(id)obj { return [self pushNSObject:obj preserveBitsInNSNumber:NO] ; }
 
@@ -361,7 +361,7 @@ nextarg:
     return 1;
 }
 
-#pragma mark - Methods for converting Lua objects on the stack to NSObjects
+#pragma mark - Conversion from lua objects into NSObjects
 
 - (id)toNSObjectAtIndex:(int)idx { return [self toNSObjectAtIndex:idx allowSelfReference:NO] ; }
 
@@ -418,9 +418,11 @@ nextarg:
     return NSMakeSize(w, h);
 }
 
-#pragma mark - Other Useful Tools
+#pragma mark - Other helpers
 
 - (BOOL)isValidUTF8AtIndex:(int)idx {
+    if (lua_type(_L, idx) != LUA_TSTRING && lua_type(_L, idx) != LUA_TNUMBER) return NO ;
+
     size_t len ;
     unsigned char *str = (unsigned char *)lua_tolstring(_L, idx, &len) ;
 
@@ -491,6 +493,11 @@ nextarg:
             return NO;
     }
     return YES;
+}
+
+- (BOOL)requireModule:(char *)moduleName {
+    lua_getglobal(_L, "require"); lua_pushstring(_L, moduleName) ;
+    return [self protectedCallAndTraceback:1 nresults:1] ;
 }
 
 #pragma mark - conversionSupport extensions to LuaSkin class

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -150,9 +150,11 @@ NSMutableDictionary *registeredTableHelperFunctions ;
     lua_insert(_L, tracebackPosition);
 
     if (lua_pcall(_L, nargs, nresults, tracebackPosition) != LUA_OK) {
+        lua_remove(_L, -2) ; // remove the message handler
         return NO;
     }
 
+    lua_remove(_L, -nresults - 1) ; // remove the message handler
     return YES;
 }
 

--- a/extensions/application/internal.m
+++ b/extensions/application/internal.m
@@ -860,7 +860,22 @@ static const luaL_Reg applicationlib[] = {
     {NULL, NULL}
 };
 
+static int nsrunningapplication_tolua(lua_State *L, id obj) {
+    NSRunningApplication *app = obj ;
+
+    if (!new_application(L, [app processIdentifier])) {
+        lua_pop(L, 1) ; // removed aborted userdata
+        lua_pushstring(L, [[NSString stringWithFormat:@"No PID: %@", obj] UTF8String]) ;
+    }
+    return 1 ;
+}
+
 int luaopen_hs_application_internal(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared];
+
+    [skin registerPushNSHelper:nsrunningapplication_tolua
+                      forClass:"NSRunningApplication"] ;
+
     luaL_newlib(L, applicationlib);
 
     // Inherit hs.uielement

--- a/extensions/json/internal.m
+++ b/extensions/json/internal.m
@@ -1,127 +1,6 @@
 #import <Cocoa/Cocoa.h>
 #import <LuaSkin/LuaSkin.h>
 
-// The following two functions will go away someday (soon I hope) and be found in the core
-// app of hammerspoon because they are just so darned useful in so many contexts... but they
-// have serious limitations as well, and I need to work to clear those... it's an absolute
-// requirement for this module, and the way this module is being used *shouldn't* trip the
-// issues unless someone absolutely tries to screw them up... and all it does is
-// crash Hammerspoon when it happens, so...
-
-static id lua_to_NSObject(lua_State* L, int idx) {
-    idx = lua_absindex(L,idx);
-    switch (lua_type(L, idx)) {
-        case LUA_TNUMBER: return @(lua_tonumber(L, idx));
-        case LUA_TSTRING: return [NSString stringWithUTF8String: lua_tostring(L, idx)];
-        case LUA_TNIL: return [NSNull null];
-        case LUA_TBOOLEAN: return lua_toboolean(L, idx) ? (id)kCFBooleanTrue : (id)kCFBooleanFalse;
-        case LUA_TTABLE: {
-            NSMutableDictionary* numerics = [NSMutableDictionary dictionary];
-            NSMutableDictionary* nonNumerics = [NSMutableDictionary dictionary];
-            NSMutableIndexSet*   numericKeys = [NSMutableIndexSet indexSet];
-            NSMutableArray*      numberArray = [NSMutableArray array];
-            lua_pushnil(L);
-            while (lua_next(L, idx) != 0) {
-                id key = lua_to_NSObject(L, -2);
-                id val = lua_to_NSObject(L, lua_gettop(L));
-                if ([key isKindOfClass: [NSNumber class]]) {
-                    [numericKeys addIndex:[key intValue]];
-                    [numerics setValue:val forKey:key];
-                } else {
-                    [nonNumerics setValue:val forKey:key];
-                }
-                lua_pop(L, 1);
-            }
-            if (numerics.count > 0) {
-                for (unsigned long i = 1; i <= [numericKeys lastIndex]; i++) {
-                    [numberArray addObject:(
-                        [numerics objectForKey:[NSNumber numberWithInteger:i]] ?
-                            [numerics objectForKey:[NSNumber numberWithInteger:i]] : [NSNull null]
-                    )];
-                }
-                if (nonNumerics.count == 0)
-                    return [numberArray copy];
-            } else {
-                return [nonNumerics copy];
-            }
-            NSMutableDictionary* unionBlob = [NSMutableDictionary dictionary];
-            [unionBlob setValue:[NSArray arrayWithObjects:numberArray, nonNumerics, nil] forKey:@"MJ_LUA_TABLE"];
-            return [unionBlob copy];
-        }
-        default: { lua_pushliteral(L, "non-serializable object"); lua_error(L); }
-    }
-    return nil;
-}
-
-static void NSObject_to_lua(lua_State* L, id obj) {
-    if (obj == nil || [obj isEqual: [NSNull null]]) { lua_pushnil(L); }
-    else if ([obj isKindOfClass: [NSDictionary class]]) {
-        BOOL handled = NO;
-        if ([obj count] == 1) {
-            if ([obj objectForKey:@"MJ_LUA_NIL"]) {
-                lua_pushnil(L);
-                handled = YES;
-            } else
-            if ([obj objectForKey:@"MJ_LUA_TABLE"]) {
-                NSArray* parts = [obj objectForKey:@"MJ_LUA_TABLE"] ;
-                NSArray* numerics = [parts objectAtIndex:0] ;
-                NSDictionary* nonNumerics = [parts objectAtIndex:1] ;
-                lua_newtable(L);
-                int i = 0;
-                for (id item in numerics) {
-                    NSObject_to_lua(L, item);
-                    lua_rawseti(L, -2, ++i);
-                }
-                NSArray *keys = [nonNumerics allKeys];
-                NSArray *values = [nonNumerics allValues];
-                for (unsigned long i = 0; i < keys.count; i++) {
-                    NSObject_to_lua(L, [keys objectAtIndex:i]);
-                    NSObject_to_lua(L, [values objectAtIndex:i]);
-                    lua_settable(L, -3);
-                }
-                handled = YES;
-            }
-        }
-        if (!handled) {
-            NSArray *keys = [obj allKeys];
-            NSArray *values = [obj allValues];
-            lua_newtable(L);
-            for (unsigned long i = 0; i < keys.count; i++) {
-                NSObject_to_lua(L, [keys objectAtIndex:i]);
-                NSObject_to_lua(L, [values objectAtIndex:i]);
-                lua_settable(L, -3);
-            }
-        }
-    } else if ([obj isKindOfClass: [NSNumber class]]) {
-        NSNumber* number = obj;
-        if (number == (id)kCFBooleanTrue)
-            lua_pushboolean(L, YES);
-        else if (number == (id)kCFBooleanFalse)
-            lua_pushboolean(L, NO);
-        else if (CFNumberIsFloatType((CFNumberRef)number))
-            lua_pushnumber(L, [number doubleValue]);
-        else
-            lua_pushinteger(L, [number intValue]);
-    } else if ([obj isKindOfClass: [NSString class]]) {
-        NSString* string = obj;
-        lua_pushstring(L, [string UTF8String]);
-    } else if ([obj isKindOfClass: [NSArray class]]) {
-        int i = 0;
-        NSArray* list = obj;
-        lua_newtable(L);
-        for (id item in list) {
-            NSObject_to_lua(L, item);
-            lua_rawseti(L, -2, ++i);
-        }
-    } else if ([obj isKindOfClass: [NSDate class]]) {
-        lua_pushnumber(L, [(NSDate *) obj timeIntervalSince1970]);
-    } else if ([obj isKindOfClass: [NSData class]]) {
-        lua_pushlstring(L, [obj bytes], [obj length]) ;
-    } else {
-        lua_pushstring(L, [[NSString stringWithFormat:@"<Object> : %@", obj] UTF8String]) ;
-    }
-}
-
 /// hs.json.encode(val[, prettyprint]) -> string
 /// Function
 /// Encodes a table as JSON
@@ -137,7 +16,7 @@ static void NSObject_to_lua(lua_State* L, id obj) {
 ///  * This is useful for storing some of the more complex lua table structures as a persistent setting (see `hs.settings`)
 static int json_encode(lua_State* L) {
     if lua_istable(L, 1) {
-        id obj = lua_to_NSObject(L, 1);
+        id obj = [[LuaSkin shared] toNSObjectAtIndex:1] ;
 
         NSJSONWritingOptions opts = 0;
         if (lua_toboolean(L, 2))
@@ -188,7 +67,7 @@ static int json_decode(lua_State* L) {
     id obj = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&error];
 
     if (obj) {
-        NSObject_to_lua(L, obj);
+        [[LuaSkin shared] pushNSObject:obj] ;
         return 1;
     }
     else {

--- a/extensions/settings/internal.m
+++ b/extensions/settings/internal.m
@@ -1,127 +1,6 @@
 #import <Cocoa/Cocoa.h>
 #import <LuaSkin/LuaSkin.h>
 
-// The following two functions will go away someday (soon I hope) and be found in the core
-// app of hammerspoon because they are just so darned useful in so many contexts... but they
-// have serious limitations as well, and I need to work to clear those... it's an absolute
-// requirement for this module, and the way this module is being used *shouldn't* trip the
-// issues unless someone absolutely tries to screw them up... and all it does is
-// crash Hammerspoon when it happens, so...
-
-static id lua_to_NSObject(lua_State* L, int idx) {
-    idx = lua_absindex(L,idx);
-    switch (lua_type(L, idx)) {
-        case LUA_TNUMBER: return @(lua_tonumber(L, idx));
-        case LUA_TSTRING: return [NSString stringWithUTF8String: lua_tostring(L, idx)];
-        case LUA_TNIL: return [NSNull null];
-        case LUA_TBOOLEAN: return lua_toboolean(L, idx) ? (id)kCFBooleanTrue : (id)kCFBooleanFalse;
-        case LUA_TTABLE: {
-            NSMutableDictionary* numerics = [NSMutableDictionary dictionary];
-            NSMutableDictionary* nonNumerics = [NSMutableDictionary dictionary];
-            NSMutableIndexSet*   numericKeys = [NSMutableIndexSet indexSet];
-            NSMutableArray*      numberArray = [NSMutableArray array];
-            lua_pushnil(L);
-            while (lua_next(L, idx) != 0) {
-                id key = lua_to_NSObject(L, -2);
-                id val = lua_to_NSObject(L, lua_gettop(L));
-                if ([key isKindOfClass: [NSNumber class]]) {
-                    [numericKeys addIndex:[key intValue]];
-                    [numerics setValue:val forKey:key];
-                } else {
-                    [nonNumerics setValue:val forKey:key];
-                }
-                lua_pop(L, 1);
-            }
-            if (numerics.count > 0) {
-                for (unsigned long i = 1; i <= [numericKeys lastIndex]; i++) {
-                    [numberArray addObject:(
-                        [numerics objectForKey:[NSNumber numberWithInteger:i]] ?
-                            [numerics objectForKey:[NSNumber numberWithInteger:i]] : [NSNull null]
-                    )];
-                }
-                if (nonNumerics.count == 0)
-                    return [numberArray copy];
-            } else {
-                return [nonNumerics copy];
-            }
-            NSMutableDictionary* unionBlob = [NSMutableDictionary dictionary];
-            [unionBlob setValue:[NSArray arrayWithObjects:numberArray, nonNumerics, nil] forKey:@"MJ_LUA_TABLE"];
-            return [unionBlob copy];
-        }
-        default: { lua_pushliteral(L, "non-serializable object"); lua_error(L); }
-    }
-    return nil;
-}
-
-static void NSObject_to_lua(lua_State* L, id obj) {
-    if (obj == nil || [obj isEqual: [NSNull null]]) { lua_pushnil(L); }
-    else if ([obj isKindOfClass: [NSDictionary class]]) {
-        BOOL handled = NO;
-        if ([obj count] == 1) {
-            if ([obj objectForKey:@"MJ_LUA_NIL"]) {
-                lua_pushnil(L);
-                handled = YES;
-            } else
-            if ([obj objectForKey:@"MJ_LUA_TABLE"]) {
-                NSArray* parts = [obj objectForKey:@"MJ_LUA_TABLE"] ;
-                NSArray* numerics = [parts objectAtIndex:0] ;
-                NSDictionary* nonNumerics = [parts objectAtIndex:1] ;
-                lua_newtable(L);
-                int i = 0;
-                for (id item in numerics) {
-                    NSObject_to_lua(L, item);
-                    lua_rawseti(L, -2, ++i);
-                }
-                NSArray *keys = [nonNumerics allKeys];
-                NSArray *values = [nonNumerics allValues];
-                for (unsigned long i = 0; i < keys.count; i++) {
-                    NSObject_to_lua(L, [keys objectAtIndex:i]);
-                    NSObject_to_lua(L, [values objectAtIndex:i]);
-                    lua_settable(L, -3);
-                }
-                handled = YES;
-            }
-        }
-        if (!handled) {
-            NSArray *keys = [obj allKeys];
-            NSArray *values = [obj allValues];
-            lua_newtable(L);
-            for (unsigned long i = 0; i < keys.count; i++) {
-                NSObject_to_lua(L, [keys objectAtIndex:i]);
-                NSObject_to_lua(L, [values objectAtIndex:i]);
-                lua_settable(L, -3);
-            }
-        }
-    } else if ([obj isKindOfClass: [NSNumber class]]) {
-        NSNumber* number = obj;
-        if (number == (id)kCFBooleanTrue)
-            lua_pushboolean(L, YES);
-        else if (number == (id)kCFBooleanFalse)
-            lua_pushboolean(L, NO);
-        else if (CFNumberIsFloatType((CFNumberRef)number))
-            lua_pushnumber(L, [number doubleValue]);
-        else
-            lua_pushinteger(L, [number intValue]);
-    } else if ([obj isKindOfClass: [NSString class]]) {
-        NSString* string = obj;
-        lua_pushstring(L, [string UTF8String]);
-    } else if ([obj isKindOfClass: [NSArray class]]) {
-        int i = 0;
-        NSArray* list = obj;
-        lua_newtable(L);
-        for (id item in list) {
-            NSObject_to_lua(L, item);
-            lua_rawseti(L, -2, ++i);
-        }
-    } else if ([obj isKindOfClass: [NSDate class]]) {
-        lua_pushnumber(L, [(NSDate *) obj timeIntervalSince1970]);
-    } else if ([obj isKindOfClass: [NSData class]]) {
-        lua_pushlstring(L, [obj bytes], [obj length]) ;
-    } else {
-        lua_pushstring(L, [[NSString stringWithFormat:@"<Object> : %@", obj] UTF8String]) ;
-    }
-}
-
 /// hs.settings.set(key, val)
 /// Function
 /// Saves a setting with common datatypes
@@ -142,8 +21,14 @@ static void NSObject_to_lua(lua_State* L, id obj) {
 ///  * This function cannot set dates or raw data types, see `hs.settings.setDate()` and `hs.settings.setData()`
 static int target_set(lua_State* L) {
     NSString* key = [NSString stringWithUTF8String: luaL_checkstring(L, 1)];
-    id val = lua_to_NSObject(L, 2);
-    [[NSUserDefaults standardUserDefaults] setObject:val forKey:key];
+    if (!key) return luaL_error(L, "key must be a valid UTF8 string") ;
+    id val = [[LuaSkin shared] toNSObjectAtIndex:2] ;
+    @try {
+        [[NSUserDefaults standardUserDefaults] setObject:val forKey:key];
+    }
+    @catch(NSException *theException) {
+        return luaL_error(L, [[NSString stringWithFormat:@"%@: %@", theException.name, theException.reason] UTF8String]);
+    }
     return 0;
 }
 
@@ -159,7 +44,8 @@ static int target_set(lua_State* L) {
 ///  * None
 static int target_setData(lua_State* L) {
     NSString* key = [NSString stringWithUTF8String: luaL_checkstring(L, 1)];
-    if (lua_type(L,2) == LUA_TSTRING) {
+        if (!key) return luaL_error(L, "key must be a valid UTF8 string") ;
+        if (lua_type(L,2) == LUA_TSTRING) {
         const char* data = lua_tostring(L,2) ;
         NSUInteger sz = lua_rawlen(L, 2) ;
         NSData* myData = [[NSData alloc] initWithBytes:data length:sz] ;
@@ -198,6 +84,7 @@ static NSDate* date_from_string(NSString* dateString) {
 ///  * See `hs.settings.dateFormat` for a convenient representation of the RFC3339 format, to use with other time/date related functions
 static int target_setDate(lua_State* L) {
     NSString* key = [NSString stringWithUTF8String: luaL_checkstring(L, 1)];
+    if (!key) return luaL_error(L, "key must be a valid UTF8 string") ;
     NSDate* myDate = lua_isnumber(L, 2) ? [[NSDate alloc] initWithTimeIntervalSince1970:(NSTimeInterval) lua_tonumber(L,2)] :
                      lua_isstring(L, 2) ? date_from_string([NSString stringWithUTF8String:lua_tostring(L, 2)]) : nil ;
     if (myDate) {
@@ -222,8 +109,9 @@ static int target_setDate(lua_State* L) {
 ///  * This function can load all of the datatypes supported by `hs.settings.set()`, `hs.settings.setData()` and `hs.settings.setDate()`
 static int target_get(lua_State* L) {
     NSString* key = [NSString stringWithUTF8String: luaL_checkstring(L, 1)];
+    if (!key) return luaL_error(L, "key must be a valid UTF8 string") ;
     id val = [[NSUserDefaults standardUserDefaults] objectForKey:key];
-    NSObject_to_lua(L, val);
+    [[LuaSkin shared] pushNSObject:val] ;
     return 1;
 }
 
@@ -238,6 +126,7 @@ static int target_get(lua_State* L) {
 ///  * A boolean, true if the setting was deleted, otherwise false
 static int target_clear(lua_State* L) {
     NSString* key = [NSString stringWithUTF8String: luaL_checkstring(L, 1)];
+    if (!key) return luaL_error(L, "key must be a valid UTF8 string") ;
     if ([[NSUserDefaults standardUserDefaults] objectForKey:key] && ![[NSUserDefaults standardUserDefaults] objectIsForcedForKey:key]) {
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
         lua_pushboolean(L, YES) ;
@@ -263,10 +152,10 @@ static int target_getKeys(lua_State* L) {
     NSArray *keys = [[[NSUserDefaults standardUserDefaults] persistentDomainForName: [[NSBundle mainBundle] bundleIdentifier]] allKeys];
     lua_newtable(L);
     for (unsigned long i = 0; i < keys.count; i++) {
-        lua_pushinteger(L, i+1) ;
-        NSObject_to_lua(L, [keys objectAtIndex:i]);
+        lua_pushinteger(L, (lua_Integer)i+1) ;
+        [[LuaSkin shared] pushNSObject:[keys objectAtIndex:i]] ;
         lua_settable(L, -3);
-        NSObject_to_lua(L, [keys objectAtIndex:i]);
+        [[LuaSkin shared] pushNSObject:[keys objectAtIndex:i]] ;
         lua_pushboolean(L, YES) ;
         lua_settable(L, -3);
     }


### PR DESCRIPTION
##### Conversion from NSObjects into Lua objects
* `- (int)pushNSObject:(id)obj ;`
  converts an NSObject into the closest lua equivalent. Built-in convertors exist for:

  From               | To
  ------------------ | ---------
  NSString           | string
  NSData             | string
  NSNumber           | number or integer
  NSDictionary       | table
  NSArray            | array (note NSArray indexes start at 0, lua arrays at 1.  This preserves the array concept, so numerically the indexes shift by 1, but their position and use in loop structures does not.)
  NSSet              | array
  NSNull (nil, NULL) | nil
  NSObject           | string -- this is the fallback if no other match is found and converts the object into a string from the objects description method (what NSLog would output for %@)
  Other converters can be registered by modules and they will be checked before the above.

* `(int)pushNSObject:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag ;`
  Variant which optionally preserves bits rather than closest signed equivalent of numeric value for an NSNumber of type unsigned long long (the above sets bitsFlag to NO)

* `- (void)registerPushNSHelper:(pushNSHelperFunction)helperFN forClass:(char *)className ;`
  Register a special helper for a specific class.  The function should match this signature: `int function(lua_State *L, id obj)`. Registering the same className twice will overwrite the existing helper function -- specify nil as the function to remove the existing helper function.

* `- (int)pushNSRect:(NSRect)theRect ;`

* `- (int)pushNSPoint:(NSPoint)thePoint ;`

* `- (int)pushNSSize:(NSSize)theSize ;`
  NSRect (CGRect), NSPoint (CGPoint), and NSSize (CGSize) are actually structs, but common enough for their own converters.

##### Conversion from lua objects into NSObjects
* `- (id)toNSObjectAtIndex:(int)idx ;`
  Converts the item at the specified stack index from Lua into it's closest equivalent NSObject.  Built in converters exist for:

  From               | To
  ------------------ | ---------
  table  | NSDictionary or NSArray if all indexes are numeric and the number of items in the table == the largest key (index) in the table -- again, this preserves the array concept at the expense of sparse arrays which are challenging in Lua in their own right to iterate.
  number | NSNumber as float or integer
  string | NSString or NSData if the string cannot be fully expressed as valid UTF8
  nil    | NSNull
  other  | userdata, thread, function, etc. get convrted to NSString as their `tostring()` output

* `- (id)toNSObjectAtIndex:(int)idx allowSelfReference:(BOOL)allow ;`
  Variant of the above which optionally allows you to allow self-reference in tables being converted.  The above calls this with allowSelfReference equal to NO.

* `- (id)tableAtIndex:(int)idx toClass:(char *)className ;`
  Converts a table into an instance of the specified NSObject class.  Requires a helper to be registered first -- there are none pre-defined at present.  This has to be handled independant of the above converter because to lua, one table is like another and there is no way to tell if it should be considered as an NSDictionary or as the fields for an NSParagraphStyle (see https://github.com/asmagill/hammerspoon_text as an example of its use, which may one day be submitted for consideration as well)

* `- (void)registerTableHelper:(tableHelperFunction)helperFN forClass:(char *)className ;`
  Register a helper function for the above converter.  The function should match this signature: `id function(lua_State *L, int idx)`.  Registering the same className twice will overwrite the existing helper function -- specify nil as the function to remove the existing helper function.

* `- (NSRect)tableToRectAtIndex:(int)idx ;`

* `- (NSPoint)tableToPointAtIndex:(int)idx ;`

* `- (NSSize)tableToSizeAtIndex:(int)idx ;`
  Like the pushNSRect, Point, and Size methods above, these return the appropriate structures.  Missing fields are set to 0.0.

##### Other helpers

* `- (BOOL)isValidUTF8AtIndex:(int)idx ;`
  Returns YES or NO indicating if the item at the specified index can be converted to a valid UTF8 string.  Like `lua_tostring()` and `lua_tolstring()`, it will convert any number on the stack into a string, so don't use this in a loop being traversed with `lua_next()`

* `- (BOOL)requireModule:(char *)moduleName ;`
  Equivalent to lua's `require("moduleName") ;` -- Attempts to load the specified module, if not already loaded, and push its value (usually a table) onto the top of the stack.  If it fails, it will push a string containing the error instead.  Returns YES on success or NO on error.  This is useful for ensuring a module is loaded or for referencing a function in another module without relying on it existing within the global name space at a specific location.


Note that regular table conversions to and from NSDictionary, NSArray, and NSSet properly handle references to the same sub-tables (i.e. without duplication) and can handle self reference (i.e. a table which has itself as an element).  Self reference has to be requested for lua->NSObject conversion because this is not usually checked for in the Objective-C side of things -- NSLog, NSJSONSerialization, and NSUserDefaults all crash if you pass a self-referencing dictionary into them.    For NSObject->lua conversion, this is not quite as big of a concern because (a) it doesn't happen as often in values returned from the Mac OS APIs, and (b) lua crashes are less catastrophic to the Hammerspoon application.