### PR TITLE
adding arc drawing type for partial circles

### DIFF
--- a/extensions/drawing/drawing.h
+++ b/extensions/drawing/drawing.h
@@ -35,6 +35,13 @@ typedef struct _drawing_t {
 @interface HSDrawingViewCircle : HSDrawingView
 @end
 
+@interface HSDrawingViewArc : HSDrawingView
+@property NSPoint center;
+@property CGFloat radius;
+@property CGFloat startAngle;
+@property CGFloat endAngle;
+@end
+
 @interface HSDrawingViewRect : HSDrawingView
 @end
 


### PR DESCRIPTION
~~~lua
r, c, a = 
    hs.drawing.rectangle{x=90, y=90, h=120, w=120}:setFillColor{white=0}:setFill(true):show(),
    hs.drawing.circle{x=100,y=100,h=100,w=100}:setFillColor{red=1}:setFill(true):setStrokeColor{red=1}:show(),
    hs.drawing.arc({x=150,y=150},50,0,45):setFillColor{green=1}:setFill(true):show()
~~~

Yields
![screen shot 2015-11-25 at 5 40 37 pm](https://cloud.githubusercontent.com/assets/8139480/11412002/b668b712-939c-11e5-913a-24081e7b4e42.png)
