### PR TITLE
More event types for hs.caffeinate.watcher

### DIFF
--- a/extensions/caffeinate/watcher.m
+++ b/extensions/caffeinate/watcher.m
@@ -79,23 +79,23 @@ typedef enum _event_t {
     }
 }
 
-- (void)applicationDidWake:(NSNotification*)notification {
+- (void)caffeinateDidWake:(NSNotification*)notification {
     [self callback:[notification userInfo] withEvent:didWake];
 }
 
-- (void)applicationWillSleep:(NSNotification*)notification {
+- (void)caffeinateWillSleep:(NSNotification*)notification {
     [self callback:[notification userInfo] withEvent:willSleep];
 }
 
-- (void)applicationWillPowerOff:(NSNotification*)notification {
+- (void)caffeinateWillPowerOff:(NSNotification*)notification {
     [self callback:[notification userInfo]  withEvent:willPowerOff];
 }
 
-- (void)applicationScreensDidSleep:(NSNotification*)notification {
+- (void)caffeinateScreensDidSleep:(NSNotification*)notification {
     [self callback:[notification userInfo] withEvent:screensDidSleep];
 }
 
-- (void)applicationScreensDidWake:(NSNotification*)notification {
+- (void)caffeinateScreensDidWake:(NSNotification*)notification {
     [self callback:[notification userInfo] withEvent:screensDidWake];
 }
 @end
@@ -110,7 +110,7 @@ typedef enum _event_t {
 ///
 /// Returns:
 ///  * An `hs.caffeinate.watcher` object
-static int app_watcher_new(lua_State* L) {
+static int caffeinate_watcher_new(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TFUNCTION, LS_TBREAK];
 
@@ -127,30 +127,30 @@ static int app_watcher_new(lua_State* L) {
     return 1;
 }
 
-// Register the CaffeinateWatcher as observer for application specific events.
+// Register the CaffeinateWatcher as observer for sleep/wake events.
 static void register_observer(CaffeinateWatcher* observer) {
     // It is crucial to use the shared workspace notification center here.
     // Otherwise the will not receive the events we are interested in.
     NSNotificationCenter* center = [[NSWorkspace sharedWorkspace] notificationCenter];
     [center addObserver:observer
-               selector:@selector(applicationDidWake:)
+               selector:@selector(caffeinateDidWake:)
                    name:NSWorkspaceDidWakeNotification
                  object:nil];
     [center addObserver:observer
-               selector:@selector(applicationWillSleep:)
+               selector:@selector(caffeinateWillSleep:)
                    name:NSWorkspaceWillSleepNotification
                  object:nil];
     [center addObserver:observer
-               selector:@selector(applicationWillPowerOff:)
+               selector:@selector(caffeinateWillPowerOff:)
                    name:NSWorkspaceWillPowerOffNotification
                  object:nil];
 
     [center addObserver:observer
-               selector:@selector(applicationScreensDidSleep:)
+               selector:@selector(caffeinateScreensDidSleep:)
                    name:NSWorkspaceScreensDidSleepNotification
                  object:nil];
     [center addObserver:observer
-               selector:@selector(applicationScreensDidWake:)
+               selector:@selector(caffeinateScreensDidWake:)
                    name:NSWorkspaceScreensDidWakeNotification
                  object:nil];
 }
@@ -174,7 +174,7 @@ static void unregister_observer(CaffeinateWatcher* observer) {
 ///
 /// Returns:
 ///  * An `hs.caffeinate.watcher` object
-static int app_watcher_start(lua_State* L) {
+static int caffeinate_watcher_start(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
 
@@ -198,7 +198,7 @@ static int app_watcher_start(lua_State* L) {
 ///
 /// Returns:
 ///  * An `hs.caffeinate.watcher` object
-static int app_watcher_stop(lua_State* L) {
+static int caffeinate_watcher_stop(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
 
@@ -214,12 +214,12 @@ static int app_watcher_stop(lua_State* L) {
 }
 
 // Perform cleanup if the CaffeinateWatcher is not required anymore.
-static int app_watcher_gc(lua_State* L) {
+static int caffeinate_watcher_gc(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
 
     caffeinatewatcher_t* caffeinateWatcher = luaL_checkudata(L, 1, USERDATA_TAG);
 
-    app_watcher_stop(L);
+    caffeinate_watcher_stop(L);
 
     caffeinateWatcher->fn = [skin luaUnref:refTable ref:caffeinateWatcher->fn];
 
@@ -254,16 +254,16 @@ static void add_event_enum(lua_State* L) {
 
 // Metatable for created objects when _new invoked
 static const luaL_Reg metaLib[] = {
-    {"start",   app_watcher_start},
-    {"stop",    app_watcher_stop},
-    {"__gc",    app_watcher_gc},
+    {"start",   caffeinate_watcher_start},
+    {"stop",    caffeinate_watcher_stop},
+    {"__gc",    caffeinate_watcher_gc},
     {"__tostring", userdata_tostring},
     {NULL,      NULL}
 };
 
 // Functions for returned object when module loads
-static const luaL_Reg appLib[] = {
-    {"new",     app_watcher_new},
+static const luaL_Reg caffeinateLib[] = {
+    {"new",     caffeinate_watcher_new},
     {NULL,      NULL}
 };
 
@@ -276,7 +276,7 @@ static const luaL_Reg metaGcLib[] = {
 // Called when loading the module. All necessary tables need to be registered here.
 int luaopen_hs_caffeinate_watcher(lua_State* L __unused) {
     LuaSkin *skin = [LuaSkin shared];
-    refTable = [skin registerLibraryWithObject:USERDATA_TAG functions:appLib metaFunctions:metaGcLib objectFunctions:metaLib];
+    refTable = [skin registerLibraryWithObject:USERDATA_TAG functions:caffeinateLib metaFunctions:metaGcLib objectFunctions:metaLib];
 
     add_event_enum(skin.L);
 

--- a/extensions/caffeinate/watcher.m
+++ b/extensions/caffeinate/watcher.m
@@ -64,7 +64,7 @@ typedef enum _event_t {
     return self;
 }
 
-// Call the lua callback function and pass the application name and event type.
+// Call the lua callback function and pass the event type.
 - (void)callback:(NSDictionary* __unused)dict withEvent:(event_t)event {
     LuaSkin *skin = [LuaSkin shared];
     lua_State *L = skin.L;
@@ -105,7 +105,7 @@ typedef enum _event_t {
 /// Creates a watcher object for system and display sleep/wake/power events
 ///
 /// Parameters:
-///  * fn - A function that will be called when system/display events happen. It should accept one parameters:
+///  * fn - A function that will be called when system/display events happen. It should accept one parameter:
 ///   * An event type (see the constants defined above)
 ///
 /// Returns:
@@ -167,7 +167,7 @@ static void unregister_observer(CaffeinateWatcher* observer) {
 
 /// hs.caffeinate.watcher:start()
 /// Method
-/// Starts the application watcher
+/// Starts the sleep/wake watcher
 ///
 /// Parameters:
 ///  * None
@@ -191,7 +191,7 @@ static int app_watcher_start(lua_State* L) {
 
 /// hs.caffeinate.watcher:stop()
 /// Method
-/// Stops the application watcher
+/// Stops the sleep/wake watcher
 ///
 /// Parameters:
 ///  * None


### PR DESCRIPTION
These patches allow you to watch fast user switching and screensaver events. My motivation is to be able to automatically delete keys from the ssh-agent when the screen is locked, or when switching users, or when the machine sleeps.

The new events are:

 * sessionDidResignActive
 * sessionDidBecomeActive
 * screensaverDidStart
 * screensaverWillStop
 * screensaverDidStop
 * screensDidLock
 * screensDidUnlock

The first two are related to fast user switching.
