### PR TITLE
Luaskin userdata struct abstraction

### DIFF
--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -363,7 +363,7 @@ typedef struct _userdata_t {
  @important You must have already registered an object with LuaSkin with the same userdata type that you pass to this method
  @important After calling this method, the userdata object will be at the top of the Lua stack
  @param type A const char * with the name of the userdata type. This is used to fetch the appropriate metatable to apply to the object
- @param obj A pointer to some data structure you wish to store in the userdata object
+ @param obj A pointer to some data structure you wish to store in the userdata object. Note that if this pointer is to an object tracked by ARC (e.g. something derived from NSObject), you should pass it in with a (__bridge_retained void*) cast
 
  @return A boolean, true if the object was created successfully, false if an error occurred
  */
@@ -374,7 +374,7 @@ typedef struct _userdata_t {
 
  @param userData A userdata object previously created with @link userDataAlloc:withObject: @/link
 
- @return A pointer to the object you stored in the userdata object, for you to deallocate it as necessary
+ @return A pointer to the object you stored in the userdata object, for you to deallocate it as necessary. Note that if this pointer is to an object tracked by ARC (e.g. something derived from NSObject), you should receive it with a (__bridge_transfer CLASSTYPE*) cast
  */
 - (void *)userDataGC:(void *)userData;
 
@@ -384,7 +384,7 @@ typedef struct _userdata_t {
 
  @param stackPos An integer stack position to pull the userdata object from
 
- @return A pointer to the object you stored in the userdata object, for you to deallocate it as necessary
+ @return A pointer to the object you stored in the userdata object, for you to deallocate it as necessary. Note that if this pointer is to an object tracked by ARC (e.g. something derived from NSObject), you should receive it with a (__bridge_transfer CLASSTYPE*) cast
  */
 - (void *)userDataGCFromStack:(int)stackPos;
 

--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -350,6 +350,72 @@ typedef id (*luaObjectHelperFunction)(lua_State *L, int idx);
  */
 - (void)checkArgs:(int)firstArg, ...;
 
+#pragma mark - Userdata object lifecycle
+
+typedef struct _userdata_t {
+    void *obj;
+    void *type;
+} lsUserData;
+
+/*!
+ @abstract Allocates a new Lua userdata object of a given type, with a given object pointer
+
+ @important You must have already registered an object with LuaSkin with the same userdata type that you pass to this method
+ @important After calling this method, the userdata object will be at the top of the Lua stack
+ @param type A const char * with the name of the userdata type. This is used to fetch the appropriate metatable to apply to the object
+ @param obj A pointer to some data structure you wish to store in the userdata object
+
+ @return A boolean, true if the object was created successfully, false if an error occurred
+ */
+- (BOOL)userDataAlloc:(const char *)type withObject:(void *)obj;
+
+/*!
+ @abstract Performs LuaSkin related garbage collection on a userdata object
+
+ @param userData A userdata object previously created with @link userDataAlloc:withObject: @/link
+
+ @return A pointer to the object you stored in the userdata object, for you to deallocate it as necessary
+ */
+- (void *)userDataGC:(void *)userData;
+
+/*!
+ @abstract Performs LuaSkin related garbage collection on a userdata object from the stack
+ @important No type verification is performed here, you must have previously validated that the userdata object is of the correct type (e.g. through the use of @link checkArgs: @/link )
+
+ @param stackPos An integer stack position to pull the userdata object from
+
+ @return A pointer to the object you stored in the userdata object, for you to deallocate it as necessary
+ */
+- (void *)userDataGCFromStack:(int)stackPos;
+
+/*!
+ @abstract Gets the type of a LuaSkin userdata object
+
+ @param userData A userdata object previously created with @link userDataAlloc:withObject: @/link
+
+ @return An NSString
+ */
+- (NSString *)userDataType:(void *)userData;
+
+/*!
+ @abstract Gets your object from a LuaSkin userdata object
+
+ @param userData A userdata object previously created with @link userDataAlloc:withObject: @/link
+
+ @return A pointer to the object you stored in the userdata object
+ */
+- (void *)userDataToObject:(void *)userData;
+
+/*!
+ @abstract Gets your object from a LuaSkin userdata object at a position in the stack
+
+ @important No type verification is performed here, you must have previously validated that the userdata object is of the correct type (e.g. through the use of @link checkArgs: @/link )
+ @param stackPos An integer stack position to pull the userdata object from
+
+ @return A pointer to the object you stored in the userdata object
+ */
+- (void *)userDataToObjectFromStack:(int)stackPos;
+
 #pragma mark - Conversion from NSObjects into Lua objects
 
 /*! @methodgroup Converting NSObject objects into Lua variables */

--- a/chooser.h
+++ b/chooser.h
@@ -15,10 +15,5 @@
 
 static int refTable = LUA_NOREF;
 
-typedef struct _chooser_userdata_t {
-    int selfRef;
-    void *chooser;
-} chooser_userdata_t;
-
 #pragma mark - Lua API defines
 static int userdata_gc(lua_State *L);

--- a/extensions/chooser/internal.m
+++ b/extensions/chooser/internal.m
@@ -17,19 +17,14 @@ static int chooserNew(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TFUNCTION, LS_TBREAK];
 
-    // Create the userdata object
-    chooser_userdata_t *userData = lua_newuserdata(L, sizeof(chooser_userdata_t));
-    memset(userData, 0, sizeof(chooser_userdata_t));
-    luaL_getmetatable(L, USERDATA_TAG);
-    lua_setmetatable(L, -2);
-
     // Parse function arguents
     lua_pushvalue(L, 1);
     int completionCallbackRef = [skin luaRef:refTable];
 
     // Create the HSChooser object with our arguments
     HSChooser *chooser = [[HSChooser alloc] initWithRefTable:&refTable completionCallbackRef:completionCallbackRef];
-    userData->chooser = (__bridge_retained void*)chooser;
+
+    [skin userDataAlloc:USERDATA_TAG withObject:(__bridge_retained void *)chooser];
 
     return 1;
 }
@@ -49,8 +44,7 @@ static int chooserShow(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     [chooser show];
 
@@ -71,8 +65,7 @@ static int chooserHide(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     [chooser hide];
 
@@ -122,8 +115,7 @@ static int chooserSetChoices(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION | LS_TTABLE | LS_TNIL, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     chooser.choicesCallbackRef = [skin luaUnref:refTable ref:chooser.choicesCallbackRef];
     [chooser clearChoices];
@@ -184,8 +176,7 @@ static int chooserRefreshChoicesCallback(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     if (chooser.choicesCallbackRef != LUA_NOREF && chooser.choicesCallbackRef != LUA_REFNIL) {
         [chooser clearChoices];
@@ -210,8 +201,7 @@ static int chooserSetQuery(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TOPTIONAL, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     switch (lua_type(L, 2)) {
         case LUA_TSTRING:
@@ -250,8 +240,7 @@ static int chooserQueryCallback(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION|LS_TOPTIONAL, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     chooser.queryChangedCallbackRef = [skin luaUnref:refTable ref:chooser.queryChangedCallbackRef];
 
@@ -261,22 +250,6 @@ static int chooserQueryCallback(lua_State *L) {
 
     lua_pushvalue(L, 1);
     return 1;
-}
-
-/// hs.chooser:delete()
-/// Method
-/// Deletes a chooser
-///
-/// Parameters:
-///  * None
-///
-/// Returns:
-///  * None
-static int chooserDelete(lua_State *L) {
-    LuaSkin *skin = [LuaSkin shared];
-    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
-
-    return userdata_gc(L);
 }
 
 /// hs.chooser:fgColor(color) -> hs.chooser object
@@ -292,8 +265,7 @@ static int chooserSetFgColor(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TTABLE | LS_TNIL | LS_TOPTIONAL, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     switch (lua_type(L, 2)) {
         case LUA_TTABLE:
@@ -332,8 +304,7 @@ static int chooserSetSubTextColor(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TTABLE | LS_TNIL | LS_TOPTIONAL, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     switch (lua_type(L, 2)) {
         case LUA_TTABLE:
@@ -375,8 +346,7 @@ static int chooserSetBgDark(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     BOOL beDark;
 
@@ -416,8 +386,7 @@ static int chooserSetSearchSubText(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     switch (lua_type(L, 2)) {
         case LUA_TBOOLEAN:
@@ -454,8 +423,7 @@ static int chooserSetWidth(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TNUMBER | LS_TOPTIONAL, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     switch (lua_type(L, 2)) {
         case LUA_TNUMBER:
@@ -489,8 +457,7 @@ static int chooserSetNumRows(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TNUMBER | LS_TOPTIONAL, LS_TBREAK];
 
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+    HSChooser *chooser = [skin userDataToObjectFromStack:1];
 
     switch (lua_type(L, 2)) {
         case LUA_TNUMBER:
@@ -515,15 +482,15 @@ static int chooserSetNumRows(lua_State *L) {
 
 static int userdata_tostring(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    [skin pushNSObject:[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, userData]];
+    [skin pushNSObject:[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, [skin userDataToObjectFromStack:1]]];
     return 1;
 }
 
 static int userdata_gc(lua_State* L) {
-    chooser_userdata_t *userData = lua_touserdata(L, 1);
-    HSChooser *chooser = (__bridge_transfer HSChooser *)userData->chooser;
-    userData->chooser = nil;
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
+
+    HSChooser *chooser = (__bridge_transfer HSChooser *)[skin userDataGCFromStack:1];
     chooser = nil;
 
     return 0;
@@ -542,7 +509,6 @@ static const luaL_Reg userdataLib[] = {
     {"choices", chooserSetChoices},
     {"queryChangedCallback", chooserQueryCallback},
     {"query", chooserSetQuery},
-    {"delete", chooserDelete},
     {"refreshChoicesCallback", chooserRefreshChoicesCallback},
 
     {"fgColor", chooserSetFgColor},
@@ -559,10 +525,8 @@ static const luaL_Reg userdataLib[] = {
 
 int luaopen_hs_chooser_internal(__unused lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
-    refTable = [skin registerLibraryWithObject:USERDATA_TAG
-                                     functions:chooserLib
-                                 metaFunctions:nil
-                               objectFunctions:userdataLib];
+    refTable = [skin registerLibrary:chooserLib metaFunctions:nil];
+    [skin registerObject:USERDATA_TAG objectFunctions:userdataLib];
 
     return 1;
 }


### PR DESCRIPTION
This adds userdata abstraction to LuaSkin by always having the module's userdata pointer be stored in a struct. This way we have a guaranteed separation of the management of memory allocation between Lua and CoreFoundation/Cocoa/ObjC/etc.

As a proof of what this looks like in use, this PR converts hs.chooser, hs.screen and hs.timer. Respectively, they were using their own struct, a pointer-to-NSObject-pointer and a struct containing a CFTypeRef.

In the case of hs.chooser and hs.screen, the NSObjects are given to LuaSkin, in the case of hs.timer, a new NSObject is created to encapsulate both the CFTypeRef and the associated properties that were previously in the userdata struct.

While this isn't a completely huge win, I think that simplifying the pointer-to-NSObject-pointer case alone justifies this, and over time I would expect all of the modules to a) migrate to this abstraction, b) use local NSObjects to encapsulate all their userdata state. For modules that already have an NSObject class relating to userdata, I'll migrate any associated properties into the class. For those that don't, I'll replace their existing structs with a class.

@asmagill I know you're a little unsure of this, but I hope it seems at least unobjectionable from the POV of simplifying another area of module<->Lua interaction :)
