### PR TITLE
allow user setable init file location

### DIFF
--- a/Hammerspoon/MJAppDelegate.m
+++ b/Hammerspoon/MJAppDelegate.m
@@ -56,6 +56,9 @@ static BOOL MJFirstRunForCurrentVersion(void) {
         const char *tmp = [[[NSBundle bundleForClass:NSClassFromString(@"Hammerspoon_Tests")] pathForResource:@"init" ofType:@"lua"] fileSystemRepresentation];
         NSLog(@"testing init.lua is [%s], if this is null, we crash on the next line", tmp);
         MJConfigFile = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:tmp length:strlen(tmp)];
+    } else {
+        NSString* userMJConfigFile = [[NSUserDefaults standardUserDefaults] stringForKey:@"MJConfigFile"];
+        if (userMJConfigFile) MJConfigFile = userMJConfigFile ;
     }
 
     MJEnsureDirectoryExists(MJConfigDir());


### PR DESCRIPTION
as suggested in #579, you can set MJConfigFile from the command line with:

~~~
defaults write org.hammerspoon.Hammerspoon MJConfigFile "~/.config/hammerspoon/init.lua"
~~~

@cmsj, I think I've left your test stuff ok by only doing the check for the user default if your XCTest in MJAppDelegate.m is false, but you should look at it to make sure.