### PR TITLE
Fix hs.notify.show() subTitle display

### DIFF
--- a/extensions/notify/init.lua
+++ b/extensions/notify/init.lua
@@ -176,7 +176,7 @@ module.show = function(title, subTitle, informativeText, tag)
     return nil
   end
   if type(title) ~= "string" or type(subTitle) ~= "string" or type(informativeText) ~= "string" then
-    error("All four arguments to hs.notify.show must be present and must be strings.", 2)
+    error("All three textual arguments to hs.notify.show must be present and must be strings.", 2)
     return nil
   else
     return module.new(tag, {

--- a/extensions/notify/init.lua
+++ b/extensions/notify/init.lua
@@ -3,9 +3,9 @@
 ---
 --- This module allows you to create on screen notifications in the User Notification Center located at the right of the users screen.
 ---
---- Notifications can be sent immediately or scheduled for delivery at a later time, even if that scheduled time occurs when Hammerspoon is not currently running.  Currently, if you take action on a notification while Hammerspoon is not running, the callback function is not honored for the first notification clicked upon -- This is expected to be fixed in a future release.
+--- Notifications can be sent immediately or scheduled for delivery at a later time, even if that scheduled time occurs when Hammerspoon is not currently running. Currently, if you take action on a notification while Hammerspoon is not running, the callback function is not honored for the first notification clicked upon -- This is expected to be fixed in a future release.
 ---
---- When setting up a callback function, you have the option of specifying it with the creation of the notification (hs.notify.new) or by pre-registering it with hs.notify.register and then referring it to by the tag name specified with hs.notify.register.  If you use this registration method for defining your callback functions, and make sure to register all expected callback functions within your init.lua file or files it includes, then callback functions will remain available for existing notifications in the User Notification Center even if Hammerspoon's configuration is reloaded or if Hammerspoon is restarted.  If the callback tag is not present when the user acts on the notification, the Hammerspoon console will be raised as a default action.
+--- When setting up a callback function, you have the option of specifying it with the creation of the notification (hs.notify.new) or by pre-registering it with hs.notify.register and then referring it to by the tag name specified with hs.notify.register. If you use this registration method for defining your callback functions, and make sure to register all expected callback functions within your init.lua file or files it includes, then callback functions will remain available for existing notifications in the User Notification Center even if Hammerspoon's configuration is reloaded or if Hammerspoon is restarted. If the callback tag is not present when the user acts on the notification, the Hammerspoon console will be raised as a default action.
 ---
 --- A shorthand, based upon the original inspiration for this module from Hydra and Mjolnir, hs.notify.show, is provided if you just require a quick and simple informative notification without the bells and whistles.
 ---
@@ -22,41 +22,41 @@ local imagemod = require("hs.image")
 local _kMetaTable = {}
 _kMetaTable._k = {}
 _kMetaTable.__index = function(obj, key)
-        if _kMetaTable._k[obj] then
-            if _kMetaTable._k[obj][key] then
-                return _kMetaTable._k[obj][key]
-            else
-                for k,v in pairs(_kMetaTable._k[obj]) do
-                    if v == key then return k end
-                end
-            end
-        end
-        return nil
+  if _kMetaTable._k[obj] then
+    if _kMetaTable._k[obj][key] then
+      return _kMetaTable._k[obj][key]
+    else
+      for k,v in pairs(_kMetaTable._k[obj]) do
+        if v == key then return k end
+      end
     end
+  end
+  return nil
+end
 _kMetaTable.__newindex = function(obj, key, value)
-        error("attempt to modify a table of constants",2)
-        return nil
-    end
+  error("attempt to modify a table of constants",2)
+  return nil
+end
 _kMetaTable.__pairs = function(obj) return pairs(_kMetaTable._k[obj]) end
 _kMetaTable.__tostring = function(obj)
-        local result = ""
-        if _kMetaTable._k[obj] then
-            local width = 0
-            for k,v in pairs(_kMetaTable._k[obj]) do width = width < #k and #k or width end
-            for k,v in require("hs.fnutils").sortByKeys(_kMetaTable._k[obj]) do
-                result = result..string.format("%-"..tostring(width).."s %s\n", k, tostring(v))
-            end
-        else
-            result = "constants table missing"
-        end
-        return result
+  local result = ""
+  if _kMetaTable._k[obj] then
+    local width = 0
+    for k,v in pairs(_kMetaTable._k[obj]) do width = width < #k and #k or width end
+    for k,v in require("hs.fnutils").sortByKeys(_kMetaTable._k[obj]) do
+      result = result..string.format("%-"..tostring(width).."s %s\n", k, tostring(v))
     end
+  else
+    result = "constants table missing"
+  end
+  return result
+end
 _kMetaTable.__metatable = _kMetaTable -- go ahead and look, but don't unset this
 
 local _makeConstantsTable = function(theTable)
-    local results = setmetatable({}, _kMetaTable)
-    _kMetaTable._k[results] = theTable
-    return results
+  local results = setmetatable({}, _kMetaTable)
+  _kMetaTable._k[results] = theTable
+  return results
 end
 
 -- private variables and methods -----------------------------------------
@@ -64,11 +64,11 @@ end
 -- functions provide by the C library which should not be treated as attributes when
 -- creating a new notification (see hs.notify.new below)
 local protected_functions = {
-    show = true,
-    release = true,
-    withdraw = true,
-    __index = true,
-    __gc = true,
+  show = true,
+  release = true,
+  withdraw = true,
+  __index = true,
+  __gc = true,
 }
 
 local emptyFunctionPlaceholder = "__emptyFunctionPlaceHolder"
@@ -79,7 +79,7 @@ module.activationTypes = _makeConstantsTable(module.activationTypes)
 
 --- hs.notify.warnAboutMissingFunctionTag
 --- Variable
---- A boolean value indicating whether or not a missing notification function tag should cause a warning to be printed to the console during activation callback.  Defaults to true.
+--- A boolean value indicating whether or not a missing notification function tag should cause a warning to be printed to the console during activation callback. Defaults to true.
 
 module.warnAboutMissingFunctionTag = true
 
@@ -88,7 +88,7 @@ module.warnAboutMissingFunctionTag = true
 --- Creates a new notification object
 ---
 --- Parameters:
----  * fn - An optional function or function-tag, which will be called when the user interacts with notifications. The notification object will be passed as an argument to the function.  If you leave this parameter out or specify nil, then no callback will be attached to the notification.
+---  * fn - An optional function or function-tag, which will be called when the user interacts with notifications. The notification object will be passed as an argument to the function. If you leave this parameter out or specify nil, then no callback will be attached to the notification.
 ---  * attributes - An optional table for applying attributes to the notification. Possible keys are:
 ---
 ---   * alwaysPresent   - see `hs.notify:alwaysPresent`
@@ -110,88 +110,95 @@ module.warnAboutMissingFunctionTag = true
 ---
 --- Notes:
 ---  * A function-tag is a string key which corresponds to a function stored in the `hs.notify.registry` table with the `hs.notify.register()` function.
----  * If a notification does not have a `title` attribute set, OS X will not display it, so by default it will be set to "Notification".  You can use the `title` key in the attributes table, or call `hs.notify:title()` before displaying the notification to change this.
+---  * If a notification does not have a `title` attribute set, OS X will not display it, so by default it will be set to "Notification". You can use the `title` key in the attributes table, or call `hs.notify:title()` before displaying the notification to change this.
 module.new = function(fn, attributes)
-    if type(fn) == "table" then
-        attributes = fn
-        fn = nil
-    end
-    fn = fn or emptyFunctionPlaceholder
-    if fn == "" then fn = emptyFunctionPlaceholder end
+  if type(fn) == "table" then
+    attributes = fn
+    fn = nil
+  end
+  fn = fn or emptyFunctionPlaceholder
+  if fn == "" then fn = emptyFunctionPlaceholder end
 
-    if type(fn) == "function" then
-        local tmpTag = host.globallyUniqueString()
-        module.register(tmpTag, fn)
-        fn = tmpTag
-    end
+  if type(fn) == "function" then
+    local tmpTag = host.globallyUniqueString()
+    module.register(tmpTag, fn)
+    fn = tmpTag
+  end
 
-    attributes = attributes or { }
-    if not attributes.title then attributes.title = "Notification" end
+  attributes = attributes or { }
+  if not attributes.title then attributes.title = "Notification" end
 
-    local note = module._new(fn)
-    for i,v in pairs(attributes) do
-        if note[i] and not protected_functions[i] then
-            note[i](note, v)
-        end
+  local note = module._new(fn)
+  for i,v in pairs(attributes) do
+    if note[i] and not protected_functions[i] then
+      note[i](note, v)
     end
-    return note
+  end
+  return note
 end
 
 module._tag_handler = function(tag, notification)
-    local found = false
-    for k,v in pairs(module.registry) do
-        if k ~= "n" and v ~= nil then
-            if v[1] == tag then
-                v[2](notification)
-                found = true
-                break
-            end
-        end
+  local found = false
+  for k,v in pairs(module.registry) do
+    if k ~= "n" and v ~= nil then
+      if tag == tostring(tonumber(tag)) and tag == tostring(k) then tag = v[1] end
+      if v[1] == tag then
+        v[2](notification)
+        found = true
+        break
+      end
     end
-    if not found and module.warnAboutMissingFunctionTag then print("-- hs.notify: function tag '"..tag.."' not found") end
+  end
+  if not found and module.warnAboutMissingFunctionTag then print("-- hs.notify: function tag '"..tag.."' not found") end
 end
 
---- hs.notify.show(title, subtitle, information, tag) -> notfication
+--- hs.notify.show(title, subTitle, information[, tag]) -> notfication
 --- Constructor
 --- Shorthand constructor to create and show simple notifications
 ---
 --- Parameters:
 ---  * title       - the title for the notification
----  * subtitle    - the subtitle, or second line, of the notification
----  * information - the main textual body of the notification.
+---  * subTitle    - the subtitle, or second line, of the notification
+---  * information - the main textual body of the notification
 ---  * tag         - a function tag corresponding to a function registered with `hs.notify.register`
 ---
 --- Returns:
 ---  * a notification object
 ---
 --- Notes:
----  * All four parameters are required, though they can be empty strings.
+---  * All three textual parameters are required, though they can be empty strings
 ---  * This function is really a shorthand for `hs.notify.new(...):send()`
-module.show = function(title, subtitle, information, tag)
-    if type(title) ~= "string" or type(subtitle) ~= "string" or
-        type(information) ~= "string" or type(tag) ~= "string" then
-        error("All four arguments to hs.notify.show must be present and must be strings.",2)
-        return nil
-    else
-        return module.new(tag, {
-                title = title,
-                subtitle = subtitle,
-                informativeText = information,
-                autoWithdraw = true,
-            }):send()
-    end
+module.show = function(title, subTitle, informativeText, tag)
+  if not hs.fnutils.contains({"function", "string", "number", "nil"}, type(tag)) or
+  (type(tag) == "number" and not module.registry[tag]) or
+  (type(tag) == "string" and tag ~= "" and not tostring(module.registry):find("\n"..tag.."\n")) then
+    error "tag must be a function or function-tag defined in hs.notify.registry"
+    return nil
+  end
+  if type(title) ~= "string" or type(subTitle) ~= "string" or type(informativeText) ~= "string" then
+    error("All four arguments to hs.notify.show must be present and must be strings.", 2)
+    return nil
+  else
+    return module.new(tag, {
+        title = title,
+        subTitle = subTitle,
+        informativeText = informativeText,
+        autoWithdraw = true,
+      }):send()
+  end
 end
+
 
 --- hs.notify.register(tag, fn) -> id
 --- Function
---- Registers a function callback with the specified tag for a notification.  The callback function will be invoked when the user clicks on or interacts with a notification.
+--- Registers a function callback with the specified tag for a notification. The callback function will be invoked when the user clicks on or interacts with a notification.
 ---
 --- Parameters:
----  * tag - a string tag to identify the registered callback function.  Use this as the function tag in `hs.notify.new` and `hs.notify.show`
+---  * tag - a string tag to identify the registered callback function. Use this as the function tag in `hs.notify.new` and `hs.notify.show`
 ---  * fn  - the function which should be invoked when a notification with this tag is interacted with.
 ---
 --- Returns:
----  * a numerical id representing the entry in `hs.notify.registry` for this function.  This number can be used with `hs.notify.unregister` to unregister a function later if you wish.
+---  * a numerical id representing the entry in `hs.notify.registry` for this function. This number can be used with `hs.notify.unregister` to unregister a function later if you wish.
 ---
 --- Notes:
 ---  * If a function is already registered with the specified tag, it is replaced by with the new one.
@@ -199,19 +206,19 @@ module.register = function(tag, fn)
   local found = false
   local id
   for k,v in pairs(module.registry) do
-      if k ~= "n" and v ~= nil then
-          if v[1] == tag then
-              id = i
-              v[2] = fn
-              found = true
-              break
-          end
+    if k ~= "n" and v ~= nil then
+      if v[1] == tag then
+        id = i
+        v[2] = fn
+        found = true
+        break
       end
+    end
   end
   if not found then
-      id = module.registry.n + 1
-      module.registry[id] = {tag, fn}
-      module.registry.n = id
+    id = module.registry.n + 1
+    module.registry[id] = {tag, fn}
+    module.registry.n = id
   end
   return id
 end
@@ -226,20 +233,20 @@ end
 --- Returns:
 ---  * None
 module.unregister = function(id)
-    local found = false
-    for i = 1, module.registry.n, 1 do
-        if module.registry[i] then
-              if type(module.registry[i][1]) == type(id) and module.registry[i][1] == id then
-                  found = i
-                  break
-              end
-        end
+  local found = false
+  for i = 1, module.registry.n, 1 do
+    if module.registry[i] then
+      if type(module.registry[i][1]) == type(id) and module.registry[i][1] == id then
+        found = i
+        break
+      end
     end
-    if not found then
-        module.registry[id] = nil
-    else
-        module.registry[found] = nil
-    end
+  end
+  if not found then
+    module.registry[id] = nil
+  else
+    module.registry[found] = nil
+  end
 end
 
 --- hs.notify.notification.unregisterall()
@@ -253,26 +260,27 @@ end
 ---  * None
 ---
 --- Notes:
----  * This does not remove the notifications from the User Notification Center, it just removes their callback function for when the user interacts with them.  To remove all notifications, see `hs.notify.withdrawAll` and `hs.notify.withdrawAllScheduled`
+---  * This does not remove the notifications from the User Notification Center, it just removes their callback function for when the user interacts with them. To remove all notifications, see `hs.notify.withdrawAll` and `hs.notify.withdrawAllScheduled`
 module.unregisterall = function()
+
 --- hs.notify.registry[]
 --- Variable
 --- A table containing the registered callback functions and their tags.
 ---
 --- Notes:
----  * This table should not be modified directly.  Use the `hs.notify.register(tag, fn)` and `hs.notify.unregister(id)` functions.
+---  * This table should not be modified directly. Use the `hs.notify.register(tag, fn)` and `hs.notify.unregister(id)` functions.
 ---  * This table has a __tostring metamethod so you can see the list of registered function tags in the console by typing `hs.notify.registry`
 ---  * If a notification attempts to perform a callback to a function tag which is not present in this table, a warning will be printed in the console.
-  module.registry = setmetatable({ { emptyFunctionPlaceholder, function(_) end } }, {
-      __tostring = function(_)
-          local result = ""
-          for k,v in pairs(_) do
-              if k ~= "n" and v ~= nil then result = result..v[1].."\n" end
-          end
-          return result
-      end,
+module.registry = setmetatable({ { emptyFunctionPlaceholder, function(_) end } }, {
+    __tostring = function(_)
+      local result = ""
+      for k,v in pairs(_) do
+        if k ~= "n" and v ~= nil then result = result..v[1].."\n" end
+      end
+      return result
+    end,
   })
-  module.registry.n = 1
+module.registry.n = 1
 end
 
 --- hs.notify:contentImage([image]) -> notificationObject | current-setting
@@ -280,35 +288,35 @@ end
 --- Get or set a notification's content image.
 ---
 --- Parameters:
----  * image - An optional hs.image parameter containing the image to display. Defaults to nil.  If no parameter is provided, then the current setting is returned.
+---  * image - An optional hs.image parameter containing the image to display. Defaults to nil. If no parameter is provided, then the current setting is returned.
 ---
 --- Returns:
 ---  * The notification object, if image is provided; otherwise the current setting.
 ---
 --- Notes:
 ---  * See hs.image for details on how to specify or define an image
----  * This method is only supported in OS X 10.9 or greater.  A warning will be displayed in the console and the method will be treated as a no-op if used on an unsupported system.
+---  * This method is only supported in OS X 10.9 or greater. A warning will be displayed in the console and the method will be treated as a no-op if used on an unsupported system.
 hs.getObjectMetatable("hs.notify").contentImage = function(...)
-    local args = table.pack(...)
-    local object = args[1]
-    if args.n == 1 then
-        return object:_contentImage()
-    else
-        local imagePath = args[2]
-        local tmpImage = nil
+  local args = table.pack(...)
+  local object = args[1]
+  if args.n == 1 then
+    return object:_contentImage()
+  else
+    local imagePath = args[2]
+    local tmpImage = nil
 
-        if type(imagePath) == "userdata" then
-            tmpImage = imagePath
-        elseif type(imagePath) == "string" then
-            if string.sub(imagePath, 1, 6) == "ASCII:" then
-                tmpImage = imagemod.imageFromASCII(string.sub(imagePath, 7, -1))
-            else
-                tmpImage = imagemod.imageFromPath(imagePath)
-            end
-        end
-
-        return object:_contentImage(tmpImage)
+    if type(imagePath) == "userdata" then
+      tmpImage = imagePath
+    elseif type(imagePath) == "string" then
+      if string.sub(imagePath, 1, 6) == "ASCII:" then
+        tmpImage = imagemod.imageFromASCII(string.sub(imagePath, 7, -1))
+      else
+        tmpImage = imagemod.imageFromPath(imagePath)
+      end
     end
+
+    return object:_contentImage(tmpImage)
+  end
 end
 
 -- Return Module Object --------------------------------------------------

--- a/extensions/osascript/init.lua
+++ b/extensions/osascript/init.lua
@@ -14,7 +14,7 @@ local processResults = function(ok, object, rawDescriptor)
         rawDescriptor = rawDescriptor:match("^{\n(.*)}$")
         descriptor = {}
         local lines = hs.fnutils.split(rawDescriptor, ";\n")
-        lines = hs.fnutils.ifilter(lines, function(line) if line ~= "" then return true end end)
+        lines = hs.fnutils.ifilter(lines, function(line) return line ~= "" end)
         for _, line in ipairs(lines) do
             local k, v = line:match('^%s*(%w+)%s=%s(.*)$')
             v = v:match('^"(.*)"$') or v:match("^'(.*)'$") or v

--- a/extensions/osascript/internal.m
+++ b/extensions/osascript/internal.m
@@ -26,11 +26,10 @@ static int runosascript(lua_State* L) {
     [osa compileAndReturnError:&compileError];
 
     if (compileError) {
-        const char *compileErrorMessage = "Unable to initialize script - perhaps you have a syntax error?";
-        [skin logError:[NSString stringWithUTF8String:compileErrorMessage]];
         lua_pushboolean(L, NO);
         lua_pushnil(L);
         [skin pushNSObject:[NSString stringWithFormat:@"%@", compileError]];
+        [skin logError:[NSString stringWithFormat:@"Unable to initialize script: %@", compileError]];
         return 3;
     }
 

--- a/extensions/socket/init.lua
+++ b/extensions/socket/init.lua
@@ -175,7 +175,7 @@ module.timeout = -1
 ---
 module.udp.timeout = -1
 
---- hs.socket.udp.parseAddress(sockaddr) -> table
+--- hs.socket.udp.parseAddress(sockaddr) -> table or nil
 --- Function
 --- Alias for [`hs.socket.parseAddress`](./hs.socket.html#parseAddress)
 ---

--- a/extensions/socket/internal.m
+++ b/extensions/socket/internal.m
@@ -101,12 +101,12 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
 
 - (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err {
     if (sock.userData == CLIENT) {
-        [LuaSkin logInfo:[NSString stringWithFormat:@"TCP client disconnected %@", [err localizedDescription]]];
+        [LuaSkin logInfo:[NSString stringWithFormat:@"TCP client disconnected: %@", [err localizedDescription]]];
         @synchronized(self.connectedSockets) {
             [self.connectedSockets removeObject:sock];
         }
     } else if (sock.userData == SERVER) {
-        [LuaSkin logInfo:[NSString stringWithFormat:@"TCP server disconnected %@", [err localizedDescription]]];
+        [LuaSkin logInfo:[NSString stringWithFormat:@"TCP server disconnected: %@", [err localizedDescription]]];
         @synchronized(self.connectedSockets) {
             for (HSAsyncTcpSocket *client in self.connectedSockets)
                 [client disconnect];
@@ -120,7 +120,7 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
             self.unixSocketPath = nil;
         }
     } else
-        [LuaSkin logInfo:[NSString stringWithFormat:@"TCP socket disconnected %@", [err localizedDescription]]];
+        [LuaSkin logInfo:[NSString stringWithFormat:@"TCP socket disconnected: %@", [err localizedDescription]]];
 
     sock.userData = nil;
 }

--- a/extensions/socket/udp.m
+++ b/extensions/socket/udp.m
@@ -79,12 +79,12 @@ static void readCallback(HSAsyncUdpSocket *asyncUdpSocket, NSData *data, NSData 
 }
 
 - (void)udpSocket:(GCDAsyncUdpSocket *)sock didNotConnect:(NSError *)error {
-    [LuaSkin logError:[NSString stringWithFormat:@"UDP socket did not connect %@", [error localizedDescription]]];
+    [LuaSkin logError:[NSString stringWithFormat:@"UDP socket did not connect: %@", [error localizedDescription]]];
     mainThreadDispatch(self.connectCallback = [[LuaSkin shared] luaUnref:refTable ref:self.connectCallback]);
 }
 
 - (void)udpSocketDidClose:(GCDAsyncUdpSocket *)sock withError:(NSError *)error {
-    [LuaSkin logInfo:[NSString stringWithFormat:@"UDP socket closed %@", [error localizedDescription]]];
+    [LuaSkin logInfo:[NSString stringWithFormat:@"UDP socket closed: %@", [error localizedDescription]]];
     sock.userData = nil;
 }
 
@@ -95,7 +95,7 @@ static void readCallback(HSAsyncUdpSocket *asyncUdpSocket, NSData *data, NSData 
 }
 
 - (void)udpSocket:(GCDAsyncUdpSocket *)sock didNotSendDataWithTag:(long)tag dueToError:(NSError *)error {
-    [LuaSkin logError:[NSString stringWithFormat:@"Data not sent on UDP socket %@", [error localizedDescription]]];
+    [LuaSkin logError:[NSString stringWithFormat:@"Data not sent on UDP socket: %@", [error localizedDescription]]];
     mainThreadDispatch(self.writeCallback = [[LuaSkin shared] luaUnref:refTable ref:self.writeCallback]);
 }
 


### PR DESCRIPTION
The `hs.notify.show()` convenience constructor was using the wrong key ('subtitle' instead of 'subTitle')
Improves function-tag handling in `hs.notify`
Reindents lua code

Also makes some error logging more consistent in `hs.osascript` and `hs.socket`