### PR TITLE
non-activating panel instead of windows for drawing holders

### DIFF
--- a/extensions/drawing/internal.m
+++ b/extensions/drawing/internal.m
@@ -24,7 +24,7 @@ typedef struct _drawing_t {
 NSMutableArray *drawingWindows;
 
 // Objective-C class interface definitions
-@interface HSDrawingWindow : NSWindow <NSWindowDelegate>
+@interface HSDrawingWindow : NSPanel <NSWindowDelegate>
 @end
 
 @interface HSDrawingView : NSView {
@@ -68,7 +68,8 @@ NSMutableArray *drawingWindows;
 @implementation HSDrawingWindow
 - (id)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger __unused)windowStyle backing:(NSBackingStoreType __unused)bufferingType defer:(BOOL __unused)deferCreation {
     //CLS_NSLOG(@"HSDrawingWindow::initWithContentRect contentRect:(%.1f,%.1f) %.1fx%.1f", contentRect.origin.x, contentRect.origin.y, contentRect.size.width, contentRect.size.height);
-    self = [super initWithContentRect:contentRect styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:YES];
+    self = [super initWithContentRect:contentRect styleMask:NSBorderlessWindowMask | NSNonactivatingPanelMask
+                                                    backing:NSBackingStoreBuffered defer:YES];
     if (self) {
         [self setDelegate:self];
         contentRect.origin.y=[[NSScreen screens][0] frame].size.height - contentRect.origin.y - contentRect.size.height;
@@ -83,6 +84,7 @@ NSMutableArray *drawingWindows;
         self.hasShadow = NO;
         self.ignoresMouseEvents = YES;
         self.restorable = NO;
+        self.hidesOnDeactivate  = NO;
         self.animationBehavior = NSWindowAnimationBehaviorNone;
         self.level = NSScreenSaverWindowLevel;
     }
@@ -1913,8 +1915,7 @@ static int setBehavior(lua_State *L) {
         [drawingWindow setCollectionBehavior:newLevel] ;
     }
     @catch ( NSException *theException ) {
-        showError(L, (char *)[[NSString stringWithFormat:@"%@: %@", theException.name, theException.reason] UTF8String]);
-        return 0 ;
+        return luaL_error(L, "%s, %s", [[theException name] UTF8String], [[theException reason] UTF8String]) ;
     }
 
     lua_settop(L, 1);
@@ -2063,6 +2064,7 @@ static const luaL_Reg drawing_metalib[] = {
     {"setBehavior", setBehavior},
     {"behavior", getBehavior},
     {"setTextStyle", drawing_setTextStyle},
+
     {"__tostring", userdata_tostring},
     {"__gc", drawing_delete},
     {NULL, NULL}


### PR DESCRIPTION
Suggestion for hs.drawing which removes the bringing forward of the Hammerspoon console when a drawing object with a callback is clicked on.