### PR TITLE
add CSS so markdown tables don't blow up inside of docstrings

### DIFF
--- a/scripts/docs/templates/ext.html.erb
+++ b/scripts/docs/templates/ext.html.erb
@@ -8,6 +8,7 @@
       th { background-color: #DDDDDD; vertical-align: top; padding: 3px; }
       td { width: 100%; background-color: #EEEEEE; vertical-align: top; padding: 3px; }
       table { width: 100% ; border: 1px solid #0; text-align: left; }
+      section > table table td { width: 0; }
     </style>
     <link rel="stylesheet" href="docs.css" type="text/css" media="screen" />
   </head>


### PR DESCRIPTION
Before:
![](http://i.imgur.com/i6UnxdO.png)

After:
![](http://i.imgur.com/5XbpB0N.png)