### PR TITLE
work around circular dependency between application and window

### DIFF
--- a/extensions/application/init.lua
+++ b/extensions/application/init.lua
@@ -5,6 +5,7 @@
 local uielement = hs.uielement  -- Make sure parent module loads
 local application = require "hs.application.internal"
 application.watcher = require "hs.application.watcher"
+package.loaded['hs.application']=application --preload application so it can be fully required by window
 local window = require "hs.window"
 local timer = require "hs.timer"
 
@@ -50,6 +51,7 @@ end
 --- hs.application:name()
 --- Method
 --- Alias for `hs.application:title()`
+application.name=application.title
 
 --- hs.application.get(hint) -> hs.application object
 --- Constructor
@@ -265,74 +267,74 @@ end
 ---    * kMenuTrademarkJapaneseGlyph, 0x1F, Unassigned (trademark in Japanese)
 ---    * kMenuAppleLogoOutlineGlyph, 0x6C, Apple logo key (outline)
 application.menuGlyphs = setmetatable({
-    [2] = "⇥",     -- kMenuTabRightGlyph, 0x02, Tab to the right key (for left-to-right script systems)
-    [3] = "⇤",     -- kMenuTabLeftGlyph, 0x03, Tab to the left key (for right-to-left script systems)
-    [4] = "⌤",     -- kMenuEnterGlyph, 0x04, Enter key
-    [5] = "⇧",     -- kMenuShiftGlyph, 0x05, Shift key
-    [6] = "⌃",     -- kMenuControlGlyph, 0x06, Control key
-    [7] = "⌥",     -- kMenuOptionGlyph, 0x07, Option key
-    [9] = "␣",      -- kMenuSpaceGlyph, 0x09, Space (always glyph 3) key
-    [10] = "⌦",    -- kMenuDeleteRightGlyph, 0x0A, Delete to the right key (for right-to-left script systems)
-    [11] = "↩",    -- kMenuReturnGlyph, 0x0B, Return key (for left-to-right script systems)
-    [12] = "↪",    -- kMenuReturnR2LGlyph, 0x0C, Return key (for right-to-left script systems)
-    [15] = "",    -- kMenuPencilGlyph, 0x0F, Pencil key
-    [16] = "↓",     -- kMenuDownwardArrowDashedGlyph, 0x10, Downward dashed arrow key
-    [17] = "⌘",    -- kMenuCommandGlyph, 0x11, Command key
-    [18] = "✓",     -- kMenuCheckmarkGlyph, 0x12, Checkmark key
-    [19] = "◇",     -- kMenuDiamondGlyph, 0x13, Diamond key
-    [20] = "",     -- kMenuAppleLogoFilledGlyph, 0x14, Apple logo key (filled)
-    [23] = "⌫",    -- kMenuDeleteLeftGlyph, 0x17, Delete to the left key (for left-to-right script systems)
-    [24] = "←",    -- kMenuLeftArrowDashedGlyph, 0x18, Leftward dashed arrow key
-    [25] = "↑",     -- kMenuUpArrowDashedGlyph, 0x19, Upward dashed arrow key
-    [26] = "→",     -- kMenuRightArrowDashedGlyph, 0x1A, Rightward dashed arrow key
-    [27] = "⎋",    -- kMenuEscapeGlyph, 0x1B, Escape key
-    [28] = "⌧",    -- kMenuClearGlyph, 0x1C, Clear key
-    [29] = "『",    -- kMenuLeftDoubleQuotesJapaneseGlyph, 0x1D, Unassigned (left double quotes in Japanese)
-    [30] = "』",    -- kMenuRightDoubleQuotesJapaneseGlyph, 0x1E, Unassigned (right double quotes in Japanese)
-    [97] = "␢",     -- kMenuBlankGlyph, 0x61, Blank key
-    [98] = "⇞",     -- kMenuPageUpGlyph, 0x62, Page up key
-    [99] = "⇪",    -- kMenuCapsLockGlyph, 0x63, Caps lock key
-    [100] = "←",   -- kMenuLeftArrowGlyph, 0x64, Left arrow key
-    [101] = "→",    -- kMenuRightArrowGlyph, 0x65, Right arrow key
-    [102] = "↖",   -- kMenuNorthwestArrowGlyph, 0x66, Northwest arrow key
-    [103] = "﹖",   -- kMenuHelpGlyph, 0x67, Help key
-    [104] = "↑",    -- kMenuUpArrowGlyph, 0x68, Up arrow key
-    [105] = "↘",   -- kMenuSoutheastArrowGlyph, 0x69, Southeast arrow key
-    [106] = "↓",    -- kMenuDownArrowGlyph, 0x6A, Down arrow key
-    [107] = "⇟",    -- kMenuPageDownGlyph, 0x6B, Page down key
-    [109] = "",   -- kMenuContextualMenuGlyph, 0x6D, Contextual menu key
-    [110] = "⌽",   -- kMenuPowerGlyph, 0x6E, Power key
-    [111] = "F1",   -- kMenuF1Glyph, 0x6F, F1 key
-    [112] = "F2",   -- kMenuF2Glyph, 0x70, F2 key
-    [113] = "F3",   -- kMenuF3Glyph, 0x71, F3 key
-    [114] = "F4",   -- kMenuF4Glyph, 0x72, F4 key
-    [115] = "F5",   -- kMenuF5Glyph, 0x73, F5 key
-    [116] = "F6",   -- kMenuF6Glyph, 0x74, F6 key
-    [117] = "F7",   -- kMenuF7Glyph, 0x75, F7 key
-    [118] = "F8",   -- kMenuF8Glyph, 0x76, F8 key
-    [119] = "F9",   -- kMenuF9Glyph, 0x77, F9 key
-    [120] = "F10",  -- kMenuF10Glyph, 0x78, F10 key
-    [121] = "F11",  -- kMenuF11Glyph, 0x79, F11 key
-    [122] = "F12",  -- kMenuF12Glyph, 0x7A, F12 key
-    [135] = "F13",  -- kMenuF13Glyph, 0x87, F13 key
-    [136] = "F14",  -- kMenuF14Glyph, 0x88, F14 key
-    [137] = "F15",  -- kMenuF15Glyph, 0x89, F15 key
-    [138] = "⎈",   -- kMenuControlISOGlyph, 0x8A, Control key (ISO standard)
-    [140] = "⏏",   -- kMenuEjectGlyph, 0x8C, Eject key (available on Mac OS X 10.2 and later)
-    [141] = "英数", -- kMenuEisuGlyph, 0x8D, Japanese eisu key (available in Mac OS X 10.4 and later)
-    [142] = "かな", -- kMenuKanaGlyph, 0x8E, Japanese kana key (available in Mac OS X 10.4 and later)
-    [143] = "F16",  -- kMenuF16Glyph, 0x8F, F16 key (available in SnowLeopard and later)
-    [144] = "F17",  -- kMenuF16Glyph, 0x90, F17 key (available in SnowLeopard and later)
-    [145] = "F18",  -- kMenuF16Glyph, 0x91, F18 key (available in SnowLeopard and later)
-    [146] = "F19",  -- kMenuF16Glyph, 0x92, F19 key (available in SnowLeopard and later)
+  [2] = "⇥",     -- kMenuTabRightGlyph, 0x02, Tab to the right key (for left-to-right script systems)
+  [3] = "⇤",     -- kMenuTabLeftGlyph, 0x03, Tab to the left key (for right-to-left script systems)
+  [4] = "⌤",     -- kMenuEnterGlyph, 0x04, Enter key
+  [5] = "⇧",     -- kMenuShiftGlyph, 0x05, Shift key
+  [6] = "⌃",     -- kMenuControlGlyph, 0x06, Control key
+  [7] = "⌥",     -- kMenuOptionGlyph, 0x07, Option key
+  [9] = "␣",      -- kMenuSpaceGlyph, 0x09, Space (always glyph 3) key
+  [10] = "⌦",    -- kMenuDeleteRightGlyph, 0x0A, Delete to the right key (for right-to-left script systems)
+  [11] = "↩",    -- kMenuReturnGlyph, 0x0B, Return key (for left-to-right script systems)
+  [12] = "↪",    -- kMenuReturnR2LGlyph, 0x0C, Return key (for right-to-left script systems)
+  [15] = "",    -- kMenuPencilGlyph, 0x0F, Pencil key
+  [16] = "↓",     -- kMenuDownwardArrowDashedGlyph, 0x10, Downward dashed arrow key
+  [17] = "⌘",    -- kMenuCommandGlyph, 0x11, Command key
+  [18] = "✓",     -- kMenuCheckmarkGlyph, 0x12, Checkmark key
+  [19] = "◇",     -- kMenuDiamondGlyph, 0x13, Diamond key
+  [20] = "",     -- kMenuAppleLogoFilledGlyph, 0x14, Apple logo key (filled)
+  [23] = "⌫",    -- kMenuDeleteLeftGlyph, 0x17, Delete to the left key (for left-to-right script systems)
+  [24] = "←",    -- kMenuLeftArrowDashedGlyph, 0x18, Leftward dashed arrow key
+  [25] = "↑",     -- kMenuUpArrowDashedGlyph, 0x19, Upward dashed arrow key
+  [26] = "→",     -- kMenuRightArrowDashedGlyph, 0x1A, Rightward dashed arrow key
+  [27] = "⎋",    -- kMenuEscapeGlyph, 0x1B, Escape key
+  [28] = "⌧",    -- kMenuClearGlyph, 0x1C, Clear key
+  [29] = "『",    -- kMenuLeftDoubleQuotesJapaneseGlyph, 0x1D, Unassigned (left double quotes in Japanese)
+  [30] = "』",    -- kMenuRightDoubleQuotesJapaneseGlyph, 0x1E, Unassigned (right double quotes in Japanese)
+  [97] = "␢",     -- kMenuBlankGlyph, 0x61, Blank key
+  [98] = "⇞",     -- kMenuPageUpGlyph, 0x62, Page up key
+  [99] = "⇪",    -- kMenuCapsLockGlyph, 0x63, Caps lock key
+  [100] = "←",   -- kMenuLeftArrowGlyph, 0x64, Left arrow key
+  [101] = "→",    -- kMenuRightArrowGlyph, 0x65, Right arrow key
+  [102] = "↖",   -- kMenuNorthwestArrowGlyph, 0x66, Northwest arrow key
+  [103] = "﹖",   -- kMenuHelpGlyph, 0x67, Help key
+  [104] = "↑",    -- kMenuUpArrowGlyph, 0x68, Up arrow key
+  [105] = "↘",   -- kMenuSoutheastArrowGlyph, 0x69, Southeast arrow key
+  [106] = "↓",    -- kMenuDownArrowGlyph, 0x6A, Down arrow key
+  [107] = "⇟",    -- kMenuPageDownGlyph, 0x6B, Page down key
+  [109] = "",   -- kMenuContextualMenuGlyph, 0x6D, Contextual menu key
+  [110] = "⌽",   -- kMenuPowerGlyph, 0x6E, Power key
+  [111] = "F1",   -- kMenuF1Glyph, 0x6F, F1 key
+  [112] = "F2",   -- kMenuF2Glyph, 0x70, F2 key
+  [113] = "F3",   -- kMenuF3Glyph, 0x71, F3 key
+  [114] = "F4",   -- kMenuF4Glyph, 0x72, F4 key
+  [115] = "F5",   -- kMenuF5Glyph, 0x73, F5 key
+  [116] = "F6",   -- kMenuF6Glyph, 0x74, F6 key
+  [117] = "F7",   -- kMenuF7Glyph, 0x75, F7 key
+  [118] = "F8",   -- kMenuF8Glyph, 0x76, F8 key
+  [119] = "F9",   -- kMenuF9Glyph, 0x77, F9 key
+  [120] = "F10",  -- kMenuF10Glyph, 0x78, F10 key
+  [121] = "F11",  -- kMenuF11Glyph, 0x79, F11 key
+  [122] = "F12",  -- kMenuF12Glyph, 0x7A, F12 key
+  [135] = "F13",  -- kMenuF13Glyph, 0x87, F13 key
+  [136] = "F14",  -- kMenuF14Glyph, 0x88, F14 key
+  [137] = "F15",  -- kMenuF15Glyph, 0x89, F15 key
+  [138] = "⎈",   -- kMenuControlISOGlyph, 0x8A, Control key (ISO standard)
+  [140] = "⏏",   -- kMenuEjectGlyph, 0x8C, Eject key (available on Mac OS X 10.2 and later)
+  [141] = "英数", -- kMenuEisuGlyph, 0x8D, Japanese eisu key (available in Mac OS X 10.4 and later)
+  [142] = "かな", -- kMenuKanaGlyph, 0x8E, Japanese kana key (available in Mac OS X 10.4 and later)
+  [143] = "F16",  -- kMenuF16Glyph, 0x8F, F16 key (available in SnowLeopard and later)
+  [144] = "F17",  -- kMenuF16Glyph, 0x90, F17 key (available in SnowLeopard and later)
+  [145] = "F18",  -- kMenuF16Glyph, 0x91, F18 key (available in SnowLeopard and later)
+  [146] = "F19",  -- kMenuF16Glyph, 0x92, F19 key (available in SnowLeopard and later)
 }, {
-    __tostring = function(self)
-        local result = ""
-        for k, v in require("hs.fnutils").sortByKeys(self) do
-            result = result..string.format("%4d %s\n", k, v)
-        end
-        return result
-    end,
+  __tostring = function(self)
+    local result = ""
+    for k, v in require("hs.fnutils").sortByKeys(self) do
+      result = result..string.format("%4d %s\n", k, v)
+    end
+    return result
+  end,
 })
 
 do

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -7,7 +7,7 @@
 
 local uielement = hs.uielement  -- Make sure parent module loads
 local window = require "hs.window.internal"
-local application = require "hs.application.internal"
+local application = require "hs.application"
 local geometry = require "hs.geometry"
 local gtype=geometry.type
 local screen = require "hs.screen"


### PR DESCRIPTION
Fixes crash when e.g. having `print(hs.window.visibleWindows())` as the first line in a config. (#736, #799)