### PR TITLE
Fix documentation typos

### DIFF
--- a/extensions/eventtap/event.m
+++ b/extensions/eventtap/event.m
@@ -13,7 +13,7 @@ static int eventtap_event_gc(lua_State* L) {
 
 /// hs.eventtap.event:copy() -> event
 /// Constructor
-/// Duplicateis an `hs.eventtap.event` event for further modification or injection
+/// Duplicates an `hs.eventtap.event` event for further modification or injection
 ///
 /// Parameters:
 ///  * None
@@ -34,7 +34,7 @@ static int eventtap_event_copy(lua_State* L) {
 /// Method
 /// Gets the keyboard modifiers of an event
 ///
-/// Parametes:
+/// Parameters:
 ///  * None
 ///
 /// Returns:
@@ -70,7 +70,7 @@ static int eventtap_event_getFlags(lua_State* L) {
 ///   * fn
 ///
 /// Returns:
-///  * The `hs.eventap.evant` object.
+///  * The `hs.eventap.event` object.
 static int eventtap_event_setFlags(lua_State* L) {
     CGEventRef event = *(CGEventRef*)luaL_checkudata(L, 1, EVENT_USERDATA_TAG);
     luaL_checktype(L, 2, LUA_TTABLE);

--- a/extensions/fnutils/init.lua
+++ b/extensions/fnutils/init.lua
@@ -65,7 +65,7 @@ end
 ---
 --- Parameters:
 ---  * list - A list-like table, i.e. one whose keys are sequential integers starting from 1
----  * fn - A function taht accepts a single parameter (a table element)
+---  * fn - A function that accepts a single parameter (a table element)
 ---
 --- Returns:
 ---  * None
@@ -462,15 +462,15 @@ fnutils.sortByKeyValues = function(t, f)
   end
 end
 
---- hs.fnutils.split(sString, sSeperator [, nMax] [, bPlain]) -> { array }
+--- hs.fnutils.split(sString, sSeparator [, nMax] [, bPlain]) -> { array }
 --- Function
 --- Convert string to an array of strings, breaking at the specified separator.
 ---
 --- Parameters:
 ---  * sString    -- the string to split into substrings
----  * sSeperator -- the separator.  If `bPlain` is false or not provided, this is treated as a Lua pattern.
+---  * sSeparator -- the separator.  If `bPlain` is false or not provided, this is treated as a Lua pattern.
 ---  * nMax       -- optional parameter specifying the maximum number (or all if `nMax` is nil) of substrings to split from `sString`.
----  * bPlain     -- optional boolean parameter, defaulting to false, specifying if `sSeperator` should be treated as plain text (true) or a Lua pattern (false)
+---  * bPlain     -- optional boolean parameter, defaulting to false, specifying if `sSeparator` should be treated as plain text (true) or a Lua pattern (false)
 ---
 --- Returns:
 ---  * An array of substrings.  The last element of the array will be the remaining portion of `sString` that remains after `nMax` (or all, if `nMax` is not provided or is nil) substrings have been identified.


### PR DESCRIPTION
I came across some typos as I was reading the docs. Here are the fixes :)

