### PR TITLE
Reset accumulated data upon new http response in accordance with docs

### DIFF
--- a/extensions/http/internal.m
+++ b/extensions/http/internal.m
@@ -45,8 +45,15 @@ static void remove_delegate(__unused lua_State* L, connectionDelegate* delegate)
 
 // Implementation of the connectionDelegate. If the property fn equals LUA_NOREF
 // no lua operations will be performed in the callbacks
+//
+// From Apple: In rare cases, for example in the case of an HTTP load where the content type
+// of the load data is multipart/x-mixed-replace, the delegate will receive more than one
+// connection:didReceiveResponse: message. When this happens, discard (or process) all
+// data previously delivered by connection:didReceiveData:, and prepare to handle the
+// next part (which could potentially have a different MIME type).
 @implementation connectionDelegate
 - (void)connection:(NSURLConnection * __unused)connection didReceiveResponse:(NSURLResponse *)response {
+    [self.receivedData setLength:0];
     self.httpResponse = (NSHTTPURLResponse *)response;
 }
 


### PR DESCRIPTION
Occasionally, data corruption as described in #759 can occur if more than one `didReceiveResponse` message is received by `NSURLConnectionDelegate` (a retry if you will) and the accumulated `receivedData` buffer is not cleared.  The metadata provided by the response (content-length, etc) is describing invalidated data. Clearing the buffer upon receipt of a new response should keep the `receivedData` buffer and the response metadata in sync and prevent data corruption.

From [Apple](https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSURLConnectionDataDelegate_protocol/index.html#//apple_ref/occ/intfm/NSURLConnectionDataDelegate/connection:didReceiveResponse:)
>In rare cases, for example in the case of an HTTP load where the content type of the load data is multipart/x-mixed-replace, the delegate will receive more than one connection:didReceiveResponse: message. When this happens, discard (or process) all data previously delivered by connection:didReceiveData:, and prepare to handle the next part (which could potentially have a different MIME type).