### PR TITLE
suppress excessive GNU statement expression warnings

### DIFF
--- a/Hammerspoon Tests/HSTestCase.h
+++ b/Hammerspoon Tests/HSTestCase.h
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "MJLua.h"
+#pragma clang diagnostic ignored "-Wgnu-statement-expression"
 
 #define RUN_LUA_TEST() XCTAssertTrue([self luaTestFromSelector:_cmd], @"Test failed: %@", NSStringFromSelector(_cmd));
 #define SKIP_IN_TRAVIS() if(self.isTravis) { NSLog(@"Skipping %@ due to Travis", NSStringFromSelector(_cmd)) ; return; }

--- a/Hammerspoon Tests/HSTestCase.m
+++ b/Hammerspoon Tests/HSTestCase.m
@@ -7,7 +7,6 @@
 //
 
 #import "HSTestCase.h"
-#pragma GCC diagnostic ignored "-Wgnu-statement-expression"
 
 @implementation HSTestCase
 

--- a/Hammerspoon Tests/HSaudiodevice.m
+++ b/Hammerspoon Tests/HSaudiodevice.m
@@ -7,7 +7,6 @@
 //
 
 #import "HSTestcase.h"
-#pragma GCC diagnostic ignored "-Wgnu-statement-expression"
 
 @interface HSaudiodevice : HSTestCase
 

--- a/Hammerspoon Tests/HSrequire_all.m
+++ b/Hammerspoon Tests/HSrequire_all.m
@@ -7,7 +7,6 @@
 //
 
 #import "HSTestCase.h"
-#pragma GCC diagnostic ignored "-Wgnu-statement-expression"
 
 @interface HSrequire_all : HSTestCase
 


### PR DESCRIPTION
~~Added `-Wno-gnu` to `Other Warning Flags` to both `Hammerspoon` Project and `Hammerspoon Tests` Target build settings, because adding it to `Hammerspoon` Project's `Other Warning Flags` alone doesn't cover `Hammerspoon Tests` for some reason. Adding it to `Other C Flags` in `Hammerspoon` Project's build settings covers both, but `Other Warning Flags` seems like the right place over `Other C Flags`.~~