### PR TITLE
add ability to set identity image for notification

### DIFF
--- a/extensions/notify/init.lua
+++ b/extensions/notify/init.lua
@@ -319,13 +319,13 @@ hs.getObjectMetatable("hs.notify").contentImage = function(...)
   end
 end
 
---- hs.notify:setIdImage(image[, hasBorder]) -> notificationObject
+--- hs.notify:setIdImage(image[, withBorder]) -> notificationObject
 --- Method
 --- Set a notification's identification image (replace the Hammerspoon icon with a custom image)
 ---
 --- Parameters:
 ---  * image - An `hs.image` object, a string containing an image path, or a string defining an ASCIImage
----  * hasBorder - An optional boolean specifying whether or not the image has a border. Defaults to `false`
+---  * withBorder - An optional boolean to give the notification image a border. Defaults to `false`
 ---
 --- Returns:
 ---  * The notification object
@@ -333,8 +333,8 @@ end
 --- Notes:
 ---  * See hs.image for details on how to specify or define an image
 ---  * **WARNING**: This method uses a private API. It could break at any time. Please file an issue if it does
-hs.getObjectMetatable("hs.notify").setIdImage = function(self, imagePath, hasBorder)
-  hasBorder = hasBorder or false
+hs.getObjectMetatable("hs.notify").setIdImage = function(self, imagePath, withBorder)
+  withBorder = withBorder or false
   local tmpImage = nil
 
   if type(imagePath) == "userdata" then
@@ -347,7 +347,7 @@ hs.getObjectMetatable("hs.notify").setIdImage = function(self, imagePath, hasBor
     end
   end
 
-  return self:_setIdImage(tmpImage, hasBorder)
+  return self:_setIdImage(tmpImage, withBorder)
 end
 
 -- Return Module Object --------------------------------------------------

--- a/extensions/notify/init.lua
+++ b/extensions/notify/init.lua
@@ -319,6 +319,35 @@ hs.getObjectMetatable("hs.notify").contentImage = function(...)
   end
 end
 
+--- hs.notify:setIdImage(image) -> notificationObject
+--- Method
+--- Set a notification's identification image (replace the Hammerspoon icon with a custom image)
+---
+--- Parameters:
+---  * image - An `hs.image` object, a string containing an image path, or a string defining an ASCIImage
+---
+--- Returns:
+---  * The notification object
+---
+--- Notes:
+---  * See hs.image for details on how to specify or define an image
+---  * **WARNING**: This method uses a private API. It could break at any time. Please file an issue if it does
+hs.getObjectMetatable("hs.notify").setIdImage = function(self, imagePath)
+  local tmpImage = nil
+
+  if type(imagePath) == "userdata" then
+    tmpImage = imagePath
+  elseif type(imagePath) == "string" then
+    if string.sub(imagePath, 1, 6) == "ASCII:" then
+      tmpImage = imagemod.imageFromASCII(string.sub(imagePath, 7, -1))
+    else
+      tmpImage = imagemod.imageFromPath(imagePath)
+    end
+  end
+
+  return self:_setIdImage(tmpImage)
+end
+
 -- Return Module Object --------------------------------------------------
 
 module.unregisterall() -- make sure placeholder is in effect and nothing else

--- a/extensions/notify/init.lua
+++ b/extensions/notify/init.lua
@@ -319,12 +319,13 @@ hs.getObjectMetatable("hs.notify").contentImage = function(...)
   end
 end
 
---- hs.notify:setIdImage(image) -> notificationObject
+--- hs.notify:setIdImage(image[, hasBorder]) -> notificationObject
 --- Method
 --- Set a notification's identification image (replace the Hammerspoon icon with a custom image)
 ---
 --- Parameters:
 ---  * image - An `hs.image` object, a string containing an image path, or a string defining an ASCIImage
+---  * hasBorder - An optional boolean specifying whether or not the image has a border. Defaults to `false`
 ---
 --- Returns:
 ---  * The notification object
@@ -332,7 +333,8 @@ end
 --- Notes:
 ---  * See hs.image for details on how to specify or define an image
 ---  * **WARNING**: This method uses a private API. It could break at any time. Please file an issue if it does
-hs.getObjectMetatable("hs.notify").setIdImage = function(self, imagePath)
+hs.getObjectMetatable("hs.notify").setIdImage = function(self, imagePath, hasBorder)
+  hasBorder = hasBorder or false
   local tmpImage = nil
 
   if type(imagePath) == "userdata" then
@@ -345,7 +347,7 @@ hs.getObjectMetatable("hs.notify").setIdImage = function(self, imagePath)
     end
   end
 
-  return self:_setIdImage(tmpImage)
+  return self:_setIdImage(tmpImage, hasBorder)
 end
 
 -- Return Module Object --------------------------------------------------

--- a/extensions/notify/internal.m
+++ b/extensions/notify/internal.m
@@ -26,6 +26,11 @@ int refTable;
 @interface ourNotificationManager () <NSUserNotificationCenterDelegate>
 @end
 
+// Private API for setting notification identity image http://stackoverflow.com/questions/19797841
+@interface NSUserNotification (NSUserNotificationPrivate)
+- (void)set_identityImage:(NSImage *)image;
+@end
+
 static id <NSUserNotificationCenterDelegate>    old_delegate ;
 // static ourNotificationManager*                  sharedManager;
 
@@ -731,6 +736,32 @@ static int notification_contentImage(lua_State *L) {
     return 1 ;
 }
 
+static int notification_setIdImage(lua_State *L) {
+// NOTE: THIS FUNCTION IS WRAPPED IN init.lua
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TUSERDATA, "hs.image", LS_TBREAK];
+    notification_t* notificationUserdata = luaL_checkudata(L, 1, USERDATA_TAG);
+
+    if (!notificationUserdata->locked) {
+        if ([((__bridge NSUserNotification *) notificationUserdata->note) respondsToSelector:@selector(set_identityImage:)]) {
+            NSImage *idImage = [skin luaObjectAtIndex:2 toClass:"NSImage"] ;
+            if (!(idImage && idImage.valid)) {
+                return luaL_error(L, "invalid image specified");
+            } else {
+                [((__bridge NSUserNotification *) notificationUserdata->note) set_identityImage:idImage];
+                notificationUserdata->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
+                lua_settop(L, 1) ;
+            }
+        } else {
+            [skin logInfo:@"hs.notify:setIdImage() is not supported. Please file an issue"] ;
+            lua_settop(L, 1) ;
+        }
+    } else {
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
+    }
+    return 1 ;
+}
+
 // Get status of a notification
 
 static int notification_presented(lua_State* L) {
@@ -904,6 +935,7 @@ static const luaL_Reg userdata_metaLib[] = {
     {"alwaysPresent",       notification_alwaysPresent},
     {"autoWithdraw",        notification_autoWithdraw},
     {"_contentImage",       notification_contentImage},
+    {"_setIdImage",         notification_setIdImage},
     {"release",             notification_release},
     {"getFunctionTag",      notification_getFunctionTag},
     {"presented",           notification_presented},


### PR DESCRIPTION
In addition to `hs.notify:contentImage`:
![](http://i.imgur.com/wGSSn8w.png)

Adds `hs.notify:setIdImage`:
![](http://i.imgur.com/N3s4TUT.png)

Requires @asmagill's review and approval because this uses a private API method:

http://stackoverflow.com/questions/19797841/nsusernotification-mavericks-custom-images
