### PR TITLE
improve hs.expose

### DIFF
--- a/extensions/expose/init.lua
+++ b/extensions/expose/init.lua
@@ -50,6 +50,7 @@ end
 
 local function fitWindows(windows,thumbnails,isInvisible,maxIterations,animate,alt_algo)
   local screenFrame = windows.frame
+  local DISPLACE=floor(screenFrame.w/200)
   local avgRatio = min(1,screenFrame.area/windows.area*2)
   log.vf('shrink %d windows to %.0f%%',#windows,avgRatio*100)
   for i,win in ipairs(windows) do if not isInvisible then win.frame:scale(avgRatio) end win.frame:fit(screenFrame) end
@@ -99,7 +100,6 @@ local function fitWindows(windows,thumbnails,isInvisible,maxIterations,animate,a
       end
 
       if totalOverlaps>0 and avgRatio<0.9 and not alt_algo then
-        local DISPLACE=5
         for dx = -DISPLACE,DISPLACE,DISPLACE*2 do
           if wframe.center.x>screenFrame.center.x then dx=-dx end
           local r=geom.copy(wframe):setx(dx>0 and wframe.x2 or (wframe.x+dx)):setw(abs(dx)*2-1)

--- a/extensions/expose/init.lua
+++ b/extensions/expose/init.lua
@@ -7,6 +7,7 @@
 --- Keyboard-driven expose replacement/enhancement
 ---
 --- Usage:
+--- ```
 --- -- set up your windowfilter
 --- expose = hs.expose.new() -- default windowfilter: only visible windows, all Spaces
 --- expose_space = hs.expose.new(hs.window.filter.new():setCurrentSpace(true):setDefaultFilter()) -- include minimized/hidden windows, current Space only
@@ -18,7 +19,7 @@
 --- -- alternatively, call .expose directly
 --- hs.hotkey.bind('ctrl-alt','e','expose',expose.expose)
 --- hs.hotkey.bind('ctrl-alt-shift','e','expose app',expose.exposeApplicationWindows)
-
+--- ```
 
 --TODO /// hs.drawing:setClickCallback(fn) -> drawingObject
 --TODO showExtraKeys
@@ -169,8 +170,8 @@ local ui = {
 
 local function getColor(t) if t.red then return t else return {red=t[1] or 0,green=t[2] or 0,blue=t[3] or 0,alpha=t[4] or 1} end end
 
---- === hs.expose.ui ===
----
+--- hs.expose.ui
+--- Variable
 --- Allows customization of the expose user interface
 ---
 --- This table contains variables that you can change to customize the look of the UI. The default values are shown in the right hand side of the assignements below.
@@ -535,11 +536,11 @@ local function showExpose(wins,animate,alt_algo)
 end
 
 --- hs.expose:toggleShow(applicationWindows)
---- Function
+--- Method
 --- Toggles the expose - see `hs.expose:show()` and `hs.expose:hide()`
 ---
 --- Parameters:
----  * applicationWindows
+---  * applicationWindows - see `hs.expose:show()`
 ---
 --- Returns:
 ---  * None
@@ -547,7 +548,7 @@ function expose:toggleShow(currentApp)
   if activeInstance then return self:hide() else return self:show(currentApp) end
 end
 --- hs.expose:hide()
---- Function
+--- Method
 --- Hides the expose, if visible, and exits the modal mode.
 --- Call this function if you need to make sure the modal is exited without waiting for the user to press `esc`.
 ---

--- a/extensions/expose/init.lua
+++ b/extensions/expose/init.lua
@@ -37,7 +37,7 @@ local execute=hs.execute
 local newmodal=require'hs.hotkey'.modal.new
 local log=require'hs.logger'.new('expose')
 
-local expose={setLogLevel=log.setLogLevel} --module
+local expose={setLogLevel=log.setLogLevel,getLogLevel=log.getLogLevel} --module
 local screens,modals={},{}
 local modes,activeInstance,tap={}
 local spacesWatcher
@@ -456,7 +456,6 @@ local function showExpose(wins,animate,iterations,alt_algo)
       --      w.ratio=drawing.text(w.frame,sformat('%.0f%%',w.frame.area*100/w.area)):setTextColor{red=1,green=0,blue=0,alpha=1}:show()
     end
   end
-  enter(hints)
   tap=eventtap.new({eventtap.event.types.flagsChanged},function(e)
     local function hasOnly(t,mod)
       local n=next(t)
@@ -467,6 +466,7 @@ local function showExpose(wins,animate,iterations,alt_algo)
     setMode('min',hasOnly(e:getFlags(),ui.minimizeModeModifier))
   end)
   tap:start()
+  enter(hints)
 end
 
 --- hs.expose:toggleShow(applicationWindows)

--- a/extensions/expose/init.lua
+++ b/extensions/expose/init.lua
@@ -661,10 +661,8 @@ end
 --- Creates a new hs.expose instance. It uses a windowfilter to determine which windows to show
 ---
 --- Parameters:
----  * windowfilter - (optional) it can be:
----    * `nil` or omitted (as in `myexpose=hs.expose.new()`): the default windowfilter will be used
----    * an `hs.window.filter` object
----    * otherwise all parameters are passed to `hs.window.filter.new` to create a new instance
+---  * windowfilter - (optional) if omitted, use the default windowfilter; otherwise it must be a windowfilter
+---    instance or constructor argument(s)
 ---
 --- Returns:
 ---  * the new instance
@@ -677,10 +675,7 @@ end
 function expose.new(wf,...)
   local o = setmetatable({},{__index=expose})
   if wf==nil then log.i('New expose instance, using default windowfilter') o.wf=windowfilter.default
-  elseif type(wf)=='table' and type(wf.isWindowAllowed)=='function' then
-    log.i('New expose instance, using windowfilter instance') o.wf=wf
-  else log.i('New expose instance, creating windowfilter') o.wf=windowfilter.new(wf,...)
-  end
+  else log.i('New expose instance using windowfilter instance') o.wf=windowfilter.new(wf,...) end
   o.wf:keepActive()
   return o
 end


### PR DESCRIPTION
- add `hs.expose.ui.showThumbnails`
- add `hs.expose.ui.showTitles`

With `hs.expose.ui.showThumbnails=false` this basically becomes a replacement for hs.hints (and just as fast), with the added advantage of using arbitrary windowfilters e.g. for #587, which would work out of the box (using the default windowfilter), or for windows across all spaces, or including hidden windows, etc