### PR TITLE
Add support for hs.task tasks to run indefinitely

### DIFF
--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -14,6 +14,8 @@
 
 
 #import <Foundation/Foundation.h>
+#import "lobject.h"
+#import "lapi.h"
 #import "lauxlib.h"
 #import "lualib.h"
 #import "lua.h"
@@ -445,6 +447,14 @@ typedef struct luaObjectHelpers {
  @returns YES if the module loaded successfully or NO if it does not
  */
 - (BOOL)requireModule:(char *)moduleName ;
+
+/*!
+ @abstract Pushes an existing Lua userdata object onto the Lua stack
+
+ @important This is a terrible hack and could easily break with future Lua versions. Its use is discouraged
+ @param userData - a pointer to memory that was allocated by lua_newuserdata()
+ */
+- (void)pushUserData:(void *)userData;
 
 @end
 

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -567,6 +567,14 @@ nextarg:
     return [self protectedCallAndTraceback:1 nresults:1] ;
 }
 
+- (void)pushUserData:(void *)userData {
+    // WARNING. This is a terrible, terrible hack, taken from http://lua-users.org/lists/lua-l/2005-05/msg00095.html
+    lua_lock(_L);
+    setuvalue(_L, _L->top, ((Udata*)userData)-1);
+    api_incr_top(_L);
+    lua_unlock(_L);
+}
+
 #pragma mark - conversionSupport extensions to LuaSkin class
 
 - (int)pushNSObject:(id)obj preserveBitsInNSNumber:(BOOL)bitsFlag


### PR DESCRIPTION
So this one is a little hairy. It adds a second (but optional) callback to hs.task.new() which will be called whenever the OS decrees that there is new data to be read on either the stdout or stderr pipes, and the callback returns true to keep the background reading going, or false to stop it (although that applies per-channel, which is unfortunate, but seemingly unavoidable).

Where things get really hairy though, is that for this callback to be properly useful, it needs to be passed the hs.task object that fired it, but Lua has no API for pushing an existing userdata object onto the stack, so I've had to borrow some code from the Internet that is effectively a clone of lua_newuserdata(). I don't know if this should go in or not, and seek opinions (on subjects such as whether pushUserData is a reasonable addition to LuaSkin,, or whether indefinite task support is still useful without the task object argument, or on any other subject).

Paging Dr @asmagill :)