### PR TITLE
Fix some autocomplete annoyances

### DIFF
--- a/Hammerspoon/MJConsoleWindowController.m
+++ b/Hammerspoon/MJConsoleWindowController.m
@@ -167,6 +167,8 @@ void MJConsoleWindowSetAlwaysOnTop(BOOL alwaysOnTop) {
              indexOfSelectedItem:(NSInteger *)index
 {
     NSString *currentText = textView.string;
+    NSString *textBeforeCursor = [currentText substringToIndex:NSMaxRange(charRange)];
+    NSString *textAfterCursor = [currentText substringFromIndex:NSMaxRange(charRange)];
     NSString *completionWord = [currentText substringWithRange:charRange];
     NSArray *completions = MJLuaCompletionsForWord(completionWord);
     if (completions.count == 1) {
@@ -180,7 +182,8 @@ void MJConsoleWindowSetAlwaysOnTop(BOOL alwaysOnTop) {
             stringToAdd = [completeWith substringFromIndex:[completionWord length]];
         }
 
-        textView.string = [NSString stringWithFormat:@"%@%@", currentText, stringToAdd];
+        textView.string = [NSString stringWithFormat:@"%@%@%@", textBeforeCursor, stringToAdd, textAfterCursor];
+        [textView setSelectedRange:NSMakeRange(NSMaxRange(charRange) + stringToAdd.length, 0)];
         return @[];
     }
     return completions;


### PR DESCRIPTION
Allows autocomplete for `table` objects ( `myHotkey:enable/disable`), where before only `userdata` objects autocompleted.

Allows you to autocomplete properly when you move the cursor, where before it would mangle text.

Functions are appended with '(' rather than '()' since there are usually arguments to type.

Allows autocomplete after '(' or '[' by resetting the completionWord because OS X's completion API has opaque rules for what it considers a completable word.

Reduces some errors with overeager use of tab.