### PR TITLE
fix nullPtr crash when attempting to set non-image to pasteboard as image

### DIFF
--- a/extensions/image/internal.m
+++ b/extensions/image/internal.m
@@ -459,13 +459,12 @@ static int NSImage_tolua(lua_State *L, id obj) {
 }
 
 static id HSImage_toNSImage(lua_State *L, int idx) {
-    if (luaL_testudata(L, idx, USERDATA_TAG)) {
-        void **thingy = luaL_testudata(L, idx, USERDATA_TAG) ;
-        if (*thingy) {
-            return (__bridge NSImage *) *thingy ;
-        }
+    void *ptr = luaL_testudata(L, idx, USERDATA_TAG) ;
+    if (ptr) {
+        return (__bridge NSImage *)*((void **)ptr) ;
+    } else {
+        return nil ;
     }
-    return nil ;
 }
 
 

--- a/extensions/image/internal.m
+++ b/extensions/image/internal.m
@@ -459,12 +459,13 @@ static int NSImage_tolua(lua_State *L, id obj) {
 }
 
 static id HSImage_toNSImage(lua_State *L, int idx) {
-    void **thingy = luaL_testudata(L, idx, USERDATA_TAG) ;
-    if (*thingy) {
-        return (__bridge NSImage *) *thingy ;
-    } else {
-        return nil ;
+    if (luaL_testudata(L, idx, USERDATA_TAG)) {
+        void **thingy = luaL_testudata(L, idx, USERDATA_TAG) ;
+        if (*thingy) {
+            return (__bridge NSImage *) *thingy ;
+        }
     }
+    return nil ;
 }
 
 

--- a/extensions/pasteboard/internal.m
+++ b/extensions/pasteboard/internal.m
@@ -84,6 +84,7 @@ static int pasteboard_setContents(lua_State* L) {
 /// Returns:
 ///  * True if the operation succeeded, otherwise false
 static int pasteboard_setImageContents(lua_State* L) {
+    [[LuaSkin shared] checkArgs:LS_TUSERDATA, "hs.image", LS_TSTRING | LS_TOPTIONAL, LS_TBREAK] ;
     NSImage*  theImage = [[LuaSkin shared] luaObjectAtIndex:1 toClass:"NSImage"] ;
     NSPasteboard* thePasteboard = lua_to_pasteboard(L, 2);
 


### PR DESCRIPTION
Also add checkArgs to pasteboard's setImageContents

See #732