### PR TITLE
Add optional duration parameter to hs.alert.closeAll.

### DIFF
--- a/extensions/alert/internal.m
+++ b/extensions/alert/internal.m
@@ -118,12 +118,20 @@ void HSShowAlert(NSString* oneLineMsg, CGFloat duration) {
 }
 
 - (void) fadeWindowOut {
+    [self fadeWindowOut:0.15];
+}
+
+- (void) fadeWindowOut:(CGFloat)fadeDuration {
+    if(fadeDuration == 0) {
+        [self closeAndResetWindow];
+        return;
+    }
     [NSAnimationContext beginGrouping];
-    [[NSAnimationContext currentContext] setDuration:0.15];
+    [[NSAnimationContext currentContext] setDuration:fadeDuration];
     [[[self window] animator] setAlphaValue:0.0];
     [NSAnimationContext endGrouping];
 
-    [self performSelector:@selector(closeAndResetWindow) withObject:nil afterDelay:0.15];
+    [self performSelector:@selector(closeAndResetWindow) withObject:nil afterDelay:fadeDuration];
 }
 
 - (void) closeAndResetWindow {
@@ -184,19 +192,31 @@ static int alert_show(lua_State* L) {
     return 0;
 }
 
-/// hs.alert.closeAll()
+/// hs.alert.closeAll([seconds])
 /// Function
 /// Closes all alerts currently open on the screen
 ///
 /// Parameters:
-///  * None
+///  * seconds - The fade out duration. Defaults to 0.15
 ///
 /// Returns:
 ///  * None
-static int alert_closeAll(lua_State* L __unused) {
+static int alert_closeAll(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TNUMBER|LS_TOPTIONAL, LS_TBREAK];
+
+    lua_settop(L, 1);
+
+    double duration = 0.15;
+    if (lua_isnumber(L, 1))
+        duration = lua_tonumber(L, 1);
+
+    if(duration < 0.0)
+        duration = 0.0;
+
     NSMutableArray *alerts = [visibleAlerts copy];
     for (id alert in alerts) {
-        [alert fadeWindowOut];
+        [alert fadeWindowOut:duration];
     }
     return 0;
 }


### PR DESCRIPTION
I have a few bindings that display alerts that I regularly run in quick succession (for example changing system volume). If I run them within the 0.15 default fade out duration, the alerts end up stacking up and change displayed screen position. With a 0 duration and bypassing the fade, the alerts are always displayed in the same position.