### PR TITLE
[READY] better arc for hs.drawing

### DIFF
--- a/extensions/drawing/drawing.h
+++ b/extensions/drawing/drawing.h
@@ -35,9 +35,7 @@ typedef struct _drawing_t {
 @interface HSDrawingViewCircle : HSDrawingView
 @end
 
-@interface HSDrawingViewArc : HSDrawingView
-@property NSPoint center;
-@property CGFloat radius;
+@interface HSDrawingViewEllipticalArc : HSDrawingView
 @property CGFloat startAngle;
 @property CGFloat endAngle;
 @end

--- a/extensions/drawing/init.lua
+++ b/extensions/drawing/init.lua
@@ -197,6 +197,31 @@ drawingObject.behaviorAsLabels = function(obj)
     end})
 end
 
+--- hs.drawing.arc(centerPoint, radius, startAngle, endAngle) -> drawingObject or nil
+--- Constructor
+--- Creates a new arc object
+---
+--- Parameters:
+---  * centerPoint - A point-table containing the center of the circle used to define the arc
+---  * radius      - The radius of the circle used to define the arc
+---  * startAngle  - The starting angle of the arc, measured in degrees clockwise from the y-axis.
+---  * endAngle    - The ending angle of the arc, measured in degrees clockwise from the y-axis.
+---
+--- Returns:
+---  * An `hs.drawing` arc object, or nil if an error occurs
+---
+--- Notes:
+---  * This constructor is actually a wrapper for the `hs.drawing.ellipticalArc` constructor.
+module.arc = function(centerPoint, radius, startAngle, endAngle)
+    local rect = {
+        x = (centerPoint.x or 0.0) - radius,
+        y = (centerPoint.y or 0.0) - radius,
+        h = (radius * 2.0) or 0.0,
+        w = (radius * 2.0) or 0.0
+    }
+    return module.ellipticalArc(rect, startAngle, endAngle)
+end
+
 module.fontNames =           styledtext.fontNames
 module.fontNamesWithTraits = styledtext.fontNamesWithTraits
 module.fontTraits =          styledtext.fontTraits


### PR DESCRIPTION
Replace arc drawing type with ellipticalArc drawing type, changed arc constructor to wrapper for ellipticalArc.  This allows arc's to stretch appropriately when applied to ellipses (ovals) or when the original view is no longer a true square due to setFrame, etc.

Moved setArcAngles out of constructor list in docs.