### PR TITLE
add LS_TTYPEDTABLE to checkArgs:

### DIFF
--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -54,6 +54,9 @@
 /*! @define LS_TTYPEDTABLE maps to LUA_TTABLE, but like LS_TUSERDATA, expects a string argument following which specifies the specific value expected in the __luaSkinType field of the table. */
 #define LS_TTYPEDTABLE    1 << 13
 
+/*! @define LS_TYPEMASK a mask specifying which bit positions contain LuaSkin type information.  Used internally; make sure to adjust if you add a type or type option. */
+#define LS_TTYPEMASK      ((size_t)((1 << 14) - 1))
+
 /*! @/definedblock Bit masks for Lua type checking */
 
 /*!

--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -51,6 +51,8 @@
 #define LS_TINTEGER       1 << 11
 /*! @define LS_TVARARG Can be OR'd with LS_TBREAK to indicate that any additional arguments on the stack after this location are to be ignored by @link //apple_ref/occ/instm/LuaSkin/checkArgs: checkArgs @/link.  It is the responsibility of the module function to check and use or ignore any additional arguments. */
 #define LS_TVARARG        1 << 12
+/*! @define LS_TTYPEDTABLE maps to LUA_TTABLE, but like LS_TUSERDATA, expects a string argument following which specifies the specific value expected in the __luaSkinType field of the table. */
+#define LS_TTYPEDTABLE    1 << 13
 
 /*! @/definedblock Bit masks for Lua type checking */
 

--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -54,9 +54,6 @@
 /*! @define LS_TTYPEDTABLE maps to LUA_TTABLE, but like LS_TUSERDATA, expects a string argument following which specifies the specific value expected in the __luaSkinType field of the table. */
 #define LS_TTYPEDTABLE    1 << 13
 
-/*! @define LS_TYPEMASK a mask specifying which bit positions contain LuaSkin type information.  Used internally; make sure to adjust if you add a type or type option. */
-#define LS_TTYPEMASK      ((size_t)((1 << 14) - 1))
-
 /*! @/definedblock Bit masks for Lua type checking */
 
 /*!

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -1,4 +1,4 @@
- //
+//
 //  Skin.m
 //  LuaSkin
 //
@@ -338,7 +338,9 @@ static int pushUserdataType(lua_State *L) {
                 if (spec & LS_TTYPEDTABLE) {
                     lsType = LS_TTYPEDTABLE;
                     char *expectedTableTag = va_arg(args, char*);
-                    if (!expectedTableTag) luaL_error(self.L, "ERROR: unable to get expected LuaSkin table type for argument %d", idx) ;
+// NOTE: Make sure LS_TTYPEMASK in Skin.h is updated as options are added. Since va_args can't check type for us, we have to do this to make sure we get an address rather than an integer cast as an address... it's a bit of a hack for bit-position based flags since at some point we enter the realm of a valid setting being a valid address, but its the best I've been able to come up with so far...
+                    if (((size_t)expectedTableTag & ~LS_TTYPEMASK) == 0)
+                        luaL_error(self.L, "DEVELOPER-ERROR: unable to get expected LuaSkin table type for argument %d", idx) ;
 
                     const char *actualTableTag   = NULL ;
                     if (lua_getfield(self.L, idx, "__luaSkinType") == LUA_TSTRING) {
@@ -361,6 +363,10 @@ static int pushUserdataType(lua_State *L) {
                 }
 
                 userdataTag = va_arg(args, char*);
+// NOTE: Make sure LS_TTYPEMASK in Skin.h is updated as options are added. Since va_args can't check type for us, we have to do this to make sure we get an address rather than an integer cast as an address... it's a bit of a hack for bit-position based flags since at some point we enter the realm of a valid setting being a valid address, but its the best I've been able to come up with so far...
+                if (((size_t)userdataTag & ~LS_TTYPEMASK) == 0)
+                    luaL_error(self.L, "DEVELOPER-ERROR: unable to get expected userdata type for argument %d", idx) ;
+
                 if (!userdataTag || strlen(userdataTag) == 0 || !luaL_testudata(self.L, idx, userdataTag)) {
                     luaL_error(self.L, "ERROR: incorrect userdata type for argument %d (expected %s)", idx, userdataTag);
                 }

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -335,7 +335,22 @@ static int pushUserdataType(lua_State *L) {
                 lsType = LS_TFUNCTION;
                 break;
             case LUA_TTABLE:
-                lsType = LS_TTABLE;
+                if (spec & LS_TTYPEDTABLE) {
+                    lsType = LS_TTYPEDTABLE;
+                    char *expectedTableTag = va_arg(args, char*);
+                    if (!expectedTableTag) luaL_error(self.L, "ERROR: unable to get expected LuaSkin table type for argument %d", idx) ;
+
+                    const char *actualTableTag   = NULL ;
+                    if (lua_getfield(self.L, idx, "__luaSkinType") == LUA_TSTRING) {
+                        actualTableTag = lua_tostring(self.L, -1) ;
+                    }
+                    lua_pop(self.L, 1) ;
+                    if (!actualTableTag || !(strcmp(actualTableTag, expectedTableTag) == 0)) {
+                        luaL_error(self.L, "ERROR: incorrect LuaSkin typed table for argument %d (expected %s)", idx, expectedTableTag) ;
+                    }
+                } else {
+                    lsType = LS_TTABLE;
+                }
                 break;
             case LUA_TUSERDATA:
                 lsType = LS_TUSERDATA;

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -1,4 +1,4 @@
-//
+ //
 //  Skin.m
 //  LuaSkin
 //
@@ -338,9 +338,7 @@ static int pushUserdataType(lua_State *L) {
                 if (spec & LS_TTYPEDTABLE) {
                     lsType = LS_TTYPEDTABLE;
                     char *expectedTableTag = va_arg(args, char*);
-// NOTE: Make sure LS_TTYPEMASK in Skin.h is updated as options are added. Since va_args can't check type for us, we have to do this to make sure we get an address rather than an integer cast as an address... it's a bit of a hack for bit-position based flags since at some point we enter the realm of a valid setting being a valid address, but its the best I've been able to come up with so far...
-                    if (((size_t)expectedTableTag & ~LS_TTYPEMASK) == 0)
-                        luaL_error(self.L, "DEVELOPER-ERROR: unable to get expected LuaSkin table type for argument %d", idx) ;
+                    if (!expectedTableTag) luaL_error(self.L, "ERROR: unable to get expected LuaSkin table type for argument %d", idx) ;
 
                     const char *actualTableTag   = NULL ;
                     if (lua_getfield(self.L, idx, "__luaSkinType") == LUA_TSTRING) {
@@ -363,10 +361,6 @@ static int pushUserdataType(lua_State *L) {
                 }
 
                 userdataTag = va_arg(args, char*);
-// NOTE: Make sure LS_TTYPEMASK in Skin.h is updated as options are added. Since va_args can't check type for us, we have to do this to make sure we get an address rather than an integer cast as an address... it's a bit of a hack for bit-position based flags since at some point we enter the realm of a valid setting being a valid address, but its the best I've been able to come up with so far...
-                if (((size_t)userdataTag & ~LS_TTYPEMASK) == 0)
-                    luaL_error(self.L, "DEVELOPER-ERROR: unable to get expected userdata type for argument %d", idx) ;
-
                 if (!userdataTag || strlen(userdataTag) == 0 || !luaL_testudata(self.L, idx, userdataTag)) {
                     luaL_error(self.L, "ERROR: incorrect userdata type for argument %d (expected %s)", idx, userdataTag);
                 }


### PR DESCRIPTION
Forgot comment...

adding LS_TTYPEDTABLE to check args to further support tables with __luaSkinType field.

E.g.

~~~objc
[skin checkArgs:LS_TTYPEDTABLE, "NSPoint", LS_TBREAK]
~~~
will verify that the table at the first index position includes the __luaSkinType field with a value of "NSPoint", as is used by LuaSkin to determine if it can automatically convert a table into an Objective-C type of some sort.

Needs some additions to the test suite.

@cmsj syntacticly, is this better as a separate type (as defined here) or as an optional addition to LS_TTABLE (for example `LS_TTABLE | LS_TTYPED` instead of `LS_TTYPEDTABLE`)?