### PR TITLE
Tweaks to the layout module:

### DIFF
--- a/extensions/layout/init.lua
+++ b/extensions/layout/init.lua
@@ -159,13 +159,18 @@ function layout.apply(layout, windowTitleComparator)
                 display = _row[3]()
             elseif fnutils.contains(screen.allScreens(), _row[3]) then
                 display = _row[3]
+            else
+                -- Default to the main screen if the passed-in screen isn't found; useful for
+                -- layouts activated using the screen watcher, meaning that screens in layouts may
+                -- not be in the current screen configuration.
+                display = screen.allScreens()[1]
             end
         else
             display = screen.allScreens()[1]
         end
 
         if not display then
-            print("Unable to find display: " .. _row[3])
+            print("Unable to find display: ", _row[3])
         else
             displaypoint = geometry.point(display:frame().x, display:frame().y)
         end

--- a/extensions/layout/init.lua
+++ b/extensions/layout/init.lua
@@ -163,10 +163,10 @@ function layout.apply(layout, windowTitleComparator)
                 -- Default to the main screen if the passed-in screen isn't found; useful for
                 -- layouts activated using the screen watcher, meaning that screens in layouts may
                 -- not be in the current screen configuration.
-                display = screen.allScreens()[1]
+                display = screen.primaryScreen()
             end
         else
-            display = screen.allScreens()[1]
+            display = screen.primaryScreen()
         end
 
         if not display then


### PR DESCRIPTION
* Default to the main screen if the passed-in screen isn't found; useful for layouts activated using the screen watcher, meaning that screens in layouts may not be in the current screen configuration.
* Correct the print statement for "Unable to find display: "; the concat will only work with strings and numbers, and if a table or function is passed in there, the print craps out and throws a misleading error message.