### PR TITLE
hs.menubar updates

### DIFF
--- a/extensions/menubar/init.lua
+++ b/extensions/menubar/init.lua
@@ -7,6 +7,8 @@ local imagemod = require("hs.image")
 local geometry = require "hs.geometry"
 local screen = require "hs.screen"
 
+require("hs.styledtext")
+
 -- This is the wrapper for hs.menubar:setIcon(). It is documented in internal.m
 
 local menubarObject = hs.getObjectMetatable("hs.menubar")


### PR DESCRIPTION
* add support for styledtext to `title` key for menu items
* add the following keys to menu items: `state`, `tooltip`, `indent`, `image`, `onStateImage`, `offStateImage`, and `mixedStateImage`
* add `stateImageSize` to adjust image size constraints for `*StateImage` keys.

Current `*StateImage` constraint defaults to a box based upon `[[NSFont menuFontOfSize:0] pointSize]` for both `h` and `w`.

Split from #703 into separate pulls.
Module benefits from, but does not require, updates to hs.image, which will follow; specifically adjusting/limiting the size of a menu item image specified with the `image` key.

Module benefits from, but does not require updates to hs.styledtext (in #741) for more easily matching/modifying system fonts.

This component is not expected to have further updates and is ready for merging.
