### PR TITLE
add requestheaders to hs.httpserver callback

### DIFF
--- a/extensions/fs/internal.m
+++ b/extensions/fs/internal.m
@@ -917,7 +917,7 @@ static int hs_fileuti(lua_State *L) {
 /// Parameters:
 ///  * a string containing a file UTI, such as one returned by `hs.fs.fileUTI`.
 ///  * a string specifying the alternate format for the UTI.  This string may be one of the following:
-//     * `extension`  - as a file extension, commonly used for platform independant file sharing when file metadata can't be guaranteed to be cross-platform compatible.  Generally considered unreliable when other file type identification methods are available.
+///     * `extension`  - as a file extension, commonly used for platform independant file sharing when file metadata can't be guaranteed to be cross-platform compatible.  Generally considered unreliable when other file type identification methods are available.
 ///    * `mime`       - as a mime-type, commonly used by Internet applications like web browsers and email applications.
 ///    * `pasteboard` - as an NSPasteboard type (see `hs.pasteboard`).
 ///    * `ostype`     - four character file type, most common pre OS X, but still used in some legacy APIs.

--- a/extensions/httpserver/internal.m
+++ b/extensions/httpserver/internal.m
@@ -115,8 +115,12 @@ int refTable;
         LuaSkin *skin = [LuaSkin shared];
         lua_State *L = skin.L;
 
-        // add client id to headers for callback function to access
-        [request setHeaderField:@"X-Client-Ip" value:asyncSocket.connectedHost];
+        // add some headers for callback function to access
+        [request setHeaderField:@"X-Remote-Addr" value:asyncSocket.connectedHost];
+        [request setHeaderField:@"X-Remote-Port" value:[NSString stringWithFormat:@"%hu", asyncSocket.connectedPort]];
+        [request setHeaderField:@"X-Server-Addr" value:asyncSocket.localHost];
+        [request setHeaderField:@"X-Server-Port" value:[NSString stringWithFormat:@"%hu", asyncSocket.localPort]];
+
 
         [skin pushLuaRef:refTable ref:((HSHTTPServer *)config.server).fn];
         lua_pushstring(L, [method UTF8String]);

--- a/extensions/httpserver/internal.m
+++ b/extensions/httpserver/internal.m
@@ -380,7 +380,7 @@ static int httpserver_maxBodySize(lua_State *L) {
 ///  * It is not currently possible to set multiple passwords for different users, or passwords only on specific paths
 static int httpserver_setPassword(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
-    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TOPTIONAL, LS_TBREAK];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TNIL | LS_TOPTIONAL, LS_TBREAK];
     HSHTTPServer *server = getUserData(L, 1);
 
     switch (lua_type(L, 2)) {
@@ -506,7 +506,7 @@ static int httpserver_getName(lua_State *L) {
 ///  * This is not the hostname of the server, just its name in Bonjour service lists (e.g. Safari's Bonjour bookmarks menu)
 static int httpserver_setName(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
-    [skin checkArgs:LS_TUSERDATA, LS_TSTRING, LS_TBREAK];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING, LS_TBREAK];
     HSHTTPServer *server = getUserData(L, 1);
     [server setName:[skin toNSObjectAtIndex:2]];
     lua_pushvalue(L, 1);

--- a/extensions/httpserver/internal.m
+++ b/extensions/httpserver/internal.m
@@ -1,5 +1,6 @@
 #import <LuaSkin/LuaSkin.h>
 #import "CocoaHTTPServer/HTTPServer.h"
+#import "CocoaHTTPServer/HTTPMessage.h"
 #import "CocoaHTTPServer/HTTPConnection.h"
 #import "CocoaHTTPServer/HTTPDataResponse.h"
 #import "CocoaAsyncSocket/GCDAsyncSocket.h"
@@ -73,8 +74,9 @@ int refTable;
         [skin pushLuaRef:refTable ref:((HSHTTPServer *)config.server).fn];
         lua_pushstring(L, [method UTF8String]);
         lua_pushstring(L, [path UTF8String]);
+        [skin pushNSObject:[request allHeaderFields]] ;
 
-        if (![skin protectedCallAndTraceback:2 nresults:3]) {
+        if (![skin protectedCallAndTraceback:3 nresults:3]) {
             const char *errorMsg = lua_tostring(L, -1);
             [skin logError:[NSString stringWithFormat:@"hs.httpserver:setCallback() callback error: %s", errorMsg]];
             responseCode = 503;


### PR DESCRIPTION
Addresses #851.

Not quite as fully detailed as I would have liked, but then again, this is a minimalist web server... I can get what I need by checking the host key:

label | value
----|----
DNT | 1
Accept-Language | en-us
User-Agent | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/601.5.17 (KHTML, like Gecko) Version/9.1 Safari/601.5.17
Host | localhost:7734
Connection | keep-alive
Accept-Encoding | gzip, deflate
Cache-Control | max-age=0
Accept | text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8