### PR TITLE
resize console input field for history items

### DIFF
--- a/Hammerspoon/HSGrowingTextField.m
+++ b/Hammerspoon/HSGrowingTextField.m
@@ -50,7 +50,7 @@
         }
         
         if (intrinsicSize.height > 100) {
-            intrinsicSize = _lastIntrinsicSize;
+            intrinsicSize.height = 100;
         } else {
             _lastIntrinsicSize = intrinsicSize;
             _hasLastIntrinsicSize = YES;

--- a/Hammerspoon/MJConsoleWindowController.m
+++ b/Hammerspoon/MJConsoleWindowController.m
@@ -124,13 +124,16 @@ typedef NS_ENUM(NSUInteger, MJReplLineType) {
 }
 
 - (void) useCurrentHistoryIndex {
+    [(HSGrowingTextField *)self.inputField resetGrowth];
+
     if (self.historyIndex == [self.history count])
         [self.inputField setStringValue: @""];
     else
         [self.inputField setStringValue: [self.history objectAtIndex:self.historyIndex]];
 
     NSText* editor = [[self.inputField window] fieldEditor:YES forObject:self.inputField];
-    [editor moveToEndOfDocument:self];
+    NSRange position = (NSRange){[[editor string] length], 0};
+    [editor setSelectedRange:position];
 }
 
 BOOL MJConsoleWindowAlwaysOnTop(void) {


### PR DESCRIPTION
When cycling through history items, the input field would not expand, making it tedious to edit. This fixes that.

It now uses `setSelectedRange` instead of `moveToEndOfDocument` as any of the NSResponder methods will 'scroll' the content upwards out of view, leaving the final line of Lua code on the first line of an empty text box which had just been resized to fit it. Even moving left or right a single character via the `NSResponder` methods will cause this. Could be a limitation of `NSTextField` not implementing the necessary scroll methods, being intended for single-line use?