### PR TITLE
add hs.network submodules

### DIFF
--- a/Hammerspoon.xcodeproj/project.pbxproj
+++ b/Hammerspoon.xcodeproj/project.pbxproj
@@ -322,6 +322,19 @@
 		D642088D1BE3CDA500673724 /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F0F97561ADE9F8600F2A199 /* Fabric.framework */; };
 		D64208981BE3CDFD00673724 /* internal.m in Sources */ = {isa = PBXBuildFile; fileRef = D64208951BE3CDEB00673724 /* internal.m */; };
 		D643B73D1B8BFE7700B372EB /* libedit.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D643B73C1B8BFE7700B372EB /* libedit.dylib */; };
+		D6477C0E1C5ED5D000F67BBC /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9445CA0E19083251002568BB /* Cocoa.framework */; };
+		D6477C0F1C5ED5D000F67BBC /* LuaSkin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F9850E81B722CBF00F7E909 /* LuaSkin.framework */; };
+		D6477C151C5ED61500F67BBC /* configurationinternal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6477BFD1C5ED5A600F67BBC /* configurationinternal.m */; };
+		D6477C191C5ED64100F67BBC /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6477C181C5ED64100F67BBC /* SystemConfiguration.framework */; };
+		D6477C221C5ED82200F67BBC /* reachabilityinternal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6477C021C5ED5A600F67BBC /* reachabilityinternal.m */; };
+		D6477C251C5ED82200F67BBC /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6477C181C5ED64100F67BBC /* SystemConfiguration.framework */; };
+		D6477C261C5ED82200F67BBC /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9445CA0E19083251002568BB /* Cocoa.framework */; };
+		D6477C271C5ED82200F67BBC /* LuaSkin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F9850E81B722CBF00F7E909 /* LuaSkin.framework */; };
+		D6477C301C5ED83C00F67BBC /* hostinternal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6477BFF1C5ED5A600F67BBC /* hostinternal.m */; };
+		D6477C331C5ED83C00F67BBC /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6477C1A1C5ED64900F67BBC /* CFNetwork.framework */; };
+		D6477C341C5ED83C00F67BBC /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6477C181C5ED64100F67BBC /* SystemConfiguration.framework */; };
+		D6477C351C5ED83C00F67BBC /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9445CA0E19083251002568BB /* Cocoa.framework */; };
+		D6477C361C5ED83C00F67BBC /* LuaSkin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F9850E81B722CBF00F7E909 /* LuaSkin.framework */; };
 		D64B03371BA954290006C468 /* webview.h in Headers */ = {isa = PBXBuildFile; fileRef = D64B03361BA9541E0006C468 /* webview.h */; };
 		D64B033E1BA954780006C468 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9473A75C1959F9AB0080C329 /* WebKit.framework */; };
 		D64B033F1BA954780006C468 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9445CA0E19083251002568BB /* Cocoa.framework */; };
@@ -742,6 +755,27 @@
 			remoteGlobalIDString = D64208871BE3CDA500673724;
 			remoteInfo = javascript;
 		};
+		D6477C1C1C5ED69700F67BBC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9445CA0319083251002568BB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D6477C0A1C5ED5D000F67BBC;
+			remoteInfo = network;
+		};
+		D6477C3C1C5EDA0500F67BBC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9445CA0319083251002568BB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D6477C2D1C5ED83C00F67BBC;
+			remoteInfo = networkhost;
+		};
+		D6477C3E1C5EDA0500F67BBC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9445CA0319083251002568BB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D6477C1E1C5ED82200F67BBC;
+			remoteInfo = networkreachability;
+		};
 		D64B03481BA955180006C468 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9445CA0319083251002568BB /* Project object */;
@@ -1070,6 +1104,18 @@
 		D64208941BE3CDEB00673724 /* init.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = init.lua; path = extensions/javascript/init.lua; sourceTree = "<group>"; };
 		D64208951BE3CDEB00673724 /* internal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = internal.m; path = extensions/javascript/internal.m; sourceTree = "<group>"; };
 		D643B73C1B8BFE7700B372EB /* libedit.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libedit.dylib; path = usr/lib/libedit.dylib; sourceTree = SDKROOT; };
+		D6477BFC1C5ED5A600F67BBC /* configuration.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = configuration.lua; path = extensions/network/configuration.lua; sourceTree = "<group>"; };
+		D6477BFD1C5ED5A600F67BBC /* configurationinternal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = configurationinternal.m; path = extensions/network/configurationinternal.m; sourceTree = "<group>"; };
+		D6477BFE1C5ED5A600F67BBC /* host.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = host.lua; path = extensions/network/host.lua; sourceTree = "<group>"; };
+		D6477BFF1C5ED5A600F67BBC /* hostinternal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = hostinternal.m; path = extensions/network/hostinternal.m; sourceTree = "<group>"; };
+		D6477C001C5ED5A600F67BBC /* init.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = init.lua; path = extensions/network/init.lua; sourceTree = "<group>"; };
+		D6477C011C5ED5A600F67BBC /* reachability.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = reachability.lua; path = extensions/network/reachability.lua; sourceTree = "<group>"; };
+		D6477C021C5ED5A600F67BBC /* reachabilityinternal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = reachabilityinternal.m; path = extensions/network/reachabilityinternal.m; sourceTree = "<group>"; };
+		D6477C141C5ED5D000F67BBC /* libnetworkconfiguration.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libnetworkconfiguration.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6477C181C5ED64100F67BBC /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		D6477C1A1C5ED64900F67BBC /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		D6477C2C1C5ED82200F67BBC /* libnetworkreachability.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libnetworkreachability.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6477C3B1C5ED83C00F67BBC /* libnetworkhost.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libnetworkhost.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		D64B03361BA9541E0006C468 /* webview.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = webview.h; path = extensions/webview/webview.h; sourceTree = "<group>"; };
 		D64B03381BA954660006C468 /* usercontent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = usercontent.m; path = extensions/webview/usercontent.m; sourceTree = "<group>"; };
 		D64B03461BA954780006C468 /* libwebviewusercontent.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libwebviewusercontent.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1699,6 +1745,37 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D6477C0D1C5ED5D000F67BBC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6477C191C5ED64100F67BBC /* SystemConfiguration.framework in Frameworks */,
+				D6477C0E1C5ED5D000F67BBC /* Cocoa.framework in Frameworks */,
+				D6477C0F1C5ED5D000F67BBC /* LuaSkin.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6477C231C5ED82200F67BBC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6477C251C5ED82200F67BBC /* SystemConfiguration.framework in Frameworks */,
+				D6477C261C5ED82200F67BBC /* Cocoa.framework in Frameworks */,
+				D6477C271C5ED82200F67BBC /* LuaSkin.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6477C321C5ED83C00F67BBC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6477C331C5ED83C00F67BBC /* CFNetwork.framework in Frameworks */,
+				D6477C341C5ED83C00F67BBC /* SystemConfiguration.framework in Frameworks */,
+				D6477C351C5ED83C00F67BBC /* Cocoa.framework in Frameworks */,
+				D6477C361C5ED83C00F67BBC /* LuaSkin.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D64B033D1BA954780006C468 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -2204,6 +2281,7 @@
 				4F6B3EEB1B73E64A00B2A4DE /* milight */,
 				4F6B3EEF1B73E77D00B2A4DE /* mjomatic */,
 				4F6B3EFC1B73E7E200B2A4DE /* mouse */,
+				D6477BFB1C5ED57400F67BBC /* network */,
 				4F6B3F0F1B73E9BA00B2A4DE /* notify */,
 				4F6B3F241B73EBF000B2A4DE /* pasteboard */,
 				4F6B3F361B73EE0E00B2A4DE /* pathwatcher */,
@@ -2614,6 +2692,9 @@
 				4F20B5291C1F1C5B00F52437 /* Hammerspoon UI Tests.xctest */,
 				4F29C23D1C29E0A300B8A69D /* libfsvolume.dylib */,
 				4F51345E1C2F315C00EFD6D4 /* libchooser.dylib */,
+				D6477C141C5ED5D000F67BBC /* libnetworkconfiguration.dylib */,
+				D6477C2C1C5ED82200F67BBC /* libnetworkreachability.dylib */,
+				D6477C3B1C5ED83C00F67BBC /* libnetworkhost.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2621,6 +2702,8 @@
 		9445CA0D19083251002568BB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D6477C1A1C5ED64900F67BBC /* CFNetwork.framework */,
+				D6477C181C5ED64100F67BBC /* SystemConfiguration.framework */,
 				D643B73C1B8BFE7700B372EB /* libedit.dylib */,
 				4FD0ABAC1B74AE9900A82496 /* CoreWLAN.framework */,
 				4FD0AB261B7485A000A82496 /* CoreGraphics.framework */,
@@ -2753,6 +2836,20 @@
 				D64208951BE3CDEB00673724 /* internal.m */,
 			);
 			name = javascript;
+			sourceTree = "<group>";
+		};
+		D6477BFB1C5ED57400F67BBC /* network */ = {
+			isa = PBXGroup;
+			children = (
+				D6477BFC1C5ED5A600F67BBC /* configuration.lua */,
+				D6477BFD1C5ED5A600F67BBC /* configurationinternal.m */,
+				D6477BFE1C5ED5A600F67BBC /* host.lua */,
+				D6477BFF1C5ED5A600F67BBC /* hostinternal.m */,
+				D6477C001C5ED5A600F67BBC /* init.lua */,
+				D6477C011C5ED5A600F67BBC /* reachability.lua */,
+				D6477C021C5ED5A600F67BBC /* reachabilityinternal.m */,
+			);
+			name = network;
 			sourceTree = "<group>";
 		};
 		D64B03351BA953E60006C468 /* webviewusercontent */ = {
@@ -3190,6 +3287,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		D642088E1BE3CDA500673724 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6477C101C5ED5D000F67BBC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6477C281C5ED82200F67BBC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6477C371C5ED83C00F67BBC /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4167,6 +4285,9 @@
 			buildRules = (
 			);
 			dependencies = (
+				D6477C3F1C5EDA0500F67BBC /* PBXTargetDependency */,
+				D6477C3D1C5EDA0500F67BBC /* PBXTargetDependency */,
+				D6477C1D1C5ED69700F67BBC /* PBXTargetDependency */,
 				D64B03491BA955180006C468 /* PBXTargetDependency */,
 				D64125681BA07D35000FB5F8 /* PBXTargetDependency */,
 				4FD0ABC61B74AFD700A82496 /* PBXTargetDependency */,
@@ -4283,6 +4404,57 @@
 			name = javascript;
 			productName = alert;
 			productReference = D64208921BE3CDA500673724 /* libjavascript.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		D6477C0A1C5ED5D000F67BBC /* networkconfiguration */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6477C111C5ED5D000F67BBC /* Build configuration list for PBXNativeTarget "networkconfiguration" */;
+			buildPhases = (
+				D6477C0B1C5ED5D000F67BBC /* Sources */,
+				D6477C0D1C5ED5D000F67BBC /* Frameworks */,
+				D6477C101C5ED5D000F67BBC /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = networkconfiguration;
+			productName = alert;
+			productReference = D6477C141C5ED5D000F67BBC /* libnetworkconfiguration.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		D6477C1E1C5ED82200F67BBC /* networkreachability */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6477C291C5ED82200F67BBC /* Build configuration list for PBXNativeTarget "networkreachability" */;
+			buildPhases = (
+				D6477C1F1C5ED82200F67BBC /* Sources */,
+				D6477C231C5ED82200F67BBC /* Frameworks */,
+				D6477C281C5ED82200F67BBC /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = networkreachability;
+			productName = alert;
+			productReference = D6477C2C1C5ED82200F67BBC /* libnetworkreachability.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		D6477C2D1C5ED83C00F67BBC /* networkhost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6477C381C5ED83C00F67BBC /* Build configuration list for PBXNativeTarget "networkhost" */;
+			buildPhases = (
+				D6477C2E1C5ED83C00F67BBC /* Sources */,
+				D6477C321C5ED83C00F67BBC /* Frameworks */,
+				D6477C371C5ED83C00F67BBC /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = networkhost;
+			productName = alert;
+			productReference = D6477C3B1C5ED83C00F67BBC /* libnetworkhost.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 		D64B033A1BA954780006C468 /* webviewusercontent */ = {
@@ -4467,6 +4639,9 @@
 				4F6B3EC81B73E23800B2A4DE /* menubar */,
 				4F6B3EDD1B73E5AC00B2A4DE /* milight */,
 				4F6B3EF11B73E7C200B2A4DE /* mouse */,
+				D6477C0A1C5ED5D000F67BBC /* networkconfiguration */,
+				D6477C2D1C5ED83C00F67BBC /* networkhost */,
+				D6477C1E1C5ED82200F67BBC /* networkreachability */,
 				4F6B3F021B73E98E00B2A4DE /* notify */,
 				4F6B3F171B73EBB500B2A4DE /* pasteboard */,
 				4F6B3F281B73EDD100B2A4DE /* pathwatcher */,
@@ -5170,6 +5345,30 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D6477C0B1C5ED5D000F67BBC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6477C151C5ED61500F67BBC /* configurationinternal.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6477C1F1C5ED82200F67BBC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6477C221C5ED82200F67BBC /* reachabilityinternal.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6477C2E1C5ED83C00F67BBC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6477C301C5ED83C00F67BBC /* hostinternal.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D64B033B1BA954780006C468 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -5500,6 +5699,21 @@
 			isa = PBXTargetDependency;
 			target = D64208871BE3CDA500673724 /* javascript */;
 			targetProxy = D64208991BE3CE1F00673724 /* PBXContainerItemProxy */;
+		};
+		D6477C1D1C5ED69700F67BBC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D6477C0A1C5ED5D000F67BBC /* networkconfiguration */;
+			targetProxy = D6477C1C1C5ED69700F67BBC /* PBXContainerItemProxy */;
+		};
+		D6477C3D1C5EDA0500F67BBC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D6477C2D1C5ED83C00F67BBC /* networkhost */;
+			targetProxy = D6477C3C1C5EDA0500F67BBC /* PBXContainerItemProxy */;
+		};
+		D6477C3F1C5EDA0500F67BBC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D6477C1E1C5ED82200F67BBC /* networkreachability */;
+			targetProxy = D6477C3E1C5EDA0500F67BBC /* PBXContainerItemProxy */;
 		};
 		D64B03491BA955180006C468 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -13150,6 +13364,414 @@
 			};
 			name = Release;
 		};
+		D6477C121C5ED5D000F67BBC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = "$(inherited)";
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = "$(inherited)";
+				CLANG_WARN_ASSIGN_ENUM = "$(inherited)";
+				CLANG_WARN_BOOL_CONVERSION = "$(inherited)";
+				CLANG_WARN_CONSTANT_CONVERSION = "$(inherited)";
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = "$(inherited)";
+				CLANG_WARN_EMPTY_BODY = "$(inherited)";
+				CLANG_WARN_ENUM_CONVERSION = "$(inherited)";
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = "$(inherited)";
+				CLANG_WARN_INT_CONVERSION = "$(inherited)";
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = "$(inherited)";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = "$(inherited)";
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = "$(inherited)";
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = "$(inherited)";
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = "$(inherited)";
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = "$(inherited)";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = "$(inherited)";
+				ENABLE_TESTABILITY = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = "$(inherited)";
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = "$(inherited)";
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = "$(inherited)";
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = "$(inherited)";
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = "$(inherited)";
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = "$(inherited)";
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = "$(inherited)";
+				GCC_WARN_MISSING_PARENTHESES = "$(inherited)";
+				GCC_WARN_MULTIPLE_DEFINITION_TYPES_FOR_SELECTOR = "$(inherited)";
+				GCC_WARN_PEDANTIC = "$(inherited)";
+				GCC_WARN_SHADOW = "$(inherited)";
+				GCC_WARN_SIGN_COMPARE = "$(inherited)";
+				GCC_WARN_STRICT_SELECTOR_MATCH = "$(inherited)";
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = "$(inherited)";
+				GCC_WARN_UNDECLARED_SELECTOR = "$(inherited)";
+				GCC_WARN_UNKNOWN_PRAGMAS = "$(inherited)";
+				GCC_WARN_UNUSED_FUNCTION = "$(inherited)";
+				GCC_WARN_UNUSED_LABEL = "$(inherited)";
+				GCC_WARN_UNUSED_PARAMETER = "$(inherited)";
+				GCC_WARN_UNUSED_VALUE = "$(inherited)";
+				GCC_WARN_UNUSED_VARIABLE = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_CLANG_STATIC_ANALYZER = "$(inherited)";
+				SDKROOT = "$(inherited)";
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Debug;
+		};
+		D6477C131C5ED5D000F67BBC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = "$(inherited)";
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = "$(inherited)";
+				CLANG_WARN_ASSIGN_ENUM = "$(inherited)";
+				CLANG_WARN_BOOL_CONVERSION = "$(inherited)";
+				CLANG_WARN_CONSTANT_CONVERSION = "$(inherited)";
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = "$(inherited)";
+				CLANG_WARN_EMPTY_BODY = "$(inherited)";
+				CLANG_WARN_ENUM_CONVERSION = "$(inherited)";
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = "$(inherited)";
+				CLANG_WARN_INT_CONVERSION = "$(inherited)";
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = "$(inherited)";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = "$(inherited)";
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = "$(inherited)";
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = "$(inherited)";
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = "$(inherited)";
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = "$(inherited)";
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = "$(inherited)";
+				EXECUTABLE_PREFIX = lib;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = "$(inherited)";
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = "$(inherited)";
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = "$(inherited)";
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = "$(inherited)";
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = "$(inherited)";
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = "$(inherited)";
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = "$(inherited)";
+				GCC_WARN_MISSING_PARENTHESES = "$(inherited)";
+				GCC_WARN_MULTIPLE_DEFINITION_TYPES_FOR_SELECTOR = "$(inherited)";
+				GCC_WARN_PEDANTIC = "$(inherited)";
+				GCC_WARN_SHADOW = "$(inherited)";
+				GCC_WARN_SIGN_COMPARE = "$(inherited)";
+				GCC_WARN_STRICT_SELECTOR_MATCH = "$(inherited)";
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = "$(inherited)";
+				GCC_WARN_UNDECLARED_SELECTOR = "$(inherited)";
+				GCC_WARN_UNKNOWN_PRAGMAS = "$(inherited)";
+				GCC_WARN_UNUSED_FUNCTION = "$(inherited)";
+				GCC_WARN_UNUSED_LABEL = "$(inherited)";
+				GCC_WARN_UNUSED_PARAMETER = "$(inherited)";
+				GCC_WARN_UNUSED_VALUE = "$(inherited)";
+				GCC_WARN_UNUSED_VARIABLE = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_CLANG_STATIC_ANALYZER = "$(inherited)";
+				SDKROOT = "$(inherited)";
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Release;
+		};
+		D6477C2A1C5ED82200F67BBC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = "$(inherited)";
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = "$(inherited)";
+				CLANG_WARN_ASSIGN_ENUM = "$(inherited)";
+				CLANG_WARN_BOOL_CONVERSION = "$(inherited)";
+				CLANG_WARN_CONSTANT_CONVERSION = "$(inherited)";
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = "$(inherited)";
+				CLANG_WARN_EMPTY_BODY = "$(inherited)";
+				CLANG_WARN_ENUM_CONVERSION = "$(inherited)";
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = "$(inherited)";
+				CLANG_WARN_INT_CONVERSION = "$(inherited)";
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = "$(inherited)";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = "$(inherited)";
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = "$(inherited)";
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = "$(inherited)";
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = "$(inherited)";
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = "$(inherited)";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = "$(inherited)";
+				ENABLE_TESTABILITY = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = "$(inherited)";
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = "$(inherited)";
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = "$(inherited)";
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = "$(inherited)";
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = "$(inherited)";
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = "$(inherited)";
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = "$(inherited)";
+				GCC_WARN_MISSING_PARENTHESES = "$(inherited)";
+				GCC_WARN_MULTIPLE_DEFINITION_TYPES_FOR_SELECTOR = "$(inherited)";
+				GCC_WARN_PEDANTIC = "$(inherited)";
+				GCC_WARN_SHADOW = "$(inherited)";
+				GCC_WARN_SIGN_COMPARE = "$(inherited)";
+				GCC_WARN_STRICT_SELECTOR_MATCH = "$(inherited)";
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = "$(inherited)";
+				GCC_WARN_UNDECLARED_SELECTOR = "$(inherited)";
+				GCC_WARN_UNKNOWN_PRAGMAS = "$(inherited)";
+				GCC_WARN_UNUSED_FUNCTION = "$(inherited)";
+				GCC_WARN_UNUSED_LABEL = "$(inherited)";
+				GCC_WARN_UNUSED_PARAMETER = "$(inherited)";
+				GCC_WARN_UNUSED_VALUE = "$(inherited)";
+				GCC_WARN_UNUSED_VARIABLE = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_CLANG_STATIC_ANALYZER = "$(inherited)";
+				SDKROOT = "$(inherited)";
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Debug;
+		};
+		D6477C2B1C5ED82200F67BBC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = "$(inherited)";
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = "$(inherited)";
+				CLANG_WARN_ASSIGN_ENUM = "$(inherited)";
+				CLANG_WARN_BOOL_CONVERSION = "$(inherited)";
+				CLANG_WARN_CONSTANT_CONVERSION = "$(inherited)";
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = "$(inherited)";
+				CLANG_WARN_EMPTY_BODY = "$(inherited)";
+				CLANG_WARN_ENUM_CONVERSION = "$(inherited)";
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = "$(inherited)";
+				CLANG_WARN_INT_CONVERSION = "$(inherited)";
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = "$(inherited)";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = "$(inherited)";
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = "$(inherited)";
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = "$(inherited)";
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = "$(inherited)";
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = "$(inherited)";
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = "$(inherited)";
+				EXECUTABLE_PREFIX = lib;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = "$(inherited)";
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = "$(inherited)";
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = "$(inherited)";
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = "$(inherited)";
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = "$(inherited)";
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = "$(inherited)";
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = "$(inherited)";
+				GCC_WARN_MISSING_PARENTHESES = "$(inherited)";
+				GCC_WARN_MULTIPLE_DEFINITION_TYPES_FOR_SELECTOR = "$(inherited)";
+				GCC_WARN_PEDANTIC = "$(inherited)";
+				GCC_WARN_SHADOW = "$(inherited)";
+				GCC_WARN_SIGN_COMPARE = "$(inherited)";
+				GCC_WARN_STRICT_SELECTOR_MATCH = "$(inherited)";
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = "$(inherited)";
+				GCC_WARN_UNDECLARED_SELECTOR = "$(inherited)";
+				GCC_WARN_UNKNOWN_PRAGMAS = "$(inherited)";
+				GCC_WARN_UNUSED_FUNCTION = "$(inherited)";
+				GCC_WARN_UNUSED_LABEL = "$(inherited)";
+				GCC_WARN_UNUSED_PARAMETER = "$(inherited)";
+				GCC_WARN_UNUSED_VALUE = "$(inherited)";
+				GCC_WARN_UNUSED_VARIABLE = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_CLANG_STATIC_ANALYZER = "$(inherited)";
+				SDKROOT = "$(inherited)";
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Release;
+		};
+		D6477C391C5ED83C00F67BBC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = "$(inherited)";
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = "$(inherited)";
+				CLANG_WARN_ASSIGN_ENUM = "$(inherited)";
+				CLANG_WARN_BOOL_CONVERSION = "$(inherited)";
+				CLANG_WARN_CONSTANT_CONVERSION = "$(inherited)";
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = "$(inherited)";
+				CLANG_WARN_EMPTY_BODY = "$(inherited)";
+				CLANG_WARN_ENUM_CONVERSION = "$(inherited)";
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = "$(inherited)";
+				CLANG_WARN_INT_CONVERSION = "$(inherited)";
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = "$(inherited)";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = "$(inherited)";
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = "$(inherited)";
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = "$(inherited)";
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = "$(inherited)";
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = "$(inherited)";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = "$(inherited)";
+				ENABLE_TESTABILITY = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = "$(inherited)";
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = "$(inherited)";
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = "$(inherited)";
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = "$(inherited)";
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = "$(inherited)";
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = "$(inherited)";
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = "$(inherited)";
+				GCC_WARN_MISSING_PARENTHESES = "$(inherited)";
+				GCC_WARN_MULTIPLE_DEFINITION_TYPES_FOR_SELECTOR = "$(inherited)";
+				GCC_WARN_PEDANTIC = "$(inherited)";
+				GCC_WARN_SHADOW = "$(inherited)";
+				GCC_WARN_SIGN_COMPARE = "$(inherited)";
+				GCC_WARN_STRICT_SELECTOR_MATCH = "$(inherited)";
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = "$(inherited)";
+				GCC_WARN_UNDECLARED_SELECTOR = "$(inherited)";
+				GCC_WARN_UNKNOWN_PRAGMAS = "$(inherited)";
+				GCC_WARN_UNUSED_FUNCTION = "$(inherited)";
+				GCC_WARN_UNUSED_LABEL = "$(inherited)";
+				GCC_WARN_UNUSED_PARAMETER = "$(inherited)";
+				GCC_WARN_UNUSED_VALUE = "$(inherited)";
+				GCC_WARN_UNUSED_VARIABLE = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_CLANG_STATIC_ANALYZER = "$(inherited)";
+				SDKROOT = "$(inherited)";
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Debug;
+		};
+		D6477C3A1C5ED83C00F67BBC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = "$(inherited)";
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = "$(inherited)";
+				CLANG_WARN_ASSIGN_ENUM = "$(inherited)";
+				CLANG_WARN_BOOL_CONVERSION = "$(inherited)";
+				CLANG_WARN_CONSTANT_CONVERSION = "$(inherited)";
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = "$(inherited)";
+				CLANG_WARN_EMPTY_BODY = "$(inherited)";
+				CLANG_WARN_ENUM_CONVERSION = "$(inherited)";
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = "$(inherited)";
+				CLANG_WARN_INT_CONVERSION = "$(inherited)";
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = "$(inherited)";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = "$(inherited)";
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = "$(inherited)";
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = "$(inherited)";
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = "$(inherited)";
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = "$(inherited)";
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = "$(inherited)";
+				EXECUTABLE_PREFIX = lib;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = "$(inherited)";
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = "$(inherited)";
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = "$(inherited)";
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = "$(inherited)";
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = "$(inherited)";
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = "$(inherited)";
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = "$(inherited)";
+				GCC_WARN_MISSING_PARENTHESES = "$(inherited)";
+				GCC_WARN_MULTIPLE_DEFINITION_TYPES_FOR_SELECTOR = "$(inherited)";
+				GCC_WARN_PEDANTIC = "$(inherited)";
+				GCC_WARN_SHADOW = "$(inherited)";
+				GCC_WARN_SIGN_COMPARE = "$(inherited)";
+				GCC_WARN_STRICT_SELECTOR_MATCH = "$(inherited)";
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = "$(inherited)";
+				GCC_WARN_UNDECLARED_SELECTOR = "$(inherited)";
+				GCC_WARN_UNKNOWN_PRAGMAS = "$(inherited)";
+				GCC_WARN_UNUSED_FUNCTION = "$(inherited)";
+				GCC_WARN_UNUSED_LABEL = "$(inherited)";
+				GCC_WARN_UNUSED_PARAMETER = "$(inherited)";
+				GCC_WARN_UNUSED_VALUE = "$(inherited)";
+				GCC_WARN_UNUSED_VARIABLE = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_CLANG_STATIC_ANALYZER = "$(inherited)";
+				SDKROOT = "$(inherited)";
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Release;
+		};
 		D64B03441BA954780006C468 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -14483,6 +15105,33 @@
 			buildConfigurations = (
 				D64208901BE3CDA500673724 /* Debug */,
 				D64208911BE3CDA500673724 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		D6477C111C5ED5D000F67BBC /* Build configuration list for PBXNativeTarget "networkconfiguration" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6477C121C5ED5D000F67BBC /* Debug */,
+				D6477C131C5ED5D000F67BBC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		D6477C291C5ED82200F67BBC /* Build configuration list for PBXNativeTarget "networkreachability" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6477C2A1C5ED82200F67BBC /* Debug */,
+				D6477C2B1C5ED82200F67BBC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		D6477C381C5ED83C00F67BBC /* Build configuration list for PBXNativeTarget "networkhost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6477C391C5ED83C00F67BBC /* Debug */,
+				D6477C3A1C5ED83C00F67BBC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/extensions/network/configuration.lua
+++ b/extensions/network/configuration.lua
@@ -1,0 +1,14 @@
+--- === hs.network.configuration ===
+---
+--- This sub-module provides access to the current location set configuration settings in the system's dynamic store.
+
+local USERDATA_TAG  = "hs.network.configuration"
+local module        = require(USERDATA_TAG.."internal")
+
+-- private variables and methods -----------------------------------------
+
+-- Public interface ------------------------------------------------------
+
+-- Return Module Object --------------------------------------------------
+
+return module

--- a/extensions/network/configurationinternal.m
+++ b/extensions/network/configurationinternal.m
@@ -1,0 +1,582 @@
+#import <Cocoa/Cocoa.h>
+#import <LuaSkin/LuaSkin.h>
+#import <SystemConfiguration/SystemConfiguration.h>
+#import <SystemConfiguration/SCDynamicStoreCopyDHCPInfo.h>
+
+#define USERDATA_TAG    "hs.network.configuration"
+static int              refTable          = LUA_NOREF;
+static dispatch_queue_t dynamicStoreQueue = nil ;
+
+#define get_structFromUserdata(objType, L, idx) ((objType *)luaL_checkudata(L, idx, USERDATA_TAG))
+
+#pragma mark - Support Functions and Classes
+
+typedef struct _dynamicstore_t {
+    SCDynamicStoreRef storeObject;
+    int               callbackRef ;
+    int               selfRef ;
+    BOOL              watcherEnabled ;
+} dynamicstore_t;
+
+static void doDynamicStoreCallback(__unused SCDynamicStoreRef store, CFArrayRef changedKeys, void *info) {
+    dynamicstore_t *thePtr = (dynamicstore_t *)info ;
+    if (thePtr->callbackRef != LUA_NOREF) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            LuaSkin   *skin = [LuaSkin shared] ;
+            lua_State *L    = [skin L] ;
+            [skin pushLuaRef:refTable ref:thePtr->callbackRef] ;
+            [skin pushLuaRef:refTable ref:thePtr->selfRef] ;
+            if (changedKeys) {
+                [skin pushNSObject:(__bridge NSArray *)changedKeys] ;
+            } else {
+                lua_pushnil(L) ;
+            }
+            if (![skin protectedCallAndTraceback:2 nresults:0]) {
+                [skin logError:[NSString stringWithFormat:@"%s:error in Lua callback:%@",
+                                                            USERDATA_TAG,
+                                                            [skin toNSObjectAtIndex:-1]]] ;
+                lua_pop(L, 1) ; // error string from pcall
+            }
+        }) ;
+    }
+}
+
+#pragma mark - Module Functions
+
+/// hs.network.configuration.open() -> storeObject
+/// Constructor
+/// Opens a session to the dynamic store maintained by the System Configuration server.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the storeObject
+static int newStoreObject(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TBREAK] ;
+    NSString *theName = [[NSUUID UUID] UUIDString] ;
+    dynamicstore_t *thePtr = lua_newuserdata(L, sizeof(dynamicstore_t)) ;
+    memset(thePtr, 0, sizeof(dynamicstore_t)) ;
+
+    SCDynamicStoreContext context = { 0, NULL, NULL, NULL, NULL };
+    context.info = (void *)thePtr;
+    SCDynamicStoreRef theStore = SCDynamicStoreCreate(kCFAllocatorDefault, (__bridge CFStringRef)theName, doDynamicStoreCallback, &context );
+    if (theStore) {
+        thePtr->storeObject    = CFRetain(theStore) ;
+        thePtr->callbackRef    = LUA_NOREF ;
+        thePtr->selfRef        = LUA_NOREF ;
+        thePtr->watcherEnabled = NO ;
+
+        luaL_getmetatable(L, USERDATA_TAG) ;
+        lua_setmetatable(L, -2) ;
+//         SCDynamicStoreSetDispatchQueue(thePtr->storeObject, dynamicStoreQueue);
+        CFRelease(theStore) ; // we retained it in the structure, so release it here
+    } else {
+        return luaL_error(L, "** unable to get dynamicStore reference:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+#pragma mark - Module Methods
+
+/// hs.network.configuration:contents([keys], [pattern]) -> table
+/// Method
+/// Return the contents of the store for the specified keys or keys matching the specified pattern(s)
+///
+/// Parameters:
+///  * keys    - a string or table of strings containing the keys or patterns of keys, if `pattern` is true.  Defaults to all keys.
+///  * pattern - a boolean indicating wether or not the string(s) provided are to be considered regular expression patterns (true) or literal strings to match (false).  Defaults to false.
+///
+/// Returns:
+///  * a table of key-value pairs from the dynamic store which match the specified keys or key patterns.
+///
+/// Notes:
+///  * if no parameters are provided, then all key-value pairs in the dynamic store are returned.
+static int dynamicStoreContents(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG,
+                    LS_TSTRING | LS_TTABLE | LS_TOPTIONAL,
+                    LS_TBOOLEAN | LS_TOPTIONAL,
+                    LS_TBREAK] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+
+    NSArray *keys ;
+    BOOL keysIsPattern = NO ;
+    if (lua_gettop(L) == 1) {
+        keys = @[ @".*" ] ;
+        keysIsPattern = YES ;
+    } else {
+        if (lua_type(L, 2) == LUA_TTABLE) {
+            keys = [skin toNSObjectAtIndex:2] ;
+        } else {
+            keys = [NSArray arrayWithObject:[skin toNSObjectAtIndex:2]] ;
+        }
+        if (lua_gettop(L) == 3) keysIsPattern = (BOOL)lua_toboolean(L, 3) ;
+    }
+
+    CFDictionaryRef results ;
+    if (keysIsPattern) {
+        results = SCDynamicStoreCopyMultiple(theStore, NULL, (__bridge CFArrayRef)keys);
+    } else {
+        results = SCDynamicStoreCopyMultiple(theStore, (__bridge CFArrayRef)keys, NULL);
+    }
+    if (results) {
+        [skin pushNSObject:(__bridge NSDictionary *)results withOptions:(LS_NSDescribeUnknownTypes | LS_NSUnsignedLongLongPreserveBits)] ;
+        CFRelease(results) ;
+    } else {
+        return luaL_error(L, "** unable to get dynamicStore contents:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+/// hs.network.configuration:keys([keypattern]) -> table
+/// Method
+/// Return the keys in the dynamic store which match the specified pattern
+///
+/// Parameters:
+///  * keypattern - a regular expression specifying which keys to return (defaults to ".*", or all keys)
+///
+/// Returns:
+///  * a table of keys from the dynamic store.
+static int dynamicStoreKeys(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TOPTIONAL, LS_TBREAK] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+
+    NSString *keys = (lua_gettop(L) == 1) ? @".*" : [skin toNSObjectAtIndex:2] ;
+    CFArrayRef results = SCDynamicStoreCopyKeyList(theStore, (__bridge CFStringRef)keys);
+    if (results) {
+        [skin pushNSObject:(__bridge NSArray *)results withOptions:(LS_NSDescribeUnknownTypes | LS_NSUnsignedLongLongPreserveBits)] ;
+        CFRelease(results) ;
+    } else {
+        return luaL_error(L, "** unable to get dynamicStore keys:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+/// hs.network.configuration:dhcpInfo([serviceID]) -> table
+/// Method
+/// Return the DHCP information for the specified service or the primary service if no parameter is specified.
+///
+/// Parameters:
+///  * serviceID - an optional string contining the service ID of the interface for which to return DHCP info.  If this parameter is not provided, then the default (primary) service is queried.
+///
+/// Returns:
+///  * a table containing DHCP information including lease time and DHCP options
+///
+/// Notes:
+///  * a list of possible Service ID's can be retrieved with `hs.network.configuration:contents("Setup:/Network/Global/IPv4")`
+///  * generates an error if the service ID is invalid or was not assigned an IP address via DHCP.
+static int dynamicStoreDHCPInfo(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TOPTIONAL, LS_TBREAK] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+
+    NSString *serviceID ;
+    if (lua_gettop(L) == 2) {
+        serviceID = [skin toNSObjectAtIndex:2] ;
+    }
+
+    CFDictionaryRef results = SCDynamicStoreCopyDHCPInfo(theStore, (__bridge CFStringRef)serviceID);
+    if (results) {
+        [skin pushNSObject:(__bridge NSDictionary *)results withOptions:(LS_NSDescribeUnknownTypes | LS_NSUnsignedLongLongPreserveBits)] ;
+        CFRelease(results) ;
+    } else {
+        return luaL_error(L, "** unable to get DHCP info:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+/// hs.network.configuration:computerName() -> name, encoding
+/// Method
+/// Returns the name of the computeras specified in the Sharing Preferences, and its string encoding
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * name     - the computer name
+///  * encoding - the encoding type
+///
+/// Notes:
+///  * You can also retrieve this information as key-value pairs with `hs.network.configuration:contents("Setup:/System")`
+static int dynamicStoreComputerName(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+
+    CFStringEncoding encoding ;
+    CFStringRef computerName = SCDynamicStoreCopyComputerName(theStore, &encoding);
+    if (computerName) {
+        [skin pushNSObject:(__bridge NSString *)computerName] ;
+        switch(encoding) {
+            case kCFStringEncodingMacRoman:      [skin pushNSObject:@"MacRoman"] ; break ;
+            case kCFStringEncodingWindowsLatin1: [skin pushNSObject:@"WindowsLatin1"] ; break ;
+            case kCFStringEncodingISOLatin1:     [skin pushNSObject:@"ISOLatin1"] ; break ;
+            case kCFStringEncodingNextStepLatin: [skin pushNSObject:@"NextStepLatin"] ; break ;
+            case kCFStringEncodingASCII:         [skin pushNSObject:@"ASCII"] ; break ;
+// alias for kCFStringEncodingUTF16; choose UTF16, since Unicode is not one specific encoding - all UTF
+// types are more accurately a way to encode Unicode
+//             case kCFStringEncodingUnicode:       [skin pushNSObject:@"Unicode"] ; break ;
+            case kCFStringEncodingUTF8:          [skin pushNSObject:@"UTF8"] ; break ;
+            case kCFStringEncodingNonLossyASCII: [skin pushNSObject:@"NonLossyASCII"] ; break ;
+            case kCFStringEncodingUTF16:         [skin pushNSObject:@"UTF16"] ; break ;
+            case kCFStringEncodingUTF16BE:       [skin pushNSObject:@"UTF16BE"] ; break ;
+            case kCFStringEncodingUTF16LE:       [skin pushNSObject:@"UTF16LE"] ; break ;
+            case kCFStringEncodingUTF32:         [skin pushNSObject:@"UTF32"] ; break ;
+            case kCFStringEncodingUTF32BE:       [skin pushNSObject:@"UTF32BE"] ; break ;
+            case kCFStringEncodingUTF32LE:       [skin pushNSObject:@"UTF32LE"] ; break ;
+            case kCFStringEncodingInvalidId:     [skin pushNSObject:@"InvalidId"] ; break ;
+            default:
+                [skin pushNSObject:[NSString stringWithFormat:@"** unrecognized encoding:%d", encoding]] ;
+                break ;
+        }
+        CFRelease(computerName) ;
+    } else {
+        return luaL_error(L, "** error retrieving computer name:%s", SCErrorString(SCError())) ;
+    }
+    return 2 ;
+}
+
+/// hs.network.configuration:consoleUser() -> name, uid, gid
+/// Method
+/// Returns the name of the user currently logged into the system, including the users id and primary group id
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * name - the user name
+///  * uid  - the user ID for the user
+///  * gid  - the user's primary group ID
+///
+/// Notes:
+///  * You can also retrieve this information as key-value pairs with `hs.network.configuration:contents("State:/Users/ConsoleUser")`
+static int dynamicStoreConsoleUser(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+
+    uid_t uid ;
+    gid_t gid ;
+    CFStringRef consoleUser = SCDynamicStoreCopyConsoleUser(theStore, &uid, &gid);
+    if (consoleUser) {
+        [skin pushNSObject:(__bridge NSString *)consoleUser] ;
+        lua_pushinteger(L, uid) ;
+        lua_pushinteger(L, gid) ;
+        CFRelease(consoleUser) ;
+    } else {
+        return luaL_error(L, "** error retrieving console user:%s", SCErrorString(SCError())) ;
+    }
+    return 3 ;
+}
+
+/// hs.network.configuration:hostname() -> name
+/// Method
+/// Returns the current local host name for the computer
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * name - the local host name
+///
+/// Notes:
+///  * You can also retrieve this information as key-value pairs with `hs.network.configuration:contents("Setup:/System")`
+static int dynamicStoreLocalHostName(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+
+    CFStringRef localHostName = SCDynamicStoreCopyLocalHostName(theStore);
+    if (localHostName) {
+        [skin pushNSObject:(__bridge NSString *)localHostName] ;
+        CFRelease(localHostName) ;
+    } else {
+        return luaL_error(L, "** error retrieving local host name:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+/// hs.network.configuration:location() -> location
+/// Method
+/// Returns the current location identifier
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * location - the UUID for the currently active network location
+///
+/// Notes:
+///  * You can also retrieve this information as key-value pairs with `hs.network.configuration:contents("Setup:")`
+///  * If you have different locations defined in the Network preferences panel, this can be used to determine the currently active location.
+static int dynamicStoreLocation(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+
+    CFStringRef location = SCDynamicStoreCopyLocation(theStore);
+    if (location) {
+        [skin pushNSObject:(__bridge NSString *)location] ;
+        CFRelease(location) ;
+    } else {
+        return luaL_error(L, "** error retrieving location:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+/// hs.network.configuration:proxies() -> table
+/// Method
+/// Returns information about the currently active proxies, if any
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a table of key-value pairs describing the current proxies in effect, both globally, and scoped to specific interfaces.
+///
+/// Notes:
+///  * You can also retrieve this information as key-value pairs with `hs.network.configuration:contents("State:/Network/Global/Proxies")`
+static int dynamicStoreProxies(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+
+    CFDictionaryRef proxies = SCDynamicStoreCopyProxies(theStore);
+    if (proxies) {
+        [skin pushNSObject:(__bridge NSDictionary *)proxies] ;
+        CFRelease(proxies) ;
+    } else {
+        return luaL_error(L, "** error retrieving proxies:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+/// hs.network.configuration:setCallback(function | nil) -> storeObject
+/// Method
+/// Set or remove the callback function for a store object
+///
+/// Parameters:
+///  * a function or nil to set or remove the store object callback function
+///
+/// Returns:
+///  * the store object
+///
+/// Notes:
+///  * The callback function will be invoked each time a monitored key changes value and the callback function should accept two parameters: the storeObject itself, and an array of the keys which contain values that have changed.
+///  * This method just sets the callback function.  You specify which keys to watch with [hs.network.configuration:monitorKeys](#monitorKeys) and start or stop the watcher with [hs.network.configuration:start](#start) or [hs.network.configuartion:stop](#stop)
+static int dynamicStoreSetCallback(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION | LS_TNIL, LS_TBREAK];
+    dynamicstore_t* thePtr = get_structFromUserdata(dynamicstore_t, L, 1) ;
+
+    // in either case, we need to remove an existing callback, so...
+    thePtr->callbackRef = [skin luaUnref:refTable ref:thePtr->callbackRef];
+    if (lua_type(L, 2) == LUA_TFUNCTION) {
+        lua_pushvalue(L, 2);
+        thePtr->callbackRef = [skin luaRef:refTable];
+        if (thePtr->selfRef == LUA_NOREF) {               // make sure that we won't be __gc'd if a callback exists
+            lua_pushvalue(L, 1) ;                         // but the user doesn't save us somewhere
+            thePtr->selfRef = [skin luaRef:refTable];
+        }
+    } else {
+        thePtr->selfRef = [skin luaUnref:refTable ref:thePtr->selfRef] ;
+    }
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
+/// hs.network.configuration:start() -> storeObject
+/// Method
+/// Starts watching the store object for changes to the monitored keys and invokes the callback function (if any) when a change occurs.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the store object
+///
+/// Notes:
+///  * The callback function should be specified with [hs.network.configuration:setCallback](#setCallback) and the keys to monitor should be specified with [hs.network.configuration:monitorKeys](#monitorKeys).
+static int dynamicStoreStartWatcher(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
+    dynamicstore_t* thePtr = get_structFromUserdata(dynamicstore_t, L, 1) ;
+    if (!thePtr->watcherEnabled) {
+        if (SCDynamicStoreSetDispatchQueue(thePtr->storeObject, dynamicStoreQueue)) {
+            thePtr->watcherEnabled = YES ;
+        } else {
+            return luaL_error(L, "unable to set watcher dispatch queue:%s", SCErrorString(SCError())) ;
+        }
+    }
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
+/// hs.network.configuration:stop() -> storeObject
+/// Method
+/// Stops watching the store object for changes.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the store object
+static int dynamicStoreStopWatcher(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
+    dynamicstore_t* thePtr = get_structFromUserdata(dynamicstore_t, L, 1) ;
+    if (!SCDynamicStoreSetDispatchQueue(thePtr->storeObject, NULL)) {
+        [skin logBreadcrumb:[NSString stringWithFormat:@"%s:stop, error removing watcher from dispatch queue:%s",
+                                                USERDATA_TAG, SCErrorString(SCError())]] ;
+    }
+    thePtr->watcherEnabled = NO ;
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
+/// hs.network.configuration:monitorKeys([keys], [pattern]) -> storeObject
+/// Method
+/// Specify the key(s) or key pattern(s) to monitor for changes.
+///
+/// Parameters:
+///  * keys    - a string or table of strings containing the keys or patterns of keys, if `pattern` is true.  Defaults to all keys.
+///  * pattern - a boolean indicating wether or not the string(s) provided are to be considered regular expression patterns (true) or literal strings to match (false).  Defaults to false.
+///
+/// Returns:
+///  * the store Object
+///
+/// Notes:
+///  * if no parameters are provided, then all key-value pairs in the dynamic store are monitored for changes.
+static int dynamicStoreMonitorKeys(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG,
+                    LS_TSTRING | LS_TTABLE | LS_TOPTIONAL,
+                    LS_TBOOLEAN | LS_TOPTIONAL,
+                    LS_TBREAK] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+
+    NSArray *keys ;
+    BOOL keysIsPattern = NO ;
+    if (lua_gettop(L) == 1) {
+        keys = @[ @".*" ] ;
+        keysIsPattern = YES ;
+    } else {
+        if (lua_type(L, 2) == LUA_TTABLE) {
+            keys = [skin toNSObjectAtIndex:2] ;
+        } else {
+            keys = [NSArray arrayWithObject:[skin toNSObjectAtIndex:2]] ;
+        }
+        if (lua_gettop(L) == 3) keysIsPattern = (BOOL)lua_toboolean(L, 3) ;
+    }
+
+    Boolean result ;
+    if (keysIsPattern) {
+        result = SCDynamicStoreSetNotificationKeys(theStore, NULL, (__bridge CFArrayRef)keys);
+    } else {
+        result = SCDynamicStoreSetNotificationKeys(theStore, (__bridge CFArrayRef)keys, NULL);
+    }
+    if (result) {
+        lua_pushvalue(L, 1) ;
+    } else {
+        return luaL_error(L, "** unable to set keys to monitor:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+#pragma mark - Module Constants
+
+#pragma mark - Hammerspoon/Lua Infrastructure
+
+static int userdata_tostring(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    SCDynamicStoreRef theStore = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+    [skin pushNSObject:[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, theStore]] ;
+    return 1 ;
+}
+
+static int userdata_eq(lua_State* L) {
+// can't get here if at least one of us isn't a userdata type, and we only care if both types are ours,
+// so use luaL_testudata before the macro causes a lua error
+    if (luaL_testudata(L, 1, USERDATA_TAG) && luaL_testudata(L, 2, USERDATA_TAG)) {
+        SCDynamicStoreRef theStore1 = get_structFromUserdata(dynamicstore_t, L, 1)->storeObject ;
+        SCDynamicStoreRef theStore2 = get_structFromUserdata(dynamicstore_t, L, 2)->storeObject ;
+        lua_pushboolean(L, CFEqual(theStore1, theStore2)) ;
+    } else {
+        lua_pushboolean(L, NO) ;
+    }
+    return 1 ;
+}
+
+static int userdata_gc(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+//     [skin logDebug:@"dynamicstore GC"] ;
+    dynamicstore_t* thePtr = get_structFromUserdata(dynamicstore_t, L, 1) ;
+    if (thePtr->callbackRef != LUA_NOREF) {
+        thePtr->callbackRef = [skin luaUnref:refTable ref:thePtr->callbackRef] ;
+        if (!SCDynamicStoreSetDispatchQueue(thePtr->storeObject, NULL)) {
+            [skin logBreadcrumb:[NSString stringWithFormat:@"%s:__gc, error removing watcher from dispatch queue:%s",
+                                                            USERDATA_TAG, SCErrorString(SCError())]] ;
+        }
+    }
+    thePtr->selfRef = [skin luaUnref:refTable ref:thePtr->selfRef] ;
+
+    CFRelease(thePtr->storeObject) ;
+    lua_pushnil(L) ;
+    lua_setmetatable(L, 1) ;
+    return 0 ;
+}
+
+static int meta_gc(lua_State* __unused L) {
+    dynamicStoreQueue = nil ;
+    return 0 ;
+}
+
+// Metatable for userdata objects
+static const luaL_Reg userdata_metaLib[] = {
+    {"contents",     dynamicStoreContents},
+    {"keys",         dynamicStoreKeys},
+    {"dhcpInfo",     dynamicStoreDHCPInfo},
+    {"computerName", dynamicStoreComputerName},
+    {"consoleUser",  dynamicStoreConsoleUser},
+    {"hostname",     dynamicStoreLocalHostName},
+    {"location",     dynamicStoreLocation},
+    {"proxies",      dynamicStoreProxies},
+    {"monitorKeys",  dynamicStoreMonitorKeys},
+    {"setCallback",  dynamicStoreSetCallback},
+    {"start",        dynamicStoreStartWatcher},
+    {"stop",         dynamicStoreStopWatcher},
+
+    {"__tostring",   userdata_tostring},
+    {"__eq",         userdata_eq},
+    {"__gc",         userdata_gc},
+    {NULL,           NULL}
+};
+
+// Functions for returned object when module loads
+static luaL_Reg moduleLib[] = {
+    {"open", newStoreObject},
+    {NULL,   NULL}
+};
+
+// Metatable for module, if needed
+static const luaL_Reg module_metaLib[] = {
+    {"__gc", meta_gc},
+    {NULL,   NULL}
+};
+
+int luaopen_hs_network_configurationinternal(lua_State* __unused L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+// Use this some of your functions return or act on a specific object unique to this module
+    refTable = [skin registerLibraryWithObject:USERDATA_TAG
+                                     functions:moduleLib
+                                 metaFunctions:module_metaLib
+                               objectFunctions:userdata_metaLib];
+
+    dynamicStoreQueue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+
+    return 1;
+}

--- a/extensions/network/host.lua
+++ b/extensions/network/host.lua
@@ -1,0 +1,14 @@
+--- === hs.network.host ===
+---
+--- This sub-module provides functions for acquiring host information, such as hostnames, addresses, and reachability.
+
+local USERDATA_TAG = "hs.network.host"
+local module       = require(USERDATA_TAG.."internal")
+
+-- private variables and methods -----------------------------------------
+
+-- Public interface ------------------------------------------------------
+
+-- Return Module Object --------------------------------------------------
+
+return module

--- a/extensions/network/hostinternal.m
+++ b/extensions/network/hostinternal.m
@@ -1,0 +1,457 @@
+#import <Cocoa/Cocoa.h>
+#import <LuaSkin/LuaSkin.h>
+#import <CFNetwork/CFNetwork.h>
+#import <SystemConfiguration/SystemConfiguration.h>
+
+#import <netinet/in.h>
+#import <netdb.h>
+
+#define USERDATA_TAG    "hs.network.host"
+static int              refTable          = LUA_NOREF;
+
+#define get_structFromUserdata(objType, L, idx) ((objType *)luaL_checkudata(L, idx, USERDATA_TAG))
+
+#pragma mark - Support Functions and Classes
+
+typedef struct _hshost_t {
+    CFHostRef      theHostObj ;
+    int            callbackRef ;
+    CFHostInfoType resolveType ;
+    int            selfRef ;
+    BOOL           running ;
+} hshost_t;
+
+static int pushCFHost(lua_State *L, CFHostRef theHost, CFHostInfoType resolveType) {
+    LuaSkin   *skin    = [LuaSkin shared] ;
+    hshost_t* thePtr = lua_newuserdata(L, sizeof(hshost_t)) ;
+    memset(thePtr, 0, sizeof(hshost_t)) ;
+
+    thePtr->theHostObj  = (CFHostRef)CFRetain(theHost) ;
+    thePtr->callbackRef = LUA_NOREF ;
+    thePtr->resolveType = resolveType ;
+    thePtr->selfRef     = LUA_NOREF ;
+    thePtr->running     = NO ;
+
+    luaL_getmetatable(L, USERDATA_TAG) ;
+    lua_setmetatable(L, -2) ;
+    // capture reference so __gc doesn't accidentally collect before callback if they don't save a reference to the object
+    lua_pushvalue(L, -1) ;
+    thePtr->selfRef = [skin luaRef:refTable] ;
+    return 1 ;
+}
+
+static int pushQueryResults(lua_State *L, BOOL syncronous, CFHostRef theHost, CFHostInfoType typeInfo) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    Boolean available = false ;
+    int argCount = syncronous ? 1 : 2 ;
+    switch(typeInfo) {
+        case kCFHostAddresses:
+            if (!syncronous) lua_pushstring(L, "addresses") ;
+            CFArrayRef theAddresses = CFHostGetAddressing(theHost, &available);
+            if (available && theAddresses) {
+                lua_newtable(L) ;
+                for (CFIndex i = 0 ; i < CFArrayGetCount(theAddresses) ; i++) {
+                    NSData *thisAddr = (__bridge NSData *)CFArrayGetValueAtIndex(theAddresses, i) ;
+                    int  err;
+                    char addrStr[NI_MAXHOST];
+                    err = getnameinfo((const struct sockaddr *) [thisAddr bytes], (socklen_t) [thisAddr length], addrStr, sizeof(addrStr), NULL, 0, NI_NUMERICHOST | NI_WITHSCOPEID | NI_NUMERICSERV);
+                    if (err == 0) {
+                        lua_pushstring(L, addrStr) ; lua_rawseti(L, -2, luaL_len(L, -2) + 1) ;
+                    } else {
+                        lua_pushfstring(L, "** error:%s", gai_strerror(err)) ;
+                    }
+                }
+            } else {
+                lua_pushnil(L) ;
+            }
+            break ;
+        case kCFHostNames:
+            if (!syncronous) lua_pushstring(L, "names") ;
+            CFArrayRef theNames = CFHostGetNames(theHost, &available);
+            if (available && theNames) {
+                [skin pushNSObject:(__bridge NSArray *)theNames] ;
+            } else {
+                lua_pushnil(L) ;
+            }
+            break ;
+        case kCFHostReachability:
+            if (!syncronous) lua_pushstring(L, "reachability") ;
+            CFDataRef theAvailability = CFHostGetReachability(theHost, &available);
+            if (available && theAvailability) {
+                SCNetworkConnectionFlags *flags = (SCNetworkConnectionFlags *)CFDataGetBytePtr(theAvailability) ;
+                lua_pushinteger(L, *flags) ;
+            } else {
+                lua_pushnil(L) ;
+            }
+            break ;
+        default:
+            lua_pushfstring(L, "** unknown:%d", typeInfo) ;
+            argCount = 1 ;
+            break ;
+    }
+    return argCount ;
+}
+
+static NSString *expandCFStreamError(CFStreamErrorDomain domain, SInt32 errorNum) {
+    NSString *ErrorString ;
+    if (domain == kCFStreamErrorDomainNetDB) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:NetDB, message:%s", gai_strerror(errorNum)] ;
+    } else if (domain == kCFStreamErrorDomainNetServices) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:NetServices, code:%d (see CFNetServices.h)", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainMach) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:Mach, code:%d (see mach/error.h)", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainFTP) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:FTP, code:%d", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainHTTP) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:HTTP, code:%d", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainSOCKS) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:SOCKS, code:%d", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainSystemConfiguration) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:SystemConfiguration, code:%d (see SystemConfiguration.h)", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainSSL) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:SSL, code:%d (see SecureTransport.h)", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainWinSock) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:WinSock, code:%d (see winsock2.h)", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainCustom) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:Custom, code:%d", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainPOSIX) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:POSIX, code:%d (see errno.h)", errorNum] ;
+    } else if (domain == kCFStreamErrorDomainMacOSStatus) {
+        ErrorString = [NSString stringWithFormat:@"Error domain:MacOSStatus, code:%d (see MacErrors.h)", errorNum] ;
+    } else {
+        ErrorString = [NSString stringWithFormat:@"Unknown domain:%ld, code:%d", domain, errorNum] ;
+    }
+    return ErrorString ;
+}
+
+void handleCallback(__unused CFHostRef theHost, __unused CFHostInfoType typeInfo, const CFStreamError *error, void *info) {
+    hshost_t *theRef = (hshost_t *)info ;
+    CFStreamErrorDomain domain = 0 ;
+    SInt32              errorNum = 0 ;
+    if (error) {
+        domain   = error->domain ;
+        errorNum = error->error ;
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (theRef->callbackRef != LUA_NOREF) {
+            LuaSkin   *skin    = [LuaSkin shared] ;
+            lua_State *L       = [skin L] ;
+            int       argCount ;
+            [skin pushLuaRef:refTable ref:theRef->callbackRef] ;
+            if ((domain == 0) && (errorNum == 0)) {
+                argCount = pushQueryResults(L, NO, theRef->theHostObj, theRef->resolveType) ;
+            } else {
+                [skin pushNSObject:[NSString stringWithFormat:@"resolution error:%@", expandCFStreamError(domain, errorNum)]] ;
+                argCount = 1 ;
+            }
+            if (![skin protectedCallAndTraceback:argCount nresults:0]) {
+                [skin logError:[NSString stringWithFormat:@"%s:error in Lua callback:%@",
+                                                            USERDATA_TAG,
+                                                            [skin toNSObjectAtIndex:-1]]] ;
+                lua_pop(L, 1) ; // error string from pcall
+            }
+        }
+        CFHostSetClient(theRef->theHostObj, NULL, NULL );
+        CFHostUnscheduleFromRunLoop(theRef->theHostObj, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        CFHostCancelInfoResolution(theRef->theHostObj, theRef->resolveType);
+        theRef->running = NO ;
+        // allow __gc when their stored version goes away
+        theRef->selfRef = [[LuaSkin shared] luaUnref:refTable ref:theRef->selfRef] ;
+    }) ;
+}
+
+static int commonConstructor(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION | LS_TNIL, LS_TBREAK] ;
+
+    hshost_t* theRef = get_structFromUserdata(hshost_t, L, 1) ;
+    CFStreamError streamError ;
+    int argCount = 1 ;
+    if (lua_type(L, 2) == LUA_TNIL) {
+        theRef->selfRef = [skin luaUnref:refTable ref:theRef->selfRef] ; // no need for hanging around - no function callback
+        if (CFHostStartInfoResolution(theRef->theHostObj, theRef->resolveType, &streamError)) {
+            argCount = pushQueryResults(L, YES, theRef->theHostObj, theRef->resolveType) ;
+        } else {
+            return luaL_error(L, [[NSString stringWithFormat:@"resolution error:%@", expandCFStreamError(streamError.domain, streamError.error)] UTF8String]) ;
+        }
+    } else {
+        lua_pushvalue(L, 2);
+        theRef->callbackRef = [skin luaRef:refTable];
+        CFHostClientContext context = { 0, NULL, NULL, NULL, NULL };
+        context.info = (void *)theRef;
+        if (CFHostSetClient(theRef->theHostObj, handleCallback, &context)) {
+            CFHostScheduleWithRunLoop(theRef->theHostObj, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+            if (CFHostStartInfoResolution(theRef->theHostObj, theRef->resolveType, &streamError)) {
+                theRef->running = YES;
+                lua_pushvalue(L, 1) ;
+            } else {
+                CFHostUnscheduleFromRunLoop(theRef->theHostObj, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+                theRef->selfRef = [skin luaUnref:refTable ref:theRef->selfRef] ;
+                return luaL_error(L, [[NSString stringWithFormat:@"resolution error:%@", expandCFStreamError(streamError.domain, streamError.error)] UTF8String]) ;
+            }
+        } else {
+            theRef->selfRef = [skin luaUnref:refTable ref:theRef->selfRef] ;
+            lua_pushnil(L) ;
+        }
+    }
+    return 1 ;
+}
+
+static int commonForHostName(lua_State *L, CFHostInfoType resolveType) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TSTRING, LS_TFUNCTION | LS_TNIL | LS_TOPTIONAL, LS_TBREAK] ;
+    BOOL syncronous = lua_isnoneornil(L, 2) ;
+
+    CFHostRef theHost = CFHostCreateWithName(kCFAllocatorDefault, (__bridge CFStringRef)[skin toNSObjectAtIndex:1]);
+
+    lua_pushcfunction(L, commonConstructor) ;
+    pushCFHost(L, theHost, resolveType) ;
+    CFRelease(theHost) ;
+    if (!syncronous) {
+        lua_pushvalue(L, 2) ;
+    } else {
+        lua_pushnil(L) ;
+    }
+    lua_call(L, 2, 1) ; // error as if the error occurred here
+    return 1 ;
+}
+
+static int commonForAddress(lua_State *L, CFHostInfoType resolveType) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TSTRING | LS_TNUMBER, LS_TFUNCTION | LS_TOPTIONAL, LS_TBREAK] ;
+    BOOL syncronous = lua_isnoneornil(L, 2) ;
+
+    luaL_checkstring(L, 1) ; // force number to be a string
+    struct addrinfo *results = NULL ;
+    struct addrinfo hints = { AI_NUMERICHOST | AI_NUMERICSERV | AI_V4MAPPED_CFG, PF_UNSPEC, 0, 0, 0, NULL, NULL, NULL } ;
+    int ecode = getaddrinfo([[skin toNSObjectAtIndex:1] UTF8String], NULL, &hints, &results);
+    if (ecode != 0) {
+        if (results) freeaddrinfo(results) ;
+        return luaL_error(L, "address parse error: %s", gai_strerror(ecode)) ;
+    }
+
+    CFDataRef theSocket =  CFDataCreate(kCFAllocatorDefault, (void *)results->ai_addr, results->ai_addrlen);
+    CFHostRef theHost   = CFHostCreateWithAddress (kCFAllocatorDefault, theSocket);
+    lua_pushcfunction(L, commonConstructor) ;
+    pushCFHost(L, theHost, resolveType) ;
+    CFRelease(theSocket) ;
+    CFRelease(theHost) ;
+    freeaddrinfo(results) ;
+    if (!syncronous) {
+        lua_pushvalue(L, 2) ;
+    } else {
+        lua_pushnil(L) ;
+    }
+    lua_call(L, 2, 1) ; // error as if the error occurred here
+    return 1 ;
+}
+
+#pragma mark - Module Functions
+
+/// hs.network.host.addressesForHostname(name[, fn]) -> table | hostObject
+/// Function
+/// Get IP addresses for the hostname specified.
+///
+/// Parameters:
+///  * name - the hostname to lookup IP addresses for
+///  * fn   - an optional callback function which, when provided, will perform the address resolution in an asynchronous, non-blocking manner.
+///
+/// Returns:
+///  * If this function is called without a callback function, returns a table containing the IP addresses for the specified name.  If a callback function is specified, then a host object is returned.
+///
+/// Notes:
+///  * If no callback function is provided, the resolution occurs in a blocking manner which may be noticeable when network access is slow or erratic.
+///  * If a callback function is provided, this function acts as a constructor, returning a host object and the callback function will be invoked when resolution is complete.  The callback function should take two parameters: the string "addresses", indicating that an address resolution occurred, and a table containing the IP addresses identified.
+///  * Generates an error if network access is currently disabled or the hostname is invalid.
+static int getAddressesForHostName(lua_State *L) {
+    return commonForHostName(L, kCFHostAddresses) ;
+}
+
+/// hs.network.host.hostnamesForAddress(address[, fn]) -> table | hostObject
+/// Function
+/// Get hostnames for the IP address specified.
+///
+/// Parameters:
+///  * address - a string or number representing an IPv4 or IPv6 network address to lookup hostnames for.  If the argument is a number, it is treated as the 32 bit numerical representation of an IPv4 address.
+///  * fn      - an optional callback function which, when provided, will perform the hostname resolution in an asynchronous, non-blocking manner.
+///
+/// Returns:
+///  * If this function is called without a callback function, returns a table containing the hostnames for the specified address.  If a callback function is specified, then a host object is returned.
+///
+/// Notes:
+///  * If no callback function is provided, the resolution occurs in a blocking manner which may be noticeable when network access is slow or erratic.
+///  * If a callback function is provided, this function acts as a constructor, returning a host object and the callback function will be invoked when resolution is complete.  The callback function should take two parameters: the string "names", indicating that hostname resolution occurred, and a table containing the hostnames identified.
+///  * Generates an error if network access is currently disabled or the IP address is invalid.
+static int getNamesForAddress(lua_State *L) {
+    return commonForAddress(L, kCFHostNames) ;
+}
+
+/// hs.network.host.reachabilityForAddress(address[, fn]) -> integer | hostObject
+/// Function
+/// Get the reachability status for the IP address specified.
+///
+/// Parameters:
+///  * address - a string or number representing an IPv4 or IPv6 network address to check the reachability for.  If the argument is a number, it is treated as the 32 bit numerical representation of an IPv4 address.
+///  * fn      - an optional callback function which, when provided, will determine the address reachability in an asynchronous, non-blocking manner.
+///
+/// Returns:
+///  * If this function is called without a callback function, returns the numeric representation of the address reachability status.  If a callback function is specified, then a host object is returned.
+///
+/// Notes:
+///  * If no callback function is provided, the resolution occurs in a blocking manner which may be noticeable when network access is slow or erratic.
+///  * If a callback function is provided, this function acts as a constructor, returning a host object and the callback function will be invoked when resolution is complete.  The callback function should take two parameters: the string "reachability", indicating that reachability was determined, and the numeric representation of the address reachability status.
+///  * Generates an error if network access is currently disabled or the IP address is invalid.
+///  * The numeric representation is made up from a combination of the flags defined in `hs.network.reachability.flags`.
+///  * Performs the same reachability test as `hs.network.reachability.forAddress`.
+static int getReachabilityForAddress(lua_State *L) {
+    return commonForAddress(L, kCFHostReachability) ;
+}
+
+/// hs.network.host.reachabilityForHostname(name[, fn]) -> integer | hostObject
+/// Function
+/// Get the reachability status for the IP address specified.
+///
+/// Parameters:
+///  * name - the hostname to check the reachability for.  If the argument is a number, it is treated as the 32 bit numerical representation of an IPv4 address.
+///  * fn   - an optional callback function which, when provided, will determine the address reachability in an asynchronous, non-blocking manner.
+///
+/// Returns:
+///  * If this function is called without a callback function, returns the numeric representation of the hostname reachability status.  If a callback function is specified, then a host object is returned.
+///
+/// Notes:
+///  * If no callback function is provided, the resolution occurs in a blocking manner which may be noticeable when network access is slow or erratic.
+///  * If a callback function is provided, this function acts as a constructor, returning a host object and the callback function will be invoked when resolution is complete.  The callback function should take two parameters: the string "reachability", indicating that reachability was determined, and the numeric representation of the hostname reachability status.
+///  * Generates an error if network access is currently disabled or the IP address is invalid.
+///  * The numeric representation is made up from a combination of the flags defined in `hs.network.reachability.flags`.
+///  * Performs the same reachability test as `hs.network.reachability.forHostName`.
+static int getReachabilityForHostName(lua_State *L) {
+    return commonForHostName(L, kCFHostReachability) ;
+}
+
+#pragma mark - Module Methods
+
+/// hs.network.host:isRunning() -> boolean
+/// Method
+/// Returns whether or not resolution is still in progress for an asynchronous query.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * true, if resolution is still in progress, or false if resolution has already completed.
+static int resolutionIsRunning(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    hshost_t* theRef = get_structFromUserdata(hshost_t, L, 1) ;
+    lua_pushboolean(L, theRef->running) ;
+    return 1 ;
+}
+
+/// hs.network.host:cancel() -> hostObject
+/// Method
+/// Cancels an in-progress asynchronous host resolution.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the hostObject
+///
+/// Notes:
+///  * This method has no effect if the resolution has already completed.
+static int cancelResolution(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    hshost_t* theRef = get_structFromUserdata(hshost_t, L, 1) ;
+    if (theRef->running) {
+        CFHostSetClient(theRef->theHostObj, NULL, NULL );
+        CFHostCancelInfoResolution(theRef->theHostObj, theRef->resolveType);
+        CFHostUnscheduleFromRunLoop(theRef->theHostObj, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        theRef->running = NO ;
+    }
+    // allow __gc when their stored version goes away
+    theRef->selfRef = [skin luaUnref:refTable ref:theRef->selfRef] ;
+    lua_settop(L, 1) ;
+    return 1 ;
+}
+
+#pragma mark - Hammerspoon/Lua Infrastructure
+
+static int userdata_tostring(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    CFHostRef theHost = get_structFromUserdata(hshost_t, L, 1)->theHostObj ;
+    [skin pushNSObject:[NSString stringWithFormat:@"%s: (%p)", USERDATA_TAG, theHost]] ;
+    return 1 ;
+}
+
+static int userdata_eq(lua_State* L) {
+// can't get here if at least one of us isn't a userdata type, and we only care if both types are ours,
+// so use luaL_testudata before the macro causes a lua error
+    if (luaL_testudata(L, 1, USERDATA_TAG) && luaL_testudata(L, 2, USERDATA_TAG)) {
+        CFHostRef theHost1 = get_structFromUserdata(hshost_t, L, 1)->theHostObj ;
+        CFHostRef theHost2 = get_structFromUserdata(hshost_t, L, 2)->theHostObj ;
+        lua_pushboolean(L, CFEqual(theHost1, theHost2)) ;
+    } else {
+        lua_pushboolean(L, NO) ;
+    }
+    return 1 ;
+}
+
+static int userdata_gc(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+//     [skin logVerbose:@"in hosts __gc"] ;
+    hshost_t* theRef = get_structFromUserdata(hshost_t, L, 1) ;
+    theRef->callbackRef = [skin luaUnref:refTable ref:theRef->callbackRef] ;
+
+    lua_pushcfunction(L, cancelResolution) ;
+    lua_pushvalue(L, 1) ;
+    lua_pcall(L, 1, 1, 0) ;
+    lua_pop(L, 1) ;
+
+    CFRelease(theRef->theHostObj) ;
+    lua_pushnil(L) ;
+    lua_setmetatable(L, 1) ;
+    return 0 ;
+}
+
+// static int meta_gc(lua_State* __unused L) {
+//     return 0 ;
+// }
+
+// Metatable for userdata objects
+static const luaL_Reg userdata_metaLib[] = {
+    {"isRunning",  resolutionIsRunning},
+    {"cancel",     cancelResolution},
+
+    {"__tostring", userdata_tostring},
+    {"__eq",       userdata_eq},
+    {"__gc",       userdata_gc},
+    {NULL,         NULL}
+};
+
+// Functions for returned object when module loads
+static luaL_Reg moduleLib[] = {
+    {"addressesForHostname",    getAddressesForHostName},
+    {"hostnamesForAddress",     getNamesForAddress},
+    {"reachabilityForHostname", getReachabilityForHostName},
+    {"reachabilityForAddress",  getReachabilityForAddress},
+
+    {NULL, NULL}
+};
+
+// // Metatable for module, if needed
+// static const luaL_Reg module_metaLib[] = {
+//     {"__gc", meta_gc},
+//     {NULL,   NULL}
+// };
+
+int luaopen_hs_network_hostinternal(lua_State* __unused L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    refTable = [skin registerLibraryWithObject:USERDATA_TAG
+                                     functions:moduleLib
+                                 metaFunctions:nil    // or module_metaLib
+                               objectFunctions:userdata_metaLib];
+
+    return 1;
+}

--- a/extensions/network/init.lua
+++ b/extensions/network/init.lua
@@ -1,0 +1,17 @@
+--- === hs.network ===
+---
+--- This module provides functions for inquiring about and monitoring changes to the network.
+
+local USERDATA_TAG   = "hs.network"
+local module         = {}
+module.reachability  = require(USERDATA_TAG..".reachability")
+module.host          = require(USERDATA_TAG..".host")
+module.configuration = require(USERDATA_TAG..".configuration")
+
+-- private variables and methods -----------------------------------------
+
+-- Public interface ------------------------------------------------------
+
+-- Return Module Object --------------------------------------------------
+
+return module

--- a/extensions/network/reachability.lua
+++ b/extensions/network/reachability.lua
@@ -1,0 +1,158 @@
+--- === hs.network.reachability ===
+---
+--- This sub-module can be used to determine the reachability of a target host. A remote host is considered reachable when a data packet, sent by an application into the network stack, can leave the local device. Reachability does not guarantee that the data packet will actually be received by the host.
+---
+--- It is important to remember that this module works by determining if the computer has a route for network traffic bound to a specific destination.  An active internet connection provides a default route for any network that the host is not a member of, so care must be used when testing for specific VPN or local networks to avoid false positives.  Some examples follow:
+---
+--- This is a simple watcher which will be invoked whenever the computer's active internet connection changes state:
+--- ~~~
+---     hs.network.reachability.internet():setCallback(function(self, flags)
+---         if (flags & hs.network.reachability.flags.reachable) > 0 then
+---             -- a default route exists, so an active internet connection is present
+---         else
+---             -- no default route exists, so no active internet connection is present
+---         end
+---    end):start()
+--- ~~~
+---
+--- Note that when an active internet connection is up (reachable), any specific network test that does not include an address pair will be reachable, since internet reachability is defined as having a default route for all non-local networks.
+---
+--- A specific test for determining if an OpenVPN network is available.  This example requires knowing what the local computer's IP address on the VPN network is (OpenVPN does not set the `isDirect` flag) and has been tested with Tunnelblick.
+--- ~~~
+---     hs.network.reachability.forAddress("10.x.y.z"):setCallback(function(self, flags)
+---         -- note that because having an internet connection at all will show the remote network
+---         -- as "reachable", we instead look at whether or not our specific address is "local" instead
+---         if (flags & hs.network.reachability.flags.isLocalAddress) > 0 then
+---             -- VPN tunnel is up
+---         else
+---             -- VPN tunnel is down
+---         end
+---    end):start()
+--- ~~~
+local USERDATA_TAG  = "hs.network.reachability"
+local module        = require(USERDATA_TAG.."internal")
+
+-- private variables and methods -----------------------------------------
+
+local _kMetaTable = {}
+_kMetaTable._k = setmetatable({}, {__mode = "k"})
+_kMetaTable._t = setmetatable({}, {__mode = "k"})
+_kMetaTable.__index = function(obj, key)
+        if _kMetaTable._k[obj] then
+            if _kMetaTable._k[obj][key] then
+                return _kMetaTable._k[obj][key]
+            else
+                for k,v in pairs(_kMetaTable._k[obj]) do
+                    if v == key then return k end
+                end
+            end
+        end
+        return nil
+    end
+_kMetaTable.__newindex = function(obj, key, value)
+        error("attempt to modify a table of constants",2)
+        return nil
+    end
+_kMetaTable.__pairs = function(obj) return pairs(_kMetaTable._k[obj]) end
+_kMetaTable.__len = function(obj) return #_kMetaTable._k[obj] end
+_kMetaTable.__tostring = function(obj)
+        local result = ""
+        if _kMetaTable._k[obj] then
+            local width = 0
+            for k,v in pairs(_kMetaTable._k[obj]) do width = width < #tostring(k) and #tostring(k) or width end
+            for k,v in require("hs.fnutils").sortByKeys(_kMetaTable._k[obj]) do
+                if _kMetaTable._t[obj] == "table" then
+                    result = result..string.format("%-"..tostring(width).."s %s\n", tostring(k),
+                        ((type(v) == "table") and "{ table }" or tostring(v)))
+                else
+                    result = result..((type(v) == "table") and "{ table }" or tostring(v)).."\n"
+                end
+            end
+        else
+            result = "constants table missing"
+        end
+        return result
+    end
+_kMetaTable.__metatable = _kMetaTable -- go ahead and look, but don't unset this
+
+local _makeConstantsTable
+_makeConstantsTable = function(theTable)
+    if type(theTable) ~= "table" then
+        local dbg = debug.getinfo(2)
+        local msg = dbg.short_src..":"..dbg.currentline..": attempting to make a '"..type(theTable).."' into a constant table"
+        if module.log then module.log.ef(msg) else print(msg) end
+        return theTable
+    end
+    for k,v in pairs(theTable) do
+        if type(v) == "table" then
+            local count = 0
+            for a,b in pairs(v) do count = count + 1 end
+            local results = _makeConstantsTable(v)
+            if #v > 0 and #v == count then
+                _kMetaTable._t[results] = "array"
+            else
+                _kMetaTable._t[results] = "table"
+            end
+            theTable[k] = results
+        end
+    end
+    local results = setmetatable({}, _kMetaTable)
+    _kMetaTable._k[results] = theTable
+    local count = 0
+    for a,b in pairs(theTable) do count = count + 1 end
+    if #theTable > 0 and #theTable == count then
+        _kMetaTable._t[results] = "array"
+    else
+        _kMetaTable._t[results] = "table"
+    end
+    return results
+end
+
+-- Public interface ------------------------------------------------------
+
+module.flags            = _makeConstantsTable(module.flags)
+module.specialAddresses = _makeConstantsTable({
+    IN_LINKLOCALNETNUM = 0xA9FE0000, -- 169.254.0.0
+    INADDR_ANY         = 0x00000000, -- 0.0.0.0
+})
+
+--- hs.network.reachability.internet() -> reachabilityObject
+--- Constructor
+--- Creates a reachability object for testing internet access
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * a reachability object
+---
+--- Notes:
+---  * This is equivalent to `hs.network.reachability.forAddress("0.0.0.0")`
+---  * This constructor assumes that a default route for IPv4 traffic is sufficient to determine internet access.  If you are on an IPv6 only network which does not also provide IPv4 route mapping, you should probably use something along the lines of `hs.network.reachability.forAddress("::")` instead.
+module.internet = function()
+    return module.forAddress(module.specialAddresses.INADDR_ANY)
+end
+
+
+--- hs.network.reachability.linkLocal() -> reachabilityObject
+--- Constructor
+--- Creates a reachability object for testing IPv4 link local networking
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * a reachability object
+---
+--- Notes:
+---  * This is equivalent to `hs.network.reachability.forAddress("169.254.0.0")`
+---  * You can use this to determine if any interface has an IPv4 link local address (i.e. zero conf or local only networking) by checking the "isDirect" flag:
+---    * `hs.network.reachability.linklocal():status() & hs.network.reachability.flags.isDirect`
+---  * If the internet is reachable, then this network will also be reachable by default -- use the isDirect flag to ensure that the route is local.
+module.linklocal = function()
+    return module.forAddress(module.specialAddresses.IN_LINKLOCALNETNUM)
+end
+
+-- Return Module Object --------------------------------------------------
+
+return module

--- a/extensions/network/reachabilityinternal.m
+++ b/extensions/network/reachabilityinternal.m
@@ -1,0 +1,438 @@
+#import <Cocoa/Cocoa.h>
+#import <LuaSkin/LuaSkin.h>
+#import <SystemConfiguration/SystemConfiguration.h>
+
+#import <netinet/in.h>
+#import <netdb.h>
+
+#define USERDATA_TAG    "hs.network.reachability"
+static int              refTable          = LUA_NOREF;
+static dispatch_queue_t reachabilityQueue = nil ;
+
+#define get_structFromUserdata(objType, L, idx) ((objType *)luaL_checkudata(L, idx, USERDATA_TAG))
+
+#pragma mark - Support Functions and Classes
+
+typedef struct _reachability_t {
+    SCNetworkReachabilityRef reachabilityObj;
+    int                      callbackRef ;
+    int                      selfRef ;
+    BOOL                     watcherEnabled ;
+} reachability_t;
+
+static int pushSCNetworkReachability(lua_State *L, SCNetworkReachabilityRef theRef) {
+    reachability_t* thePtr = lua_newuserdata(L, sizeof(reachability_t)) ;
+    memset(thePtr, 0, sizeof(reachability_t)) ;
+
+    thePtr->reachabilityObj = CFRetain(theRef) ;
+    thePtr->callbackRef     = LUA_NOREF ;
+    thePtr->selfRef         = LUA_NOREF ;
+    thePtr->watcherEnabled  = NO ;
+
+    luaL_getmetatable(L, USERDATA_TAG) ;
+    lua_setmetatable(L, -2) ;
+    return 1 ;
+}
+
+static void doReachabilityCallback(__unused SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info) {
+    reachability_t *theRef = (reachability_t *)info ;
+    if (theRef->callbackRef != LUA_NOREF) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            LuaSkin   *skin = [LuaSkin shared] ;
+            lua_State *L    = [skin L] ;
+            [skin pushLuaRef:refTable ref:theRef->callbackRef] ;
+            [skin pushLuaRef:refTable ref:theRef->selfRef] ;
+            lua_pushinteger(L, (lua_Integer)flags) ;
+            if (![skin protectedCallAndTraceback:2 nresults:0]) {
+                [skin logError:[NSString stringWithFormat:@"%s:error in Lua callback:%@",
+                                                            USERDATA_TAG,
+                                                            [skin toNSObjectAtIndex:-1]]] ;
+                lua_pop(L, 1) ; // error string from pcall
+            }
+        }) ;
+    }
+}
+
+static NSString *statusString(SCNetworkReachabilityFlags flags) {
+    return [NSString stringWithFormat:@"%c%c%c%c%c%c%c%c",
+                (flags & kSCNetworkReachabilityFlagsTransientConnection)  ? 't' : '-',
+                (flags & kSCNetworkReachabilityFlagsReachable)            ? 'R' : '-',
+                (flags & kSCNetworkReachabilityFlagsConnectionRequired)   ? 'c' : '-',
+                (flags & kSCNetworkReachabilityFlagsConnectionOnTraffic)  ? 'C' : '-',
+                (flags & kSCNetworkReachabilityFlagsInterventionRequired) ? 'i' : '-',
+                (flags & kSCNetworkReachabilityFlagsConnectionOnDemand)   ? 'D' : '-',
+                (flags & kSCNetworkReachabilityFlagsIsLocalAddress)       ? 'l' : '-',
+                (flags & kSCNetworkReachabilityFlagsIsDirect)             ? 'd' : '-'] ;
+}
+
+#pragma mark - Module Functions
+
+/// hs.network.reachability.forAddress(address) -> reachabilityObject
+/// Constructor
+/// Returns a reachability object for the specified network address.
+///
+/// Parameters:
+///  * address - a string or number representing an IPv4 or IPv6 network address to get or track reachability status for.  If the argument is a number, it is treated as the 32 bit numerical representation of an IPv4 address.
+///
+/// Returns:
+///  * a reachability object for the specified network address.
+///
+/// Notes:
+///  * this object will reflect reachability status for any interface available on the computer.  To check for reachability from a specific interface, use [hs.network.reachability.forAddressPair](#addressPair).
+static int reachabilityForAddress(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TSTRING | LS_TNUMBER, LS_TBREAK] ;
+
+    luaL_checkstring(L, 1) ; // force number to be a string
+    struct addrinfo *results = NULL ;
+    struct addrinfo hints = { AI_NUMERICHOST | AI_NUMERICSERV, PF_UNSPEC, 0, 0, 0, NULL, NULL, NULL } ;
+    int ecode = getaddrinfo([[skin toNSObjectAtIndex:1] UTF8String], NULL, &hints, &results);
+    if (ecode != 0) {
+        if (results) freeaddrinfo(results) ;
+        return luaL_error(L, "address parse error: %s", gai_strerror(ecode)) ;
+    }
+    SCNetworkReachabilityRef theRef = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (void *)results->ai_addr);
+    pushSCNetworkReachability(L, theRef) ;
+    CFRelease(theRef) ;
+    if (results) freeaddrinfo(results) ;
+    return 1 ;
+}
+
+/// hs.network.reachability.forAddressPair(localAddress, remoteAddress) -> reachabilityObject
+/// Constructor
+/// Returns a reachability object for the specified network address from the specified localAddress.
+///
+/// Parameters:
+///  * localAddress - a string or number representing a local IPv4 or IPv6 network address. If the address specified is not present on the computer, the remote address will be unreachable.
+///  * remoteAddress - a string or number representing an IPv4 or IPv6 network address to get or track reachability status for.  If the argument is a number, it is treated as the 32 bit numerical representation of an IPv4 address.
+///
+/// Returns:
+///  * a reachability object for the specified network address.
+///
+/// Notes:
+///  * this object will reflect reachability status for a specific interface on the computer.  To check for reachability from any interface, use [hs.network.reachability.forAddress](#address).
+///  * this constructor can be used to test for a specific local network.
+static int reachabilityForAddressPair(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TSTRING | LS_TNUMBER, LS_TSTRING | LS_TNUMBER, LS_TBREAK] ;
+
+    luaL_checkstring(L, 1) ; // force number to be a string
+    struct addrinfo *results1 = NULL ;
+    struct addrinfo hints = { AI_NUMERICHOST | AI_NUMERICSERV, PF_UNSPEC, 0, 0, 0, NULL, NULL, NULL } ;
+    int ecode1 = getaddrinfo([[skin toNSObjectAtIndex:1] UTF8String], NULL, &hints, &results1);
+    if (ecode1 != 0) {
+        if (results1) freeaddrinfo(results1) ;
+        return luaL_error(L, "local address parse error: %s", gai_strerror(ecode1)) ;
+    }
+
+    luaL_checkstring(L, 2) ; // force number to be a string
+    struct addrinfo *results2 = NULL ;
+    int ecode2 = getaddrinfo([[skin toNSObjectAtIndex:2] UTF8String], NULL, &hints, &results2);
+    if (ecode2 != 0) {
+        if (results1) freeaddrinfo(results1) ;
+        if (results2) freeaddrinfo(results2) ;
+        return luaL_error(L, "remote address parse error: %s", gai_strerror(ecode2)) ;
+    }
+
+    SCNetworkReachabilityRef theRef = SCNetworkReachabilityCreateWithAddressPair(kCFAllocatorDefault, results1->ai_addr, results2->ai_addr);
+    pushSCNetworkReachability(L, theRef) ;
+    CFRelease(theRef) ;
+
+    if (results1) freeaddrinfo(results1) ;
+    if (results2) freeaddrinfo(results2) ;
+    return 1 ;
+}
+
+/// hs.network.reachability.forHostName(hostName) -> reachabilityObject
+/// Constructor
+/// Returns a reachability object for the specified host.
+///
+/// Parameters:
+///  * hostName - a string containing the hostname of a machine to check or track the reachability status for.
+///
+/// Returns:
+///  * a reachability object for the specified host.
+///
+/// Notes:
+///  * this object will reflect reachability status for any interface available on the computer.
+///  * this constructor relies on the hostname being resolvable, possibly through DNS, Bonjour, locally defined, etc.
+static int reachabilityForHostName(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TSTRING, LS_TBREAK] ;
+
+    SCNetworkReachabilityRef theRef = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, [[skin toNSObjectAtIndex:1] UTF8String]);
+    pushSCNetworkReachability(L, theRef) ;
+    CFRelease(theRef) ;
+    return 1 ;
+}
+
+#pragma mark - Module Methods
+
+/// hs.network.reachability:status() -> number
+/// Method
+/// Returns the reachability status for the object
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a numeric representation of the reachability status
+///
+/// Notes:
+///  * The numeric representation is made up from a combination of the flags defined in [hs.network.reachability.flags](#flags).
+static int reachabilityStatus(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    SCNetworkReachabilityRef theRef = get_structFromUserdata(reachability_t, L, 1)->reachabilityObj ;
+    SCNetworkReachabilityFlags flags = 0 ;
+    Boolean valid = SCNetworkReachabilityGetFlags(theRef, &flags);
+    if (valid) {
+        lua_pushinteger(L, flags) ;
+    } else {
+        return luaL_error(L, "unable to get reachability flags:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+/// hs.network.reachability:statusString() -> string
+/// Method
+/// Returns a string representation of the reachability status for the object
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a string representation of the reachability status for the object
+///
+/// Notes:
+///  * This is included primarily for debugging, but may be more useful when you just want a quick look at the reachability status for display or testing.
+///  * The string will be made up of the following flags:
+///    * 't'|'-' indicates if the destination is reachable through a transient connection
+///    * 'R'|'-' indicates if the destination is reachable
+///    * 'c'|'-' indicates that a connection of some sort is required for the destination to be reachable
+///    * 'C'|'-' indicates if the destination requires a connection which will be initiated when traffic to the destination is present
+///    * 'i'|'-' indicates if the destination requires a connection which will require user activity to initiate
+///    * 'D'|'-' indicates if the destination requires a connection which will be initiated on demand through the CFSocketStream interface
+///    * 'l'|'-' indicates if the destination is actually a local address
+///    * 'd'|'-' indicates if the destination is directly connected
+static int reachabilityStatusString(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    SCNetworkReachabilityRef theRef = get_structFromUserdata(reachability_t, L, 1)->reachabilityObj ;
+    SCNetworkReachabilityFlags flags = 0 ;
+    Boolean valid = SCNetworkReachabilityGetFlags(theRef, &flags);
+    if (valid) {
+        [skin pushNSObject:statusString(flags)] ;
+    } else {
+        return luaL_error(L, "unable to get reachability flags:%s", SCErrorString(SCError())) ;
+    }
+    return 1 ;
+}
+
+/// hs.network.reachability:setCallback(function | nil) -> reachabilityObject
+/// Method
+/// Set or remove the callback function for a reachability object
+///
+/// Parameters:
+///  * a function or nil to set or remove the reachability object callback function
+///
+/// Returns:
+///  * the reachability object
+///
+/// Notes:
+///  * The callback function will be invoked each time the status for the given reachability object changes.  The callback function should expect 2 arguments, the reachability object itself and a numeric representation of the reachability flags, and should not return anything.
+///  * This method just sets the callback function.  You can start or stop the watcher with [hs.network.reachability:start](#start) or [hs.network.reachability:stop](#stop)
+static int reachabilityCallback(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION | LS_TNIL, LS_TBREAK];
+    reachability_t* theRef = get_structFromUserdata(reachability_t, L, 1) ;
+
+    // in either case, we need to remove an existing callback, so...
+    theRef->callbackRef = [skin luaUnref:refTable ref:theRef->callbackRef];
+    if (lua_type(L, 2) == LUA_TFUNCTION) {
+        lua_pushvalue(L, 2);
+        theRef->callbackRef = [skin luaRef:refTable];
+        if (theRef->selfRef == LUA_NOREF) {               // make sure that we won't be __gc'd if a callback exists
+            lua_pushvalue(L, 1) ;                         // but the user doesn't save us somewhere
+            theRef->selfRef = [skin luaRef:refTable];
+        }
+    } else {
+        theRef->selfRef = [skin luaUnref:refTable ref:theRef->selfRef] ;
+    }
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
+/// hs.network.reachability:start() -> reachabilityObject
+/// Method
+/// Starts watching the reachability object for changes and invokes the callback function (if any) when a change occurs.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the reachability object
+///
+/// Notes:
+///  * The callback function should be specified with [hs.network.reachability:setCallback](#setCallback).
+static int reachabilityStartWatcher(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
+    reachability_t* theRef = get_structFromUserdata(reachability_t, L, 1) ;
+    if (!theRef->watcherEnabled) {
+        SCNetworkReachabilityContext    context = { 0, NULL, NULL, NULL, NULL };
+        context.info = (void *)theRef;
+        if(SCNetworkReachabilitySetCallback(theRef->reachabilityObj, doReachabilityCallback, &context)) {
+            if (SCNetworkReachabilitySetDispatchQueue(theRef->reachabilityObj, reachabilityQueue)) {
+                theRef->watcherEnabled = YES ;
+            } else {
+                SCNetworkReachabilitySetCallback(theRef->reachabilityObj, NULL, NULL);
+                return luaL_error(L, "unable to set watcher dispatch queue:%s", SCErrorString(SCError())) ;
+            }
+        } else {
+            return luaL_error(L, "unable to set watcher callback:%s", SCErrorString(SCError())) ;
+        }
+    }
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
+/// hs.network.reachability:stop() -> reachabilityObject
+/// Method
+/// Stops watching the reachability object for changes.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the reachability object
+static int reachabilityStopWatcher(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
+    reachability_t* theRef = get_structFromUserdata(reachability_t, L, 1) ;
+    SCNetworkReachabilitySetCallback(theRef->reachabilityObj, NULL, NULL);
+    SCNetworkReachabilitySetDispatchQueue(theRef->reachabilityObj, NULL);
+    theRef->watcherEnabled = NO ;
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
+#pragma mark - Module Constants
+
+/// hs.network.reachability.flags[]
+/// Constant
+///
+/// A table containing the numeric value for the possible flags returned by the [hs.network.reachability:status](#status) method or in the `flags` parameter of the callback function.
+///
+/// * transientConnection  - indicates if the destination is reachable through a transient connection
+/// * reachable            - indicates if the destination is reachable
+/// * connectionRequired   - indicates that a connection of some sort is required for the destination to be reachable
+/// * connectionOnTraffic  - indicates if the destination requires a connection which will be initiated when traffic to the destination is present
+/// * interventionRequired - indicates if the destination requires a connection which will require user activity to initiate
+/// * connectionOnDemand   - indicates if the destination requires a connection which will be initiated on demand through the CFSocketStream interface
+/// * isLocalAddress       - indicates if the destination is actually a local address
+/// * isDirect             - indicates if the destination is directly connected
+static int pushReachabilityFlags(lua_State *L) {
+    lua_newtable(L) ;
+    lua_pushinteger(L, kSCNetworkReachabilityFlagsTransientConnection) ;  lua_setfield(L, -2, "transientConnection") ;
+    lua_pushinteger(L, kSCNetworkReachabilityFlagsReachable) ;            lua_setfield(L, -2, "reachable") ;
+    lua_pushinteger(L, kSCNetworkReachabilityFlagsConnectionRequired) ;   lua_setfield(L, -2, "connectionRequired") ;
+    lua_pushinteger(L, kSCNetworkReachabilityFlagsConnectionOnTraffic) ;  lua_setfield(L, -2, "connectionOnTraffic") ;
+    lua_pushinteger(L, kSCNetworkReachabilityFlagsInterventionRequired) ; lua_setfield(L, -2, "interventionRequired") ;
+    lua_pushinteger(L, kSCNetworkReachabilityFlagsConnectionOnDemand) ;   lua_setfield(L, -2, "connectionOnDemand") ;
+    lua_pushinteger(L, kSCNetworkReachabilityFlagsIsLocalAddress) ;       lua_setfield(L, -2, "isLocalAddress") ;
+    lua_pushinteger(L, kSCNetworkReachabilityFlagsIsDirect) ;             lua_setfield(L, -2, "isDirect") ;
+    return 1 ;
+}
+
+#pragma mark - Hammerspoon/Lua Infrastructure
+
+static int userdata_tostring(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    SCNetworkReachabilityRef theRef = get_structFromUserdata(reachability_t, L, 1)->reachabilityObj ;
+    SCNetworkReachabilityFlags flags = 0 ;
+    Boolean valid = SCNetworkReachabilityGetFlags(theRef, &flags);
+    NSString *flagString = @"** unable to get reachability flags*" ;
+    if (valid)  flagString = statusString(flags) ;
+    [skin pushNSObject:[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, flagString, theRef]] ;
+    return 1 ;
+}
+
+static int userdata_eq(lua_State* L) {
+// can't get here if at least one of us isn't a userdata type, and we only care if both types are ours,
+// so use luaL_testudata before the macro causes a lua error
+    if (luaL_testudata(L, 1, USERDATA_TAG) && luaL_testudata(L, 2, USERDATA_TAG)) {
+        SCNetworkReachabilityRef theRef1 = get_structFromUserdata(reachability_t, L, 1)->reachabilityObj ;
+        SCNetworkReachabilityRef theRef2 = get_structFromUserdata(reachability_t, L, 2)->reachabilityObj ;
+        lua_pushboolean(L, CFEqual(theRef1, theRef2)) ;
+    } else {
+        lua_pushboolean(L, NO) ;
+    }
+    return 1 ;
+}
+
+static int userdata_gc(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+//     [skin logVerbose:@"Reachability GC"] ;
+    reachability_t* theRef = get_structFromUserdata(reachability_t, L, 1) ;
+    if (theRef->callbackRef != LUA_NOREF) {
+        theRef->callbackRef = [skin luaUnref:refTable ref:theRef->callbackRef] ;
+        SCNetworkReachabilitySetCallback(theRef->reachabilityObj, NULL, NULL);
+        SCNetworkReachabilitySetDispatchQueue(theRef->reachabilityObj, NULL);
+    }
+    theRef->selfRef = [skin luaUnref:refTable ref:theRef->selfRef] ;
+
+    CFRelease(theRef->reachabilityObj) ;
+    lua_pushnil(L) ;
+    lua_setmetatable(L, 1) ;
+    return 0 ;
+}
+
+static int meta_gc(lua_State* __unused L) {
+    reachabilityQueue = nil ;
+    return 0 ;
+}
+
+// Metatable for userdata objects
+static const luaL_Reg userdata_metaLib[] = {
+    {"status",       reachabilityStatus},
+    {"statusString", reachabilityStatusString},
+    {"setCallback",  reachabilityCallback},
+    {"start",        reachabilityStartWatcher},
+    {"stop",         reachabilityStopWatcher},
+
+    {"__tostring",   userdata_tostring},
+    {"__eq",         userdata_eq},
+    {"__gc",         userdata_gc},
+    {NULL,           NULL}
+};
+
+// Functions for returned object when module loads
+static luaL_Reg moduleLib[] = {
+    {"forAddressPair", reachabilityForAddressPair},
+    {"forAddress",     reachabilityForAddress},
+    {"forHostName",    reachabilityForHostName},
+    {NULL,             NULL}
+};
+
+// Metatable for module, if needed
+static const luaL_Reg module_metaLib[] = {
+    {"__gc", meta_gc},
+    {NULL,   NULL}
+};
+
+int luaopen_hs_network_reachabilityinternal(lua_State* __unused L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    refTable = [skin registerLibraryWithObject:USERDATA_TAG
+                                     functions:moduleLib
+                                 metaFunctions:module_metaLib
+                               objectFunctions:userdata_metaLib];
+
+    // unlike dispatch_get_main_queue, this is concurrent... make sure to invoke lua part of callback
+    // on main queue, though...
+    reachabilityQueue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+    pushReachabilityFlags(L) ; lua_setfield(L, -2, "flags") ;
+
+    return 1;
+}

--- a/scripts/copy_extensions_to_bundle.sh
+++ b/scripts/copy_extensions_to_bundle.sh
@@ -69,6 +69,7 @@ export HS_LUAONLY="_coresetup \
     logger \
     messages \
     mjomatic \
+    network \
     redshift \
     spotify \
     spaces \
@@ -113,6 +114,14 @@ cp -av "${BUILT_PRODUCTS_DIR}/hs" "${HS_DST}/ipc/bin/hs"
 
 # Special copier for hs.speech.listener
 cp -av "${BUILT_PRODUCTS_DIR}/libspeechlistener.dylib" "${HS_DST}/speech/listener.so"
+
+# Special copier for hs.network submodules
+cp -av "${SRCROOT}/extensions/network/configuration.lua" "${HS_DST}/network/configuration.lua"
+cp -av "${BUILT_PRODUCTS_DIR}/libnetworkconfiguration.dylib" "${HS_DST}/network/configurationinternal.so"
+cp -av "${SRCROOT}/extensions/network/host.lua" "${HS_DST}/network/host.lua"
+cp -av "${BUILT_PRODUCTS_DIR}/libnetworkhost.dylib" "${HS_DST}/network/hostinternal.so"
+cp -av "${SRCROOT}/extensions/network/reachability.lua" "${HS_DST}/network/reachability.lua"
+cp -av "${BUILT_PRODUCTS_DIR}/libnetworkreachability.dylib" "${HS_DST}/network/reachabilityinternal.so"
 
 # Special copier for hs.window submodules
 cp -av "${SRCROOT}/extensions/window/filter.lua" "${HS_DST}/window/filter.lua"


### PR DESCRIPTION
Adds:

hs.network.reachability - check internet and network availability, includes callback when status changes

hs.network.host - ip-to-hostname and hostname-to-ip resolution in both blocking and non-blocking (callback) styles

hs.network.configuration - get network information from the Dynamic Store and monitor keys in store for changes