### PR TITLE
allow hs.pasteboard to get image contents 

### DIFF
--- a/extensions/pasteboard/init.lua
+++ b/extensions/pasteboard/init.lua
@@ -5,6 +5,7 @@
 --- This module is based partially on code from the previous incarnation of Mjolnir by [Steven Degutis](https://github.com/sdegutis/).
 
 local module = require("hs.pasteboard.internal")
+require("hs.image")
 
 -- private variables and methods -----------------------------------------
 

--- a/extensions/pasteboard/internal.m
+++ b/extensions/pasteboard/internal.m
@@ -24,6 +24,27 @@ static int pasteboard_getContents(lua_State* L) {
     return 1;
 }
 
+/// hs.pasteboard.getImageContents([name]) -> hs.image object or nil
+/// Function
+/// Gets the first image of the pasteboard
+///
+/// Parameters:
+///  * name - An optional string containing the name of the pasteboard. Defaults to the system pasteboard
+///
+/// Returns:
+///  * An `hs.image` object from the first pasteboard image, or nil if an error occurred
+static int pasteboard_getImageContents(lua_State* L) {
+    NSImage *image = [[NSImage alloc] initWithData:[lua_to_pasteboard(L, 1) dataForType:NSPasteboardTypePNG]];
+
+    if (image && image.valid) {
+        [[LuaSkin shared] pushNSObject:image];
+    } else {
+        return luaL_error(L, "No valid image data in pasteboard");
+    }
+
+    return 1;
+}
+
 /// hs.pasteboard.setContents(contents[, name]) -> boolean
 /// Function
 /// Sets the contents of the pasteboard
@@ -144,6 +165,7 @@ static int pasteboard_delete(lua_State* L) {
 static const luaL_Reg pasteboardLib[] = {
     {"changeCount",      pasteboard_changeCount},
     {"getContents",      pasteboard_getContents},
+    {"getImageContents", pasteboard_getImageContents},
     {"setContents",      pasteboard_setContents},
     {"clearContents",    pasteboard_clearContents},
     {"pasteboardTypes",  pasteboard_pasteboardTypes},

--- a/scripts/docs/templates/ext.html.erb
+++ b/scripts/docs/templates/ext.html.erb
@@ -13,7 +13,7 @@
   </head>
   <body>
     <header>
-      <h1><%= mod['name'] %></h1>
+      <h1><a href="./index.html">docs</a> &raquo; <%= mod['name'] %></h1>
       <%= GitHub::Markdown.render_gfm(mod['doc']) %>
       </header>
       <h3>API Overview</h3>


### PR DESCRIPTION
Adds a getImageContents() method to hs.pasteboard, which returns an `hs.image` object if available.
Resolves #626

Also, I find it annoying to navigate the docs without a link back to the index, so I added one:
![](http://i.imgur.com/7LAQ0nz.png)
