### PR TITLE
Add support for mapping userdata tags to NSObject subclasses, allowin…

### DIFF
--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -393,11 +393,21 @@ typedef struct luaObjectHelpers {
 /*!
  @abstract Register a luaObjectAtIndex:toClass: conversion helper function for the specified class
 
- @important This method registers a converter functions for use with the luaObjectAtIndex:toClass: method for converting lua tables into NSObjects
+ @important This method registers a converter function for use with the luaObjectAtIndex:toClass: method for converting lua tables into NSObjects
  @param helperFN - a function of the type 'id (*luaObjectHelperFunction) (lua_State *L, int idx)'
  @param className - a string containing the class name of the NSObject type this function can convert
  */
 - (void)registerLuaObjectHelper:(luaObjectHelperFunction)helperFN forClass:(char *)className ;
+
+/*!
+ @abstract Register a luaObjectAtIndex:toClass: conversion helper function for the specified class and record a mapping between a userdata type and the class
+
+ @important This method registers a converter function for use with the luaObjectAtIndex:toClass: method for converting lua tables into NSObjects. It builds on registerLuaObjectHelper:forClass by also storing a mapping between the NSObject class and Lua userdata type so userdata objects of this type can be automatically converted
+ @param helperFN - a function of the type 'id (*luaObjectHelperFunction) (lua_State *L, int idx)'
+ @param className - a string containing the class name of the NSObject type this function can convert
+ @param userdataTag - a string containing the Lua userdata type that can be converted to an NSObject
+ */
+- (void)registerLuaObjectHelper:(luaObjectHelperFunction)helperFN forClass:(char *)className withUserdataMapping:(char *)userdataTag;
 
 /*!
  @abstract Convert a lua geometry object (table with x,y,h, and w keys) into an NSRect

--- a/extensions/image/internal.m
+++ b/extensions/image/internal.m
@@ -491,6 +491,6 @@ int luaopen_hs_image_internal(lua_State* L) {
     pushNSImageNameTable(L); lua_setfield(L, -2, "systemImageNames") ;
 
     [[LuaSkin shared] registerPushNSHelper:NSImage_tolua        forClass:"NSImage"] ;
-    [[LuaSkin shared] registerLuaObjectHelper:HSImage_toNSImage forClass:"NSImage"] ;
+    [[LuaSkin shared] registerLuaObjectHelper:HSImage_toNSImage forClass:"NSImage" withUserdataMapping:USERDATA_TAG] ;
     return 1;
 }


### PR DESCRIPTION
…g toNSObjectAtIndex to converted supported userdata objects in tables to NSObjects

This is definitely one for the eyes of @asmagill :)

The idea here is that I want to be able to bridge a Lua table which contains hs.image objects, into an NSDictionary without walking it and converting each thing individually, so I've taught the toNSObjectAtIndex parts of LuaSkin to be able to inspect userdata and a pre-supplied store of USERDATA_TAG to NSObject class mappings.

This depends on 3d63eb65351431675a10469c59947399113ac49f for storing USERDATA_TAG in the userdata objects, which is already in master because it didn't seem as controversial as this :)