### PR TITLE
use hs.logger in LuaSkin log handling

### DIFF
--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -580,6 +580,10 @@ typedef id (*luaObjectHelperFunction)(lua_State *L, int idx);
  */
 - (BOOL)requireModule:(char *)moduleName ;
 
+#pragma mark - Logging methods
+
+/*! @methodgroup Logging methods */
+
 /*!
  @abstract Log the specified message with at the specified level
  @discussion Logs the specified message at the specified level by invoking the delegate method @link logForLuaSkinAtLevel:withMessage: @/link.
@@ -597,36 +601,83 @@ typedef id (*luaObjectHelperFunction)(lua_State *L, int idx);
  @param theMessage the message to log
  */
 - (void)logVerbose:(NSString *)theMessage ;
+
 /*!
  @abstract Log the specified message with LS_LOG_DEBUG level
  @discussion This method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_DEBUG @/link
  @param theMessage the message to log
  */
 - (void)logDebug:(NSString *)theMessage ;
+
 /*!
  @abstract Log the specified message with LS_LOG_INFO level
  @discussion This method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_INFO @/link
  @param theMessage the message to log
  */
 - (void)logInfo:(NSString *)theMessage ;
+
 /*!
  @abstract Log the specified message with LS_LOG_WARN level
  @discussion This method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_WARN @/link
  @param theMessage the message to log
  */
 - (void)logWarn:(NSString *)theMessage ;
+
 /*!
  @abstract Log the specified message with LS_LOG_ERROR level
  @discussion This method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_ERROR @/link
  @param theMessage the message to log
  */
 - (void)logError:(NSString *)theMessage ;
+
 /*!
  @abstract Log the specified message with LS_LOG_BREADCRUMB level
  @discussion This method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_BREADCRUMB @/link
  @param theMessage the message to log
  */
 - (void)logBreadcrumb:(NSString *)theMessage ;
+
+/*!
+ @abstract Log the specified message from any thread with LS_LOG_VERBOSE level
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_VERBOSE @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @param theMessage the message to log
+ */
++ (void)logVerbose:(NSString *)theMessage ;
+
+/*!
+ @abstract Log the specified message from any thread with LS_LOG_DEBUG level
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_DEBUG @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @param theMessage the message to log
+ */
++ (void)logDebug:(NSString *)theMessage ;
+
+/*!
+ @abstract Log the specified message from any thread with LS_LOG_INFO level
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_INFO @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @param theMessage the message to log
+ */
++ (void)logInfo:(NSString *)theMessage ;
+
+/*!
+ @abstract Log the specified message from any thread with LS_LOG_WARN level
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_WARN @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @param theMessage the message to log
+ */
++ (void)logWarn:(NSString *)theMessage ;
+
+/*!
+ @abstract Log the specified message from any thread with LS_LOG_ERROR level
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_ERROR @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @param theMessage the message to log
+ */
++ (void)logError:(NSString *)theMessage ;
+
+/*!
+ @abstract Log the specified message from any thread with LS_LOG_BREADCRUMB level
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_BREADCRUMB @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @param theMessage the message to log
+ */
++ (void)logBreadcrumb:(NSString *)theMessage ;
 
 /*!
  @abstract Returns a string containing the current stack top, the absolute index position of the stack top, and the output from luaL_traceback.
@@ -652,7 +703,6 @@ typedef id (*luaObjectHelperFunction)(lua_State *L, int idx);
  @param pos the lua traceback level to attempt to retrieve the chunk name and line number from
  */
 - (void)logAtLevel:(int)level withMessage:(NSString *)theMessage fromStackPos:(int)pos ;
-
 
 @end
 

--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -639,42 +639,42 @@ typedef id (*luaObjectHelperFunction)(lua_State *L, int idx);
 
 /*!
  @abstract Log the specified message from any thread with LS_LOG_VERBOSE level
- @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_VERBOSE @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_VERBOSE @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_async to submit the logging message to the main thread for proper handling by the delegate.
  @param theMessage the message to log
  */
 + (void)logVerbose:(NSString *)theMessage ;
 
 /*!
  @abstract Log the specified message from any thread with LS_LOG_DEBUG level
- @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_DEBUG @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_DEBUG @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_async to submit the logging message to the main thread for proper handling by the delegate.
  @param theMessage the message to log
  */
 + (void)logDebug:(NSString *)theMessage ;
 
 /*!
  @abstract Log the specified message from any thread with LS_LOG_INFO level
- @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_INFO @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_INFO @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_async to submit the logging message to the main thread for proper handling by the delegate.
  @param theMessage the message to log
  */
 + (void)logInfo:(NSString *)theMessage ;
 
 /*!
  @abstract Log the specified message from any thread with LS_LOG_WARN level
- @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_WARN @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_WARN @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_async to submit the logging message to the main thread for proper handling by the delegate.
  @param theMessage the message to log
  */
 + (void)logWarn:(NSString *)theMessage ;
 
 /*!
  @abstract Log the specified message from any thread with LS_LOG_ERROR level
- @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_ERROR @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_ERROR @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_async to submit the logging message to the main thread for proper handling by the delegate.
  @param theMessage the message to log
  */
 + (void)logError:(NSString *)theMessage ;
 
 /*!
  @abstract Log the specified message from any thread with LS_LOG_BREADCRUMB level
- @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_BREADCRUMB @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_sync to submit the logging message to the main thread for proper handling by the delegate.
+ @discussion This class method is equivalent to invoking @link logAtLevel:withMessage: @/link with level @link LS_LOG_BREADCRUMB @/link, but is safe to use from any thread, not just the main application thread.  If this method is invoked from a thread other than the main thread, it uses dispatch_async to submit the logging message to the main thread for proper handling by the delegate.
  @param theMessage the message to log
  */
 + (void)logBreadcrumb:(NSString *)theMessage ;

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -1003,7 +1003,7 @@ nextarg:
     if ([NSThread isMainThread]) {
         [[LuaSkin shared] logAtLevel:LS_LOG_VERBOSE withMessage:theMessage] ;
     } else {
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
             [[LuaSkin shared] logAtLevel:LS_LOG_VERBOSE
                              withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
         }) ;
@@ -1013,7 +1013,7 @@ nextarg:
     if ([NSThread isMainThread]) {
         [[LuaSkin shared] logAtLevel:LS_LOG_DEBUG withMessage:theMessage] ;
     } else {
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
             [[LuaSkin shared] logAtLevel:LS_LOG_DEBUG
                              withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
         }) ;
@@ -1023,7 +1023,7 @@ nextarg:
     if ([NSThread isMainThread]) {
         [[LuaSkin shared] logAtLevel:LS_LOG_INFO withMessage:theMessage] ;
     } else {
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
             [[LuaSkin shared] logAtLevel:LS_LOG_INFO
                              withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
         }) ;
@@ -1033,7 +1033,7 @@ nextarg:
     if ([NSThread isMainThread]) {
         [[LuaSkin shared] logAtLevel:LS_LOG_WARN withMessage:theMessage] ;
     } else {
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
             [[LuaSkin shared] logAtLevel:LS_LOG_WARN
                              withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
         }) ;
@@ -1043,7 +1043,7 @@ nextarg:
     if ([NSThread isMainThread]) {
         [[LuaSkin shared] logAtLevel:LS_LOG_ERROR withMessage:theMessage] ;
     } else {
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
             [[LuaSkin shared] logAtLevel:LS_LOG_ERROR
                              withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
         }) ;
@@ -1053,7 +1053,7 @@ nextarg:
     if ([NSThread isMainThread]) {
         [[LuaSkin shared] logAtLevel:LS_LOG_BREADCRUMB withMessage:theMessage] ;
     } else {
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
             [[LuaSkin shared] logAtLevel:LS_LOG_BREADCRUMB
                              withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
         }) ;

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -717,10 +717,10 @@ nextarg:
             lua_pushstring(_L, [[obj absoluteString] UTF8String]) ;
         } else {
             if ((options & LS_NSDescribeUnknownTypes) == LS_NSDescribeUnknownTypes) {
-                [self logDebug:[NSString stringWithFormat:@"unrecognized type %@; converting to '%@'", NSStringFromClass([obj class]), [obj debugDescription]]] ;
+                [self logVerbose:[NSString stringWithFormat:@"unrecognized type %@; converting to '%@'", NSStringFromClass([obj class]), [obj debugDescription]]] ;
                 lua_pushstring(_L, [[NSString stringWithFormat:@"%@", [obj debugDescription]] UTF8String]) ;
             } else if ((options & LS_NSIgnoreUnknownTypes) == LS_NSIgnoreUnknownTypes) {
-                [self logDebug:[NSString stringWithFormat:@"unrecognized type %@; ignoring", NSStringFromClass([obj class])]] ;
+                [self logVerbose:[NSString stringWithFormat:@"unrecognized type %@; ignoring", NSStringFromClass([obj class])]] ;
                 return 0 ;
             }else {
                 [self logDebug:[NSString stringWithFormat:@"unrecognized type %@; returning nil", NSStringFromClass([obj class])]] ;
@@ -998,6 +998,67 @@ nextarg:
 - (void)logWarn:(NSString *)theMessage       { [self logAtLevel:LS_LOG_WARN withMessage:theMessage] ; }
 - (void)logError:(NSString *)theMessage      { [self logAtLevel:LS_LOG_ERROR withMessage:theMessage] ; }
 - (void)logBreadcrumb:(NSString *)theMessage { [self logAtLevel:LS_LOG_BREADCRUMB withMessage:theMessage] ; }
+
++ (void)logVerbose:(NSString *)theMessage    {
+    if ([NSThread isMainThread]) {
+        [[LuaSkin shared] logAtLevel:LS_LOG_VERBOSE withMessage:theMessage] ;
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [[LuaSkin shared] logAtLevel:LS_LOG_VERBOSE
+                             withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
+        }) ;
+    }
+}
++ (void)logDebug:(NSString *)theMessage      {
+    if ([NSThread isMainThread]) {
+        [[LuaSkin shared] logAtLevel:LS_LOG_DEBUG withMessage:theMessage] ;
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [[LuaSkin shared] logAtLevel:LS_LOG_DEBUG
+                             withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
+        }) ;
+    }
+}
++ (void)logInfo:(NSString *)theMessage       {
+    if ([NSThread isMainThread]) {
+        [[LuaSkin shared] logAtLevel:LS_LOG_INFO withMessage:theMessage] ;
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [[LuaSkin shared] logAtLevel:LS_LOG_INFO
+                             withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
+        }) ;
+    }
+}
++ (void)logWarn:(NSString *)theMessage       {
+    if ([NSThread isMainThread]) {
+        [[LuaSkin shared] logAtLevel:LS_LOG_WARN withMessage:theMessage] ;
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [[LuaSkin shared] logAtLevel:LS_LOG_WARN
+                             withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
+        }) ;
+    }
+}
++ (void)logError:(NSString *)theMessage      {
+    if ([NSThread isMainThread]) {
+        [[LuaSkin shared] logAtLevel:LS_LOG_ERROR withMessage:theMessage] ;
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [[LuaSkin shared] logAtLevel:LS_LOG_ERROR
+                             withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
+        }) ;
+    }
+}
++ (void)logBreadcrumb:(NSString *)theMessage {
+    if ([NSThread isMainThread]) {
+        [[LuaSkin shared] logAtLevel:LS_LOG_BREADCRUMB withMessage:theMessage] ;
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [[LuaSkin shared] logAtLevel:LS_LOG_BREADCRUMB
+                             withMessage:[@"(secondary thread): " stringByAppendingString:theMessage]] ;
+        }) ;
+    }
+}
 
 - (NSString *)tracebackWithTag:(NSString *)theTag fromStackPos:(int)level{
     int topIndex         = lua_gettop(_L) ;

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -902,11 +902,11 @@ nextarg:
         default:
             if ((options & LS_NSDescribeUnknownTypes) == LS_NSDescribeUnknownTypes) {
                 NSString *answer = [NSString stringWithFormat:@"%s", luaL_tolstring(_L, idx, NULL)];
-                [self logDebug:[NSString stringWithFormat:@"unrecognized type %s; converting to '%@'", lua_typename(_L, lua_type(_L, realIndex)), answer]] ;
+                [self logVerbose:[NSString stringWithFormat:@"unrecognized type %s; converting to '%@'", lua_typename(_L, lua_type(_L, realIndex)), answer]] ;
                 lua_pop(_L, 1) ;
                 return answer ;
             } else if ((options & LS_NSIgnoreUnknownTypes) == LS_NSIgnoreUnknownTypes) {
-                [self logDebug:[NSString stringWithFormat:@"unrecognized type %s; ignoring with placeholder [NSNull null]",
+                [self logVerbose:[NSString stringWithFormat:@"unrecognized type %s; ignoring with placeholder [NSNull null]",
                                                           lua_typename(_L, lua_type(_L, realIndex))]] ;
                 return [NSNull null] ;
             } else {

--- a/extensions/_coresetup/init.lua
+++ b/extensions/_coresetup/init.lua
@@ -221,9 +221,10 @@ return {setup=function(...)
   hs.luaSkinLog = logger
 
   hs.handleLogMessage = function(level, message)
+      local levelLabels = { "ERROR", "WARNING", "INFO", "DEBUG", "VERBOSE" }
     -- may change in the future if this fills crashlog with too much useless stuff
       if level ~= 5 then
-          require("hs.crash").crashLog(string.format("(%d) %s", level, message))
+          crashLog(string.format("(%s) %s", (levelLabels[level] or tostring(level)), message))
       end
 
       if level == 5 then     logger.v(message) -- LS_LOG_VERBOSE

--- a/extensions/_coresetup/init.lua
+++ b/extensions/_coresetup/init.lua
@@ -6,6 +6,7 @@ return {setup=function(...)
   local modpath, prettypath, fullpath, configdir, docstringspath, hasinitfile, autoload_extensions = ...
   local tostring,pack,tconcat,sformat=tostring,table.pack,table.concat,string.format
   local crashLog = require("hs.crash").crashLog
+
   -- setup core functions
 
   os.exit = hs._exit
@@ -216,25 +217,21 @@ return {setup=function(...)
     })
   end
 
+  local logger = require("hs.logger").new("LuaSkin", "info")
+  hs.luaSkinLog = logger
+
   hs.handleLogMessage = function(level, message)
     -- may change in the future if this fills crashlog with too much useless stuff
       if level ~= 5 then
           require("hs.crash").crashLog(string.format("(%d) %s", level, message))
       end
 
-    -- may change in the future to use hs.logger, but for now I want to see everything for testing purposes
-      if level == 5 then                  -- LS_LOG_VERBOSE
-          print("*** VERBOSE: "..message)
-      elseif level == 4 then              -- LS_LOG_DEBUG
-          print("*** DEBUG:   "..message)
-      elseif level == 3 then              -- LS_LOG_INFO
-          print("*** INFO:    "..message)
-      elseif level == 2 then              -- LS_LOG_WARN
-          print("*** WARN:    "..message)
-      elseif level == 1 then              -- LS_LOG_ERROR
-          hs.showError(message)
-          crashLog("ERROR: "..message)
---           print("*** ERROR:   "..message)
+      if level == 5 then     logger.v(message) -- LS_LOG_VERBOSE
+      elseif level == 4 then logger.d(message) -- LS_LOG_DEBUG
+      elseif level == 3 then logger.i(message) -- LS_LOG_INFO
+      elseif level == 2 then logger.w(message) -- LS_LOG_WARN
+      elseif level == 1 then logger.e(message) -- LS_LOG_ERROR
+--           hs.showError(message)
       else
           print("*** UNKNOWN LOG LEVEL: "..tostring(level).."\n\t"..message)
       end


### PR DESCRIPTION
Makes turning LuaSkin logs on and off, using hs.logger's history, etc. possible for logXXX: methods in LuaSkin.


Per comments about class level/thread-agnostic logging methods discussed in a comment thread concerning hs.socket (somewhere in the history of #791 I think), what's the consensus? should I add them as well?