### PR TITLE
Add "Run in Hammerspoon" to OS X Services menu

### DIFF
--- a/Hammerspoon/Hammerspoon-Info.plist
+++ b/Hammerspoon/Hammerspoon-Info.plist
@@ -86,6 +86,33 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSKeyEquivalent</key>
+			<dict>
+				<key>default</key>
+				<string>H</string>
+			</dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Run in Hammerspoon</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>hammerspoonAsService</string>
+			<key>NSPortName</key>
+			<string>${EXECUTABLE_NAME}</string>
+			<key>NSSendTypes</key>
+			<array>
+				<string>public.utf8-plain-text</string>
+			</array>
+			<key>NSReturnTypes</key>
+			<array>
+				<string>public.utf8-plain-text</string>
+			</array>
+		</dict>
+	</array>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/Hammerspoon/MJLua.h
+++ b/Hammerspoon/MJLua.h
@@ -1,5 +1,8 @@
 #import <LuaSkin/LuaSkin.h>
 
+@interface MJLuaAsService : NSObject
+@end
+
 void MJLuaAlloc(void);
 void MJLuaInit(void);
 void MJLuaDeinit(void);


### PR DESCRIPTION
Adds a service which allows you to select text in any Services aware application and tap Cmd-Shift-H (by default) to execute it in Hammerspoon and return the results.

You may need to log out and log back in to get the service to show up when you select text... you could also try `/System/Library/CoreServices/pbs -flush` in the terminal.

I wasn't able to find a way to enable the service automatically... I also had to go into System Preferences->Keyboard->Shortcuts->Services and enable "Run in Hammerspoon" in the Text section.

Since adding a service menu item seems to require editing the application info.plist, it seemed best to go ahead and stick it in MJLua.m/MJLua.h.

Would it be useful/interesting to also have a service which can call a user-defined callback function?  As far as I can tell, each service registered has to be described in an info.plist file somewhere, either in the application or in a bundle installed into Library/Services, so it would be just one callback or have to decide which callback function to invoke based upon something in the selection itself (some of the text, file extension if we add support for files, etc.)

(if I'm wrong about the plist requirement, please chime in, because I'd love to be able to dynamically add them via code in a users init.lua file... I just can't find a way to do it with the searching I've done.)