### PR TITLE
Reordered log message before the msg is deleted

### DIFF
--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -113,8 +113,8 @@ local function delete(self)
   if not idx or not hotkeys[idx] then log.w('The hotkey has already been deleted') return end --?
   disable(self)
   for i,hk in ipairs(hotkeys[idx]) do if hk==self then tremove(hotkeys[idx],i) break end end
-  for k in pairs(self) do self[k]=nil end --gc
   log.i('Deleted hotkey '..self.msg)
+  for k in pairs(self) do self[k]=nil end --gc
 end
 
 


### PR DESCRIPTION
Fixed ordering of log message to be before the msg has been deleted.

Otherwise, got this error when deleting a hotkey:
```
...oon.app/Contents/Resources/extensions/hs/hotkey/init.lua:123: attempt to concatenate a nil value (field 'msg')
stack traceback:
	...oon.app/Contents/Resources/extensions/hs/hotkey/init.lua:123: in method 'delete'
```

Code had the msg attribute trying to be printed, after it had been deleted by:
```for k in pairs(self) do self[k]=nil end --gc```

