### PR TITLE
[READY] setInput for hs.task

### DIFF
--- a/extensions/task/internal.m
+++ b/extensions/task/internal.m
@@ -181,7 +181,6 @@ static int task_setInput(lua_State *L) {
         [task setStandardInput:[NSPipe pipe]] ;
 
         NSFileHandle *inputFH = [task.standardInput fileHandleForWriting] ;
-        __weak NSFileHandle *_inputFH = inputFH;
 
         inputFH.writeabilityHandler = ^(NSFileHandle *theHandle){
             if ([(__bridge id)userData->input isKindOfClass:[NSData class]]) {
@@ -189,8 +188,8 @@ static int task_setInput(lua_State *L) {
             } else {
                 [theHandle writeData:[(__bridge id)userData->input dataUsingEncoding:NSUTF8StringEncoding]] ;
             }
-            _inputFH.writeabilityHandler = nil ;
-            [_inputFH closeFile] ;
+            theHandle.writeabilityHandler = nil ;
+            [theHandle closeFile] ;
         } ;
     }
     @catch (NSException *exception) {

--- a/extensions/task/internal.m
+++ b/extensions/task/internal.m
@@ -199,7 +199,7 @@ static int task_setInput(lua_State *L) {
                     }
                 }
                 @catch (NSException *theException) {
-CLS_NSLOG(@"%s:stdin exception: %@", theException);                    // do nothing
+CLS_NSLOG(@"%s:stdin exception: %@", USERDATA_TAG, theException);                    // do nothing
                 }
                 @finally {
                     theHandle.writeabilityHandler = nil ;


### PR DESCRIPTION
Added a method to hs.task which allows setting the stdin to a string (which can be arbitrary binary data -- i.e. not proper UTF8) as the STDIN for an `hs.task`.

See #682
