### PR TITLE
Allow floats when setting audio device volume.

### DIFF
--- a/extensions/audiodevice/internal.m
+++ b/extensions/audiodevice/internal.m
@@ -536,7 +536,7 @@ static int audiodevice_volume(lua_State* L) {
     };
 
     if (AudioObjectHasProperty(deviceId, &propertyAddress) && (AudioObjectGetPropertyData(deviceId, &propertyAddress, 0, NULL, &volumeSize, &volume) == noErr)) {
-        lua_pushinteger(L, (int)(volume * 100.0));
+        lua_pushnumber(L, volume * 100.0);
     } else {
         lua_pushnil(L);
     }
@@ -561,7 +561,7 @@ static int audiodevice_setvolume(lua_State* L) {
     audioDeviceUserData *audioDevice = userdataToAudioDevice(L, 1);
     AudioDeviceID deviceId = audioDevice->deviceId;
     unsigned int scope;
-    int value = (int)lua_tointeger(L, 2);
+    Float32 value = (Float32)lua_tonumber(L, 2);
 
     if (value < 0) {
         value = 0;


### PR DESCRIPTION
Hello! I ran into the issue of not being able to set audio device volume with floats when replicating the OS X volume indicator in my bindings. OS X uses a 6.25% volume per step (16 steps) in their indicator, and I wasn't able to replicate it with only integers.