### PR TITLE
[WIP] add attributedTitle support and priority positioning to hs.menubar

### DIFF
--- a/extensions/application/init.lua
+++ b/extensions/application/init.lua
@@ -185,6 +185,156 @@ function application.open(app,wait,waitForWindow)
   return r
 end
 
+--- hs.application.menuGlyphs
+--- Variable
+--- A table containing UTF8 representations of the defined key glyphs used in Menus for keybaord shortcuts which are presented pictorially rather than as text (arrow keys, return key, etc.)
+---
+--- These glyphs are indexed numerically where the numeric index matches a possible value for the AXMenuItemCmdGlyph key of an entry returned by `hs.application.getMenus`.  If the AXMenuItemCmdGlyph field is non-numeric, then no glyph is used in the presentation of the keyboard shortcut for a menu item.
+---
+--- The following glyphs are defined:
+---  * "⇥",  -- kMenuTabRightGlyph, 0x02, Tab to the right key (for left-to-right script systems)
+---  * "⇤",  -- kMenuTabLeftGlyph, 0x03, Tab to the left key (for right-to-left script systems)
+---  * "⌤",   -- kMenuEnterGlyph, 0x04, Enter key
+---  * "⇧",  -- kMenuShiftGlyph, 0x05, Shift key
+---  * "⌃",   -- kMenuControlGlyph, 0x06, Control key
+---  * "⌥",  -- kMenuOptionGlyph, 0x07, Option key
+---  * "␣",    -- kMenuSpaceGlyph, 0x09, Space (always glyph 3) key
+---  * "⌦",  -- kMenuDeleteRightGlyph, 0x0A, Delete to the right key (for right-to-left script systems)
+---  * "↩",  -- kMenuReturnGlyph, 0x0B, Return key (for left-to-right script systems)
+---  * "↪",  -- kMenuReturnR2LGlyph, 0x0C, Return key (for right-to-left script systems)
+---  * "",   -- kMenuPencilGlyph, 0x0F, Pencil key
+---  * "↓",   -- kMenuDownwardArrowDashedGlyph, 0x10, Downward dashed arrow key
+---  * "⌘",  -- kMenuCommandGlyph, 0x11, Command key
+---  * "✓",   -- kMenuCheckmarkGlyph, 0x12, Checkmark key
+---  * "⃟",   -- kMenuDiamondGlyph, 0x13, Diamond key
+---  * "",   -- kMenuAppleLogoFilledGlyph, 0x14, Apple logo key (filled)
+---  * "⌫",  -- kMenuDeleteLeftGlyph, 0x17, Delete to the left key (for left-to-right script systems)
+---  * "←",  -- kMenuLeftArrowDashedGlyph, 0x18, Leftward dashed arrow key
+---  * "↑",   -- kMenuUpArrowDashedGlyph, 0x19, Upward dashed arrow key
+---  * "→",   -- kMenuRightArrowDashedGlyph, 0x1A, Rightward dashed arrow key
+---  * "⎋",  -- kMenuEscapeGlyph, 0x1B, Escape key
+---  * "⌧",  -- kMenuClearGlyph, 0x1C, Clear key
+---  * "『",  -- kMenuLeftDoubleQuotesJapaneseGlyph, 0x1D, Unassigned (left double quotes in Japanese)
+---  * "』",  -- kMenuRightDoubleQuotesJapaneseGlyph, 0x1E, Unassigned (right double quotes in Japanese)
+---  * "␢",   -- kMenuBlankGlyph, 0x61, Blank key
+---  * "⇞",   -- kMenuPageUpGlyph, 0x62, Page up key
+---  * "⇪",  -- kMenuCapsLockGlyph, 0x63, Caps lock key
+---  * "←",  -- kMenuLeftArrowGlyph, 0x64, Left arrow key
+---  * "→",   -- kMenuRightArrowGlyph, 0x65, Right arrow key
+---  * "↖",  -- kMenuNorthwestArrowGlyph, 0x66, Northwest arrow key
+---  * "﹖",  -- kMenuHelpGlyph, 0x67, Help key
+---  * "↑",   -- kMenuUpArrowGlyph, 0x68, Up arrow key
+---  * "↘",  -- kMenuSoutheastArrowGlyph, 0x69, Southeast arrow key
+---  * "↓",   -- kMenuDownArrowGlyph, 0x6A, Down arrow key
+---  * "⇟",   -- kMenuPageDownGlyph, 0x6B, Page down key
+---  * "",  -- kMenuContextualMenuGlyph, 0x6D, Contextual menu key
+---  * "⌽",  -- kMenuPowerGlyph, 0x6E, Power key
+---  * "F1",  -- kMenuF1Glyph, 0x6F, F1 key
+---  * "F2",  -- kMenuF2Glyph, 0x70, F2 key
+---  * "F3",  -- kMenuF3Glyph, 0x71, F3 key
+---  * "F4",  -- kMenuF4Glyph, 0x72, F4 key
+---  * "F5",  -- kMenuF5Glyph, 0x73, F5 key
+---  * "F6",  -- kMenuF6Glyph, 0x74, F6 key
+---  * "F7",  -- kMenuF7Glyph, 0x75, F7 key
+---  * "F8",  -- kMenuF8Glyph, 0x76, F8 key
+---  * "F9",  -- kMenuF9Glyph, 0x77, F9 key
+---  * "F10", -- kMenuF10Glyph, 0x78, F10 key
+---  * "F11", -- kMenuF11Glyph, 0x79, F11 key
+---  * "F12", -- kMenuF12Glyph, 0x7A, F12 key
+---  * "F13", -- kMenuF13Glyph, 0x87, F13 key
+---  * "F14", -- kMenuF14Glyph, 0x88, F14 key
+---  * "F15", -- kMenuF15Glyph, 0x89, F15 key
+---  * "⎈",  -- kMenuControlISOGlyph, 0x8A, Control key (ISO standard)
+---  * "⏏",   -- kMenuEjectGlyph, 0x8C, Eject key (available on Mac OS X 10.2 and later)
+---  * "英数", -- kMenuEisuGlyph, 0x8D, Japanese eisu key (available in Mac OS X 10.4 and later)
+---  * "かな", -- kMenuKanaGlyph, 0x8E, Japanese kana key (available in Mac OS X 10.4 and later)
+---  * "F16", -- kMenuF16Glyph, 0x8F, F16 key (available in SnowLeopard and later)
+---  * "F17", -- kMenuF16Glyph, 0x90, F17 key (available in SnowLeopard and later)
+---  * "F18", -- kMenuF16Glyph, 0x91, F18 key (available in SnowLeopard and later)
+---  * "F19", -- kMenuF16Glyph, 0x92, F19 key (available in SnowLeopard and later)
+---
+--- Notes:
+---  * a `__tostring` metamethod is provided for this table so you can view its current contents by typing `hs.application.menuGlyphs` into the Hammerspoon console.
+---  * This table is provided as a variable so that you can change any representation if you feel you know of a better or more appropriate one for you usage at runtime.
+---
+---  * The glyphs provided are defined in the Carbon framework headers in the Menus.h file, located (as of 10.11) at /System/Library/Frameworks/Carbon.framework/Frameworks/HIToolbox.framework/Headers/Menus.h.
+---  * The following constants are defined in Menus.h, but do not seem to correspond to a visible UTF8 character or well defined representation that I could discover.  If you believe that you know of a (preferably sanctioned by Apple) proper visual representation, please submit an issue detailing it at the Hammerspoon repository on Github.
+---    * kMenuNullGlyph, 0x00, Null (always glyph 1)
+---    * kMenuNonmarkingReturnGlyph, 0x0D, Nonmarking return key
+---    * kMenuParagraphKoreanGlyph, 0x15, Unassigned (paragraph in Korean)
+---    * kMenuTrademarkJapaneseGlyph, 0x1F, Unassigned (trademark in Japanese)
+---    * kMenuAppleLogoOutlineGlyph, 0x6C, Apple logo key (outline)
+application.menuGlyphs = setmetatable({
+    [2] = "⇥",     -- kMenuTabRightGlyph, 0x02, Tab to the right key (for left-to-right script systems)
+    [3] = "⇤",     -- kMenuTabLeftGlyph, 0x03, Tab to the left key (for right-to-left script systems)
+    [4] = "⌤",     -- kMenuEnterGlyph, 0x04, Enter key
+    [5] = "⇧",     -- kMenuShiftGlyph, 0x05, Shift key
+    [6] = "⌃",     -- kMenuControlGlyph, 0x06, Control key
+    [7] = "⌥",     -- kMenuOptionGlyph, 0x07, Option key
+    [9] = "␣",      -- kMenuSpaceGlyph, 0x09, Space (always glyph 3) key
+    [10] = "⌦",    -- kMenuDeleteRightGlyph, 0x0A, Delete to the right key (for right-to-left script systems)
+    [11] = "↩",    -- kMenuReturnGlyph, 0x0B, Return key (for left-to-right script systems)
+    [12] = "↪",    -- kMenuReturnR2LGlyph, 0x0C, Return key (for right-to-left script systems)
+    [15] = "",    -- kMenuPencilGlyph, 0x0F, Pencil key
+    [16] = "↓",     -- kMenuDownwardArrowDashedGlyph, 0x10, Downward dashed arrow key
+    [17] = "⌘",    -- kMenuCommandGlyph, 0x11, Command key
+    [18] = "✓",     -- kMenuCheckmarkGlyph, 0x12, Checkmark key
+    [19] = "◇",     -- kMenuDiamondGlyph, 0x13, Diamond key
+    [20] = "",     -- kMenuAppleLogoFilledGlyph, 0x14, Apple logo key (filled)
+    [23] = "⌫",    -- kMenuDeleteLeftGlyph, 0x17, Delete to the left key (for left-to-right script systems)
+    [24] = "←",    -- kMenuLeftArrowDashedGlyph, 0x18, Leftward dashed arrow key
+    [25] = "↑",     -- kMenuUpArrowDashedGlyph, 0x19, Upward dashed arrow key
+    [26] = "→",     -- kMenuRightArrowDashedGlyph, 0x1A, Rightward dashed arrow key
+    [27] = "⎋",    -- kMenuEscapeGlyph, 0x1B, Escape key
+    [28] = "⌧",    -- kMenuClearGlyph, 0x1C, Clear key
+    [29] = "『",    -- kMenuLeftDoubleQuotesJapaneseGlyph, 0x1D, Unassigned (left double quotes in Japanese)
+    [30] = "』",    -- kMenuRightDoubleQuotesJapaneseGlyph, 0x1E, Unassigned (right double quotes in Japanese)
+    [97] = "␢",     -- kMenuBlankGlyph, 0x61, Blank key
+    [98] = "⇞",     -- kMenuPageUpGlyph, 0x62, Page up key
+    [99] = "⇪",    -- kMenuCapsLockGlyph, 0x63, Caps lock key
+    [100] = "←",   -- kMenuLeftArrowGlyph, 0x64, Left arrow key
+    [101] = "→",    -- kMenuRightArrowGlyph, 0x65, Right arrow key
+    [102] = "↖",   -- kMenuNorthwestArrowGlyph, 0x66, Northwest arrow key
+    [103] = "﹖",   -- kMenuHelpGlyph, 0x67, Help key
+    [104] = "↑",    -- kMenuUpArrowGlyph, 0x68, Up arrow key
+    [105] = "↘",   -- kMenuSoutheastArrowGlyph, 0x69, Southeast arrow key
+    [106] = "↓",    -- kMenuDownArrowGlyph, 0x6A, Down arrow key
+    [107] = "⇟",    -- kMenuPageDownGlyph, 0x6B, Page down key
+    [109] = "",   -- kMenuContextualMenuGlyph, 0x6D, Contextual menu key
+    [110] = "⌽",   -- kMenuPowerGlyph, 0x6E, Power key
+    [111] = "F1",   -- kMenuF1Glyph, 0x6F, F1 key
+    [112] = "F2",   -- kMenuF2Glyph, 0x70, F2 key
+    [113] = "F3",   -- kMenuF3Glyph, 0x71, F3 key
+    [114] = "F4",   -- kMenuF4Glyph, 0x72, F4 key
+    [115] = "F5",   -- kMenuF5Glyph, 0x73, F5 key
+    [116] = "F6",   -- kMenuF6Glyph, 0x74, F6 key
+    [117] = "F7",   -- kMenuF7Glyph, 0x75, F7 key
+    [118] = "F8",   -- kMenuF8Glyph, 0x76, F8 key
+    [119] = "F9",   -- kMenuF9Glyph, 0x77, F9 key
+    [120] = "F10",  -- kMenuF10Glyph, 0x78, F10 key
+    [121] = "F11",  -- kMenuF11Glyph, 0x79, F11 key
+    [122] = "F12",  -- kMenuF12Glyph, 0x7A, F12 key
+    [135] = "F13",  -- kMenuF13Glyph, 0x87, F13 key
+    [136] = "F14",  -- kMenuF14Glyph, 0x88, F14 key
+    [137] = "F15",  -- kMenuF15Glyph, 0x89, F15 key
+    [138] = "⎈",   -- kMenuControlISOGlyph, 0x8A, Control key (ISO standard)
+    [140] = "⏏",   -- kMenuEjectGlyph, 0x8C, Eject key (available on Mac OS X 10.2 and later)
+    [141] = "英数", -- kMenuEisuGlyph, 0x8D, Japanese eisu key (available in Mac OS X 10.4 and later)
+    [142] = "かな", -- kMenuKanaGlyph, 0x8E, Japanese kana key (available in Mac OS X 10.4 and later)
+    [143] = "F16",  -- kMenuF16Glyph, 0x8F, F16 key (available in SnowLeopard and later)
+    [144] = "F17",  -- kMenuF16Glyph, 0x90, F17 key (available in SnowLeopard and later)
+    [145] = "F18",  -- kMenuF16Glyph, 0x91, F18 key (available in SnowLeopard and later)
+    [146] = "F19",  -- kMenuF16Glyph, 0x92, F19 key (available in SnowLeopard and later)
+}, {
+    __tostring = function(self)
+        local result = ""
+        for k, v in require("hs.fnutils").sortByKeys(self) do
+            result = result..string.format("%4d %s\n", k, v)
+        end
+        return result
+    end,
+})
+
 do
   local mt=getmetatable(application)
   -- whoever gets it first (window vs application)

--- a/extensions/application/internal.m
+++ b/extensions/application/internal.m
@@ -809,7 +809,8 @@ id _getMenuStructure(AXUIElementRef menuItem) {
                                                                       (__bridge NSString *)kAXMenuItemCmdCharAttribute,
                                                                       (__bridge NSString *)kAXMenuItemCmdModifiersAttribute,
                                                                       //(__bridge NSString *)kAXMenuItemCmdVirtualKeyAttribute,
-                                                                      (__bridge NSString *)kAXEnabledAttribute]];
+                                                                      (__bridge NSString *)kAXEnabledAttribute,
+                                                                      (__bridge NSString *)kAXMenuItemCmdGlyphAttribute]];
     CFArrayRef cfAttributeValues = NULL;
 
     AXUIElementCopyMultipleAttributeValues(menuItem, (__bridge CFArrayRef)attributeNames, 0, &cfAttributeValues);
@@ -923,6 +924,7 @@ id _getMenuStructure(AXUIElementRef menuItem) {
 ///   * AXMenuItemMarkChar - A string containing the "mark" character for a menu item. This is for toggleable menu items and will usually be an empty string or a Unicode tick character (✓)
 ///   * AXMenuItemCmdModifiers - A table containing string representations of the keyboard modifiers for the menu item's keyboard shortcut, or nil if no modifiers are present
 ///   * AXMenuItemCmdChar - A string containing the key for the menu item's keyboard shortcut, or an empty string if no shortcut is present
+///   * AXMenuItemCmdGlyph - An integer, corresponding to one of the defined glyphs in `hs.application.menuGlyphs` if the keyboard shortcut is a special character usually represented by a pictorial representation (think arrow keys, return, etc), or an empty string if no glyph is used in presenting the keyboard shortcut.
 ///  * Using `hs.inspect()` on these tables, while useful for exploration, can be extremely slow, taking several minutes to correctly render very complex menus
 static int application_getMenus(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];

--- a/extensions/menubar/init.lua
+++ b/extensions/menubar/init.lua
@@ -9,6 +9,84 @@ local screen = require "hs.screen"
 
 require("hs.styledtext")
 
+-- protects tables of constants
+
+local _kMetaTable = {}
+_kMetaTable._k = setmetatable({}, {__mode = "k"})
+_kMetaTable._t = setmetatable({}, {__mode = "k"})
+_kMetaTable.__index = function(obj, key)
+        if _kMetaTable._k[obj] then
+            if _kMetaTable._k[obj][key] then
+                return _kMetaTable._k[obj][key]
+            else
+                for k,v in pairs(_kMetaTable._k[obj]) do
+                    if v == key then return k end
+                end
+            end
+        end
+        return nil
+    end
+_kMetaTable.__newindex = function(obj, key, value)
+        error("attempt to modify a table of constants",2)
+        return nil
+    end
+_kMetaTable.__pairs = function(obj) return pairs(_kMetaTable._k[obj]) end
+_kMetaTable.__len = function(obj) return #_kMetaTable._k[obj] end
+_kMetaTable.__tostring = function(obj)
+        local result = ""
+        if _kMetaTable._k[obj] then
+            local width = 0
+            for k,v in pairs(_kMetaTable._k[obj]) do width = width < #tostring(k) and #tostring(k) or width end
+            for k,v in require("hs.fnutils").sortByKeys(_kMetaTable._k[obj]) do
+                if _kMetaTable._t[obj] == "table" then
+                    result = result..string.format("%-"..tostring(width).."s %s\n", tostring(k),
+                        ((type(v) == "table") and "{ table }" or tostring(v)))
+                else
+                    result = result..((type(v) == "table") and "{ table }" or tostring(v)).."\n"
+                end
+            end
+        else
+            result = "constants table missing"
+        end
+        return result
+    end
+_kMetaTable.__metatable = _kMetaTable -- go ahead and look, but don't unset this
+
+local _makeConstantsTable
+_makeConstantsTable = function(theTable)
+    if type(theTable) ~= "table" then
+        local dbg = debug.getinfo(2)
+        local msg = dbg.short_src..":"..dbg.currentline..": attempting to make a '"..type(theTable).."' into a constant table"
+        if module.log then module.log.ef(msg) else print(msg) end
+        return theTable
+    end
+    for k,v in pairs(theTable) do
+        if type(v) == "table" then
+            local count = 0
+            for a,b in pairs(v) do count = count + 1 end
+            local results = _makeConstantsTable(v)
+            if #v > 0 and #v == count then
+                _kMetaTable._t[results] = "array"
+            else
+                _kMetaTable._t[results] = "table"
+            end
+            theTable[k] = results
+        end
+    end
+    local results = setmetatable({}, _kMetaTable)
+    _kMetaTable._k[results] = theTable
+    local count = 0
+    for a,b in pairs(theTable) do count = count + 1 end
+    if #theTable > 0 and #theTable == count then
+        _kMetaTable._t[results] = "array"
+    else
+        _kMetaTable._t[results] = "table"
+    end
+    return results
+end
+
+menubar.priorities = _makeConstantsTable(menubar.priorities)
+
 -- This is the wrapper for hs.menubar:setIcon(). It is documented in internal.m
 
 local menubarObject = hs.getObjectMetatable("hs.menubar")


### PR DESCRIPTION
This pull adds:
* styledText support to the `setTitle` and `title` methods
* `hs.menubar.newWithPriority` to create a menubar item with a positioning priority other than the default
* `hs.menubar:priority` to get/set an existing menubar item's positioning priority

Addresses #831 and #821

While I believe it is ready for integration (I have no further expected additions to this module at present), I want to run a few more tests, but I figured I'd put it out there for anyone who's been following the referenced issues and wants to work with it now.