### PR TITLE
[READY] fix screen edge stickiness, hs.geometry fixes, add window:sendToBack()

### DIFF
--- a/extensions/application/init.lua
+++ b/extensions/application/init.lua
@@ -112,7 +112,7 @@ function application.find(hint,exact)
   local apps=application.runningApplications()
 
   if exact then for _,a in ipairs(apps) do if a:name()==hint then r[#r+1]=a end end
-  else for _,a in ipairs(apps) do if a:name():lower():find(hint:lower()) then r[#r+1]=a end end end
+  else for _,a in ipairs(apps) do local aname=a:name() if aname and aname:lower():find(hint:lower()) then r[#r+1]=a end end end
   tsort(r,function(a,b)return a:kind()>b:kind()end) -- gui apps first
   if exact or #r>0 then return tunpack(r) end
 

--- a/extensions/geometry/init.lua
+++ b/extensions/geometry/init.lua
@@ -55,7 +55,7 @@ local function gettype(t)
   if t._x and t._y then
     if t._w and t._h then
       for _,k in ipairs{'_x','_y','_w','_h'} do
-        if t[k]>1 or t[k]<0 then return 'rect' end
+        if t[k]>1.0000000000001 or t[k]<-0.0000000000001 then return 'rect' end
       end
       return 'unitrect'
     else return 'point' end

--- a/extensions/geometry/init.lua
+++ b/extensions/geometry/init.lua
@@ -129,7 +129,7 @@ local function maketable(t,x,y,w,h)
 end
 
 local function new(x,y,w,h)
-  if getmetatable(x)==geometry then return x end -- disable copy-on-new
+  if y==nil and getmetatable(x)==geometry then return x end -- disable copy-on-new
   local t=maketable({},x,y,w,h)
   for _,a in ipairs{x,y--[[,w,h--]]} do
     if a~=nil and (not t._x or not t._y or not t._w or not t._h) then t=maketable(t,parsearg(a)) end
@@ -190,8 +190,8 @@ geometry.getx1=geometry.getx
 geometry.gety1=geometry.gety
 function geometry.getw(t) return t._w end
 function geometry.geth(t) return t._h end
-function geometry.getx2(t) return t._x+(t._w or 0) end
-function geometry.gety2(t) return t._y+(t._h or 0) end
+function geometry.getx2(t) return (t._w and t._x) and (t._x+t._w) or nil end
+function geometry.gety2(t) return (t._h and t._y) and (t._y+t._h) or nil end
 
 function geometry.setx(t,v) t._x=tonumber(v) or error('number expected',3) return t end
 function geometry.sety(t,v) t._y=tonumber(v) or error('number expected',3) return t end
@@ -205,7 +205,7 @@ geometry.sety1=geometry.sety
 --- hs.geometry.topleft
 --- Field
 --- Alias for `xy`
-function geometry.getxy(t) return new(t._x,t._y) end
+function geometry.getxy(t) return (t._x and t._y) and new(t._x,t._y) or nil end
 function geometry.setxy(t,p) p=new(p) t._x=p.x t._y=p.y return t end
 geometry.gettopleft=geometry.getxy
 geometry.settopleft=geometry.setxy
@@ -254,7 +254,7 @@ end
 --- hs.geometry.size
 --- Field
 --- Alias for `wh`
-function geometry.getwh(t) return new(nil,nil,t._w or 0,t._h or 0)end
+function geometry.getwh(t) return (t._w and t._h) and new(nil,nil,t._w,t._h) or nil end
 function geometry.setwh(t,s) s=new(s) t._w=s.w t._h=s.h return t end
 geometry.getsize=geometry.getwh
 geometry.setsize=geometry.setwh
@@ -266,7 +266,7 @@ geometry.setsize=geometry.setwh
 --- hs.geometry.bottomright
 --- Field
 --- Alias for `x2y2`
-function geometry.getx2y2(t) return new(t.x2,t.y2) end
+function geometry.getx2y2(t) return (t.x2 and t.y2) and new(t.x2,t.y2) or nil end
 function geometry.setx2y2(t,s) s=new(s) t.x2=s.x t.y2=s.y return t end
 geometry.getbottomright=geometry.getx2y2
 geometry.setbottomright=geometry.setx2y2
@@ -274,7 +274,7 @@ geometry.setbottomright=geometry.setx2y2
 --- hs.geometry.table
 --- Field
 --- The `{x=X,y=Y,w=W,h=H}` table for this hs.geometry object; useful e.g. for serialization/deserialization
-function geometry.gettable(t) return {x=t.x,y=t.y,w=t.w,h=t.h} end
+function geometry.gettable(t) return {x=t._x,y=t._y,w=t._w,h=t._h} end
 function geometry.settable(t,nt) t._x=nt.x t._y=nt.y t._w=nt.w t._h=nt.h return t end
 
 --- hs.geometry.string
@@ -370,7 +370,7 @@ end
 
 function geometry.__index(t,k)
   local r=rawget(geometry,'get'..k)
-  return r and r(t) or rawget(geometry,k)
+  if r then return r(t) else return rawget(geometry,k) end --avoid getting .size metatable fn when it's nil
 end
 function geometry.__newindex(t,k,v)
   local r=rawget(geometry,'set'..k)

--- a/extensions/geometry/init.lua
+++ b/extensions/geometry/init.lua
@@ -289,7 +289,7 @@ end
 function geometry.getstring(t)
   local typ=geometry.type(t)
   if typ=='point' then return ntos(t._x)..','..ntos(t._y)--sformat('%.2f,%.2f',t._x,t._y)
-  elseif typ=='size' then return ntos(t._x)..'x'..ntos(t._y) --sformat('%.2fx%.2f',t._w,t._h)
+  elseif typ=='size' then return ntos(t._w)..'x'..ntos(t._h) --sformat('%.2fx%.2f',t._w,t._h)
   elseif typ=='rect' then return ntos(t._x)..','..ntos(t._y)..'/'..ntos(t._w)..'x'..ntos(t._h) --sformat('%.2f,%.2f/%.2fx%.2f',t._x,t._y,t._w,t._h)
   elseif typ=='unitrect' then return '['..ntos(t._x*100)..','..ntos(t._y*100)..'>'..ntos(t.x2*100)..','..ntos(t.y2*100)..']' --sformat('[%.0f,%.0f>%.0f,%.0f]',t._x*100,t._y*100,t.x2*100,t.y2*100)
   else return ''

--- a/extensions/geometry/init.lua
+++ b/extensions/geometry/init.lua
@@ -436,6 +436,26 @@ function geometry.scale(t,s1,s2,...)
   return t
 end
 
+--- hs.geometry:fit(bounds) -> hs.geometry object
+--- Method
+--- Ensure this rect is fully inside `bounds`, by scaling it down if it's larger (preserving its aspect ratio) and moving it if necessary
+---
+--- Parameters:
+---  * bounds - an hs.geometry rect object, or a table or string or parameter list to construct one, indicating the rect that
+---    must fully contain this rect
+---
+--- Returns:
+---  * this hs.geometry object for method chaining
+
+function geometry.fit(t,...)
+  t=new(t) local bounds=new(...)
+  if not isRect(t) then error('not a rect',2) elseif not isRect(bounds) then error('bounds must be a rect',2) end
+  if t:inside(bounds) then return t end
+  if t.w>bounds.w then t:scale(bounds.w/t.w) end
+  if t.h>bounds.h then t:scale(bounds.h/t.h) end
+  return t:move(bounds:intersect(t).center-t.center):move((t:intersect(bounds).center-t.center)*2):intersect(bounds)
+end
+
 --- hs.geometry:normalize() -> point
 --- Method
 --- Normalizes this vector2

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -64,7 +64,7 @@ function screen.find(p,...)
     local screens,r=screen.allScreens(),{}
     if typ=='number' and p>20 then for _,s in ipairs(screens) do if p==s:id() then return s end return end -- not found
     elseif typ=='string' then
-      for _,s in ipairs(screens) do if s:name():lower():find(p:lower()) then r[#r+1]=s end end
+      for _,s in ipairs(screens) do local sname=s:name() if sname and sname:lower():find(p:lower()) then r[#r+1]=s end end
       if #r>0 then return tunpack(r) end
     elseif typ~='table' then error('hint can be a number, string or table',2) end
     local ok

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -831,9 +831,10 @@ end
 ---    the potential issues described in the Notes section for `hs.window:setFrame()`. As a side effect the window might appear to
 ---    jump around briefly before setting toward its destination frame, and, in some cases, the move/resize animation (if requested)
 ---    might be skipped entirely - due to OSX quirks, these tradeoffs are necessary to ensure the desired result.
-local function frameInBounds(frame,bounds)
-  return geometry.copy(frame):move((frame:intersect(bounds).center-frame.center)*2):intersect(bounds)
-end
+
+--local function frameInBounds(frame,bounds)
+--  return geometry.copy(frame):move((frame:intersect(bounds).center-frame.center)*2):intersect(bounds)
+--end
 
 function window:setFrameInScreenBounds(frame,duration)
   if type(frame)=='number' then duration=frame frame=nil end
@@ -855,10 +856,10 @@ function window:setFrameInScreenBounds(frame,duration)
   local safeFrame=geometry.new(originalFrame.xy,frame.size) --apply the desired size
   local safeBounds=self:screen():frame() safeBounds:move(30,30) -- offset
   safeBounds.w=safeBounds.w-60 safeBounds.h=safeBounds.h-60 -- and shrink
-  self:_setFrame(frameInBounds(safeFrame,safeBounds)) -- put it within a 'safe' area in the current screen, and insta-resize
+  self:_setFrame(safeFrame:fit(safeBounds)) -- put it within a 'safe' area in the current screen, and insta-resize
   local actualSize=geometry(self:_size()) -- get the *actual* size the window resized to
   if actualSize.area>frame.area then frame.size=actualSize end -- if it's bigger apply it
-  local finalFrame=frameInBounds(frame,findScreenForFrame(frame):frame())
+  local finalFrame=frame:fit(findScreenForFrame(frame):frame())
   if duration==0 then
     self:_setSize(frame.size) -- apply the final size while the window is still in the safe area
     return self:_setFrame(finalFrame)

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -141,7 +141,7 @@ function window.find(hint,exact,wins)
   if typ=='number' then for _,w in ipairs(wins) do if w:id()==hint then return w end end return
   elseif typ~='string' then error('hint must be a number or string',2) end
   if exact then for _,w in ipairs(wins) do if w:title()==hint then r[#r+1]=w end end
-  else hint=hint:lower() for _,w in ipairs(wins) do if w:title():lower():find(hint) then r[#r+1]=w end end end
+  else hint=hint:lower() for _,w in ipairs(wins) do local wtitle=w:title() if wtitle and wtitle:lower():find(hint) then r[#r+1]=w end end end
   if #r>0 then return tunpack(r) end
 end
 

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -246,6 +246,15 @@ end
 ---
 --- Returns:
 ---  * The `hs.window` object
+---
+--- Notes:
+---  * In some cases this method won't work: namely, the bottom (or Dock) edge, and edges between screens, might exhibit some
+---    "stickiness"; trying to make a window abutting one of those edges just *slightly* smaller could result in no change at all
+---    (you can verify this by trying to resize such a window with the mouse: at first it won't budge, and, as you drag
+---    further away, suddenly snap to the new size). Additionally some windows (no matter their placement on screen) only allow
+---    being resized at "discrete" steps of several screen points; the typical example is Terminal windows, which only resize to
+---    whole rows and columns. Both situations can result in unexpected behavior when using this method (especially when using
+---    animations). As a safer alternative, you can use `hs.window:setFrameInScreenBounds()` instead.
 function window:setFrame(f, duration)
   if duration==nil then duration = window.animationDuration end
   if type(duration)~='number' then duration = 0 end
@@ -768,7 +777,12 @@ end
 ---
 --- Returns:
 ---  * The `hs.window` object
-
+---
+--- Notes:
+---  * This method, besides ensuring that the window lies fully inside its screen, performs several additional checks and workarounds for
+---    the potential issues described in the Notes section for `hs.window:setFrame()`. As a side effect the window might appear to
+---    jump around briefly before setting toward its destination frame, and, in some cases, the move/resize animation (if requested)
+---    might be skipped entirely - due to OSX quirks, these tradeoffs are necessary to ensure the desired result.
 local function frameInBounds(frame,bounds)
   return geometry.copy(frame):move((frame:intersect(bounds).center-frame.center)*2):intersect(bounds)
 end
@@ -805,7 +819,6 @@ function window:setFrameInScreenBounds(frame,duration)
   return self:setFrame(finalFrame,duration)
 end
 window.ensureIsInScreenBounds=window.setFrameInScreenBounds --backward compatible
-
 
 package.loaded[...]=window
 window.filter=require'hs.window.filter'


### PR DESCRIPTION
### hs.geometry
- add `:fit(bounds)`
- ugly workaround for a precision error where `print(t.w) --> 1.0` but `t.w>1.0 --> true`; `.type()` will now correctly recognise these as unit rects
- fix `.string` for size objects
- fix `geometry.new(point,size) --> rect`

### hs.window
- add `:sendToBack()`
- improve `:setFrameInScreenBounds()`
- don't crash `.find()` if `:title()` is nil

### hs.application
- don't crash `.find()` if `:name()` is nil

### hs.screen
- don't crash `.find()` if `:name()` is nil

-----

As per my last comment in #217, I modified `setFrameInScreenBounds()` to also take into account (in addition to the likes of Terminal windows) edge stickiness. Same tradeoff as the previous incarnation - namely, if the window is potentially trouble, it will first jump around a little, regardless of whether it will then animate or not.

~~A case can be made to extend these safety precautions (minus the actual "ensure is in screen bounds part", of course) also to plain `:setFrame()`, however I haven't done so (yet); the question is **is the correct (or at least, expected) behaviour of setFrame in these edge cases worth the occasional annoying window dance?** Or shall we just inform the users and let them decide whether to use setFrameInScreenBounds() when dealing with these situations? (if so, I'll just add the relevant bits to the docstring and mark this PR as ready)~~ (added docs, see below)

(Also, following the 'fixes' theme, I snuck in some fixes for hs.geometry)