### PR TITLE
uielement and timer tweaks

### DIFF
--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -283,6 +283,32 @@ static int checkForUpdates(lua_State *L) {
     return 0 ;
 }
 
+/// hs.canCheckForUpdates() -> boolean
+/// Function
+/// Returns a boolean indicating whether or not the Sparkle framework is available to check for Hammerspoon updates.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a boolean indicating whether or not the Sparkle framework is available to check for Hammerspoon updates
+///
+/// Notes:
+///  * The Sparkle framework is included in all regular releases of Hammerspoon but not included if you are running a non-release or locally compiled version of Hammerspoon, so this function can be used as a simple test to determine whether or not you are running a formal release Hammerspoon or not.
+static int canCheckForUpdates(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    BOOL canUpdate = NO ;
+
+    if (NSClassFromString(@"SUUpdater")) {
+        NSString *frameworkPath = [[[NSBundle mainBundle] privateFrameworksPath] stringByAppendingPathComponent:@"Sparkle.framework"];
+        if ([[NSBundle bundleWithPath:frameworkPath] load]) {
+            canUpdate = YES ;
+        }
+    }
+    lua_pushboolean(L, canUpdate) ;
+    return 1 ;
+}
+
 /// hs.focus()
 /// Function
 /// Makes Hammerspoon the foreground app.
@@ -365,6 +391,7 @@ static luaL_Reg corelib[] = {
     {"autoLaunch", core_autolaunch},
     {"automaticallyCheckForUpdates", automaticallyChecksForUpdates},
     {"checkForUpdates", checkForUpdates},
+    {"canCheckForUpdates", canCheckForUpdates},
     {"reload", core_reload},
     {"focus", core_focus},
     {"accessibilityState", core_accessibilityState},

--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -441,7 +441,7 @@ NSString *specMaskToString(int spec);
 
  Basic Lua type to NSObject conversion rules:
 
-   nil     - [NSNull null]
+   nil     - nil if the index points directly to a nil lua object, or [NSNull null] if the nil is a member of a table
 
    string  - NSString
 
@@ -468,7 +468,8 @@ NSString *specMaskToString(int spec);
 
  Basic Lua type to NSObject conversion rules:
 
-   nil     - [NSNull null]
+   nil     - nil if the index points directly to a nil lua object, or [NSNull null] if the nil is a member of a table
+
 
    string  - NSString or NSData, depending upon options specified
 

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -1019,7 +1019,7 @@ nextarg:
                 }
             }
         case LUA_TNIL:
-            return [NSNull null] ;
+            return ([alreadySeen count] > 0) ? [NSNull null] : nil ;
         case LUA_TBOOLEAN:
             return lua_toboolean(self.L, idx) ? (id)kCFBooleanTrue : (id)kCFBooleanFalse;
         case LUA_TTABLE:
@@ -1055,9 +1055,8 @@ nextarg:
                 lua_pop(self.L, 1) ;
                 return answer ;
             } else if ((options & LS_NSIgnoreUnknownTypes) == LS_NSIgnoreUnknownTypes) {
-                [self logVerbose:[NSString stringWithFormat:@"unrecognized type %s; ignoring with placeholder [NSNull null]",
-                                                          lua_typename(self.L, lua_type(self.L, realIndex))]] ;
-                return [NSNull null] ;
+                [self logVerbose:[NSString stringWithFormat:@"unrecognized type %s; ignoring with %s", lua_typename(self.L, lua_type(self.L, realIndex)), (([alreadySeen count] > 0) ? "placeholder [NSNull null]" : "nil")]] ;
+                return ([alreadySeen count] > 0) ? [NSNull null] : nil ;
             } else {
                 [self logDebug:[NSString stringWithFormat:@"unrecognized type %s; returning nil", lua_typename(self.L, lua_type(self.L, realIndex))]] ;
                 return nil ;

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -247,6 +247,9 @@ NSString *specMaskToString(int spec) {
     lua_setfield(self.L, -2, "__index");
     lua_pushstring(self.L, objectName);
     lua_setfield(self.L, -2, "__type");
+    // used by some error functions in Lua
+    lua_pushstring(self.L, objectName);
+    lua_setfield(self.L, -2, "__name");
     lua_setfield(self.L, LUA_REGISTRYINDEX, objectName);
 }
 

--- a/LuaSkin/LuaSkinTests/LuaSkinTests.m
+++ b/LuaSkin/LuaSkinTests/LuaSkinTests.m
@@ -697,7 +697,7 @@ static int pushTestUserData(lua_State *L, id object) {
     XCTAssertEqualObjects(@"Testing toNSObject", [self.skin toNSObjectAtIndex:-1]);
 
     lua_pushnil(self.skin.L);
-    XCTAssertEqualObjects([NSNull null], [self.skin toNSObjectAtIndex:-1]);
+    XCTAssertEqualObjects(nil, [self.skin toNSObjectAtIndex:-1]);
 
     lua_pushboolean(self.skin.L, YES);
     XCTAssertEqualObjects(@YES, [self.skin toNSObjectAtIndex:-1]);

--- a/extensions/application/watcher.m
+++ b/extensions/application/watcher.m
@@ -109,6 +109,7 @@ typedef enum _event_t {
     if (![skin protectedCallAndTraceback:3 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.application.watcher callback error: %s", errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
 }
 

--- a/extensions/audiodevice/internal.m
+++ b/extensions/audiodevice/internal.m
@@ -85,7 +85,9 @@ OSStatus audiodevice_callback(AudioDeviceID deviceID, UInt32 numAddresses, const
                 lua_pushstring(skin.L, ((__bridge_transfer NSString *)UTCreateStringForOSType(addressList[i].mSelector)).UTF8String);
                 lua_pushstring(skin.L, ((__bridge_transfer NSString *)UTCreateStringForOSType(addressList[i].mScope)).UTF8String);
                 lua_pushinteger(skin.L, addressList[i].mElement);
-                [skin protectedCallAndTraceback:4 nresults:0];
+                if (![skin protectedCallAndTraceback:4 nresults:0]) {
+                    lua_pop(skin.L, 1) ; // remove error message
+                }
             }
         }
 
@@ -217,7 +219,7 @@ error:
 
 end:
     free(deviceList);
-    
+
     return 1;
 }
 
@@ -1160,7 +1162,7 @@ error:
 
 end:
     free(datasourceList);
-    
+
     return 1;
 }
 

--- a/extensions/audiodevice/watcher.m
+++ b/extensions/audiodevice/watcher.m
@@ -52,7 +52,9 @@ OSStatus audiodevicewatcher_callback(AudioDeviceID deviceID, UInt32 numAddresses
                 //NSLog(@"Examining selector: %@", UTCreateStringForOSType(addressList[i].mSelector));
                 [skin pushLuaRef:refTable ref:theWatcher->callback];
                 lua_pushstring(skin.L, [(__bridge_transfer NSString *)UTCreateStringForOSType(addressList[i].mSelector) UTF8String]);
-                [skin protectedCallAndTraceback:1 nresults:0];
+                if (![skin protectedCallAndTraceback:1 nresults:0]) {
+                    lua_pop(skin.L, 1) ; // remove error message
+                }
             }
         }
 

--- a/extensions/battery/watcher.m
+++ b/extensions/battery/watcher.m
@@ -33,6 +33,7 @@ static void callback(void *info) {
     if (![skin protectedCallAndTraceback:0 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.battery.watcher callback error: %s", errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
 }
 

--- a/extensions/caffeinate/watcher.m
+++ b/extensions/caffeinate/watcher.m
@@ -111,6 +111,7 @@ typedef enum _event_t {
     if (![skin protectedCallAndTraceback:1 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.caffeinate.watcher callback error: %s", errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
 }
 

--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -257,7 +257,9 @@
 
         [skin pushLuaRef:*(self.refTable) ref:self.completionCallbackRef];
         [skin pushNSObject:choice];
-        [skin protectedCallAndTraceback:1 nresults:0];
+        if (![skin protectedCallAndTraceback:1 nresults:0]) {
+            lua_pop(skin.L, 1) ; // remove error message
+        }
     }
 }
 
@@ -269,7 +271,9 @@
     LuaSkin *skin = [LuaSkin shared];
     [skin pushLuaRef:*(self.refTable) ref:self.completionCallbackRef];
     lua_pushnil(skin.L);
-    [skin protectedCallAndTraceback:1 nresults:0];
+    if (![skin protectedCallAndTraceback:1 nresults:0]) {
+        lua_pop(skin.L, 1) ; // remove error message
+    }
 }
 
 - (IBAction)queryDidPressEnter:(id)sender {
@@ -286,7 +290,9 @@
         LuaSkin *skin = [LuaSkin shared];
         [skin pushLuaRef:*(self.refTable) ref:self.queryChangedCallbackRef];
         [skin pushNSObject:queryString];
-        [skin protectedCallAndTraceback:1 nresults:0];
+        if (![skin protectedCallAndTraceback:1 nresults:0]) {
+            lua_pop(skin.L, 1) ; // remove error message
+        }
     } else {
         // We do not have a query callback set, so we are doing the filtering
         if (queryString.length > 0) {
@@ -397,6 +403,7 @@
                     self.currentCallbackChoices = nil;
                 }
             }
+            lua_pop(skin.L, 1) ; // remove result or error message
         }
 
         if (self.currentCallbackChoices != nil) {

--- a/extensions/distributednotifications/internal.m
+++ b/extensions/distributednotifications/internal.m
@@ -29,6 +29,7 @@ typedef struct _distnot_t {
         [skin pushNSObject:note.userInfo];
         if (![skin protectedCallAndTraceback:3 nresults:0]) {
             [skin logError:[NSString stringWithFormat:@"hs.distributednotification callback failed: %@", [skin toNSObjectAtIndex:-1]]];
+            lua_pop([skin L], 1);
         }
     }
 }
@@ -53,6 +54,9 @@ static int distnot_new(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TFUNCTION, LS_TSTRING|LS_TNIL|LS_TOPTIONAL, LS_TSTRING|LS_TNIL|LS_TOPTIONAL, LS_TBREAK];
 
+    NSString *name = lua_isnoneornil(L, 2) ? nil : [skin toNSObjectAtIndex:2];
+    NSString *obj  = lua_isnoneornil(L, 3) ? nil : [skin toNSObjectAtIndex:3];
+
     distnot_t *userData = lua_newuserdata(L, sizeof(distnot_t));
     memset(userData, 0, sizeof(distnot_t));
 
@@ -64,16 +68,8 @@ static int distnot_new(lua_State *L) {
 
     lua_pushvalue(L, 1);
     watcher.fnRef = [skin luaRef:refTable];
-    if (lua_isnoneornil(L, 2)) {
-        watcher.name = nil;
-    } else {
-        watcher.name = [skin toNSObjectAtIndex:2];
-    }
-    if (lua_isnoneornil(L, 3)) {
-        watcher.object = nil;
-    } else {
-        watcher.object = [skin toNSObjectAtIndex:3];
-    }
+    watcher.name = name;
+    watcher.object = obj;
 
     return 1;
 }

--- a/extensions/distributednotifications/internal.m
+++ b/extensions/distributednotifications/internal.m
@@ -29,7 +29,7 @@ typedef struct _distnot_t {
         [skin pushNSObject:note.userInfo];
         if (![skin protectedCallAndTraceback:3 nresults:0]) {
             [skin logError:[NSString stringWithFormat:@"hs.distributednotification callback failed: %@", [skin toNSObjectAtIndex:-1]]];
-            lua_pop([skin L], 1);
+            lua_pop([skin L], 1); // remove error message
         }
     }
 }

--- a/extensions/drawing/internal.m
+++ b/extensions/drawing/internal.m
@@ -151,6 +151,7 @@ NSMutableArray *drawingWindows;
         if (![skin protectedCallAndTraceback:0 nresults:0]) {
             const char *errorMsg = lua_tostring(_L, -1);
             [skin logError:[NSString stringWithFormat:@"hs.drawing:setClickCallback() mouseUp callback error: %s", errorMsg]];
+            lua_pop(_L, 1) ; // remove error message
         }
     }
 }
@@ -172,6 +173,7 @@ NSMutableArray *drawingWindows;
         if (![skin protectedCallAndTraceback:0 nresults:0]) {
             const char *errorMsg = lua_tostring(_L, -1);
             [skin logError:[NSString stringWithFormat:@"hs.drawing:setClickCallback() mouseDown callback error: %s", errorMsg]];
+            lua_pop(_L, 1) ; // remove error message
         }
     }
 }

--- a/extensions/drawing/internal.m
+++ b/extensions/drawing/internal.m
@@ -599,6 +599,10 @@ static int drawing_newEllipticalArc(lua_State *L) {
                     LS_TBREAK];
 
     NSRect windowRect = [skin tableToRectAtIndex:1];
+    CGFloat startAngle = lua_tonumber(L, 2) - 90 ;
+    CGFloat endAngle   = lua_tonumber(L, 3) - 90 ;
+    if (!isfinite(startAngle)) return luaL_argerror(L, 2, "start angle must be a finite number");
+    if (!isfinite(endAngle))   return luaL_argerror(L, 3, "end angle must be a finite number");
 
     HSDrawingWindow *theWindow = [[HSDrawingWindow alloc] initWithContentRect:windowRect styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:YES];
 
@@ -614,8 +618,8 @@ static int drawing_newEllipticalArc(lua_State *L) {
         [theView setLuaState:L];
         theWindow.contentView = theView;
 
-        theView.startAngle = lua_tonumber(L, 2) - 90 ;
-        theView.endAngle   = lua_tonumber(L, 3) - 90 ;
+        theView.startAngle = startAngle ;
+        theView.endAngle   = endAngle ;
 
         if (!drawingWindows) {
             drawingWindows = [[NSMutableArray alloc] init];

--- a/extensions/eventtap/internal.m
+++ b/extensions/eventtap/internal.m
@@ -34,6 +34,7 @@ CGEventRef eventtap_callback(CGEventTapProxy proxy, CGEventType type, CGEventRef
         } else {
             [skin logError:[NSString stringWithFormat:@"hs.eventtap callback error: %s", errorMsg]];
         }
+        lua_pop(L, 1) ; // remove error message
         return NULL;
     }
 

--- a/extensions/fs/volume.m
+++ b/extensions/fs/volume.m
@@ -91,6 +91,7 @@ typedef enum _event_t {
     if (![skin protectedCallAndTraceback:2 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.fs.volume callback error: %s", errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
 }
 

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -37,7 +37,7 @@ local hotkeys = {}
 --- hs.hotkey.alertDuration = 0 -- hotkey alerts are disabled
 hotkey.alertDuration = 1
 
---- hs.hotkey:enable() -> hs.hotkey object
+--- hs.hotkey:enable() -> hs.hotkey object | nil
 --- Method
 --- Enables a hotkey object
 ---
@@ -45,7 +45,7 @@ hotkey.alertDuration = 1
 ---  * None
 ---
 --- Returns:
----  * The `hs.hotkey` object for method chaining
+---  * The `hs.hotkey` object for method chaining or nil if the hotkey could not be enabled for some reason.
 ---
 --- Notes:
 ---  * When you enable a hotkey that uses the same keyboard combination as another previously-enabled hotkey, the old
@@ -67,10 +67,10 @@ local function enable(self,force,isModal)
     hk._hk:disable() --objc
   end
   self.enabled = true
-  self._hk:enable() --objc
+  local returnVal = self._hk:enable() --objc
   log[isModal and 'df' or 'f']('Enabled hotkey %s%s',self.msg,isModal and ' (in modal)' or '')
   tinsert(hotkeys[idx],self) -- bring to the top of the stack
-  return self
+  return returnVal
 end
 
 --- hs.hotkey:disable() -> hs.hotkey object

--- a/extensions/hotkey/internal.m
+++ b/extensions/hotkey/internal.m
@@ -202,12 +202,15 @@ static int hotkey_enable(lua_State* L) {
 
     if (result == noErr) {
         hotkey->enabled = YES;
+        lua_pushvalue(L, 1);
     } else {
-        [skin logBreadcrumb:[NSString stringWithFormat:@"hs.hotkey:enable() RegisterEventHotKey failed: %d", (int)result]];
+        [skin logError:[NSString stringWithFormat:@"%s:enable() keycode: %d, mods: 0x%04x, RegisterEventHotKey failed: %d", USERDATA_TAG, hotkey->keycode, hotkey->mods, (int)result]];
+
         hotkey->uid = remove_hotkey(L, hotkey->uid);
+
+        lua_pushnil(L) ;
     }
 
-    lua_pushvalue(L, 1);
     return 1;
 }
 
@@ -226,7 +229,7 @@ static void stop(lua_State* L, hotkey_t* hotkey) {
         OSStatus result = UnregisterEventHotKey(hotkey->carbonHotKey);
         hotkey->carbonHotKey = nil;
         if (result != noErr) {
-            [skin logBreadcrumb:[NSString stringWithFormat:@"hs.hotkey stop() UnregisterEventHotKey failed: %d", (int)result]];
+            [skin logError:[NSString stringWithFormat:@"%s:stop() keycode: %d, mods: 0x%04x, UnregisterEventHotKey failed: %d", USERDATA_TAG, hotkey->keycode, hotkey->mods, (int)result]];
         }
     }
 

--- a/extensions/hotkey/internal.m
+++ b/extensions/hotkey/internal.m
@@ -309,6 +309,7 @@ static OSStatus trigger_hotkey_callback(int eventUID, int eventKind, BOOL isRepe
                 [keyRepeatManager stopTimer];
                 const char *errorMsg = lua_tostring(L, -1);
                 [skin logError:[NSString stringWithFormat:@"hs.hotkey callback error: %s", errorMsg]];
+                lua_pop(L, 1) ; // remove error message
                 return noErr;
             }
         }

--- a/extensions/http/internal.m
+++ b/extensions/http/internal.m
@@ -79,6 +79,7 @@ static void remove_delegate(__unused lua_State* L, connectionDelegate* delegate)
     if (![skin protectedCallAndTraceback:3 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.http callback error: %s", errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
     remove_delegate(L, self);
 }

--- a/extensions/httpserver/internal.m
+++ b/extensions/httpserver/internal.m
@@ -133,6 +133,7 @@ int refTable;
             [skin logError:[NSString stringWithFormat:@"hs.httpserver:setCallback() callback error: %s", errorMsg]];
             responseCode = 503;
             responseBody = [NSData dataWithData:[@"An error occurred during hs.httpserver callback handling" dataUsingEncoding:NSUTF8StringEncoding]];
+            lua_pop(L, 1) ; // the error message
         } else {
             if (!(lua_type(L, -3) == LUA_TSTRING && lua_type(L, -2) == LUA_TNUMBER && lua_type(L, -1) == LUA_TTABLE)) {
                 [skin logError:@"hs.httpserver:setCallback() callbacks must return three values. A string for the response body, an integer response code, and a table of headers"];
@@ -160,6 +161,7 @@ int refTable;
                     [skin logError:@"hs.httpserver:setCallback() callback returned a header table that contains non-strings"];
                 }
             }
+            lua_pop(L, 3) ; // our results... don't leave them on the stack
         }
     };
 

--- a/extensions/ipc/internal.m
+++ b/extensions/ipc/internal.m
@@ -27,6 +27,7 @@ CFDataRef ipc_callback(CFMessagePortRef __unused local, SInt32 __unused msgid, C
         const char *errorMsg = lua_tostring(skin.L, -1);
 
         [skin logError:[NSString stringWithFormat:@"hs.ipc: Unable to require('hs.ipc'): %s", errorMsg]];
+        lua_pop(skin.L, 1) ; // remove error message
 
         if (shouldFree) {
             free((char *)cmd);

--- a/extensions/keycodes/internal.m
+++ b/extensions/keycodes/internal.m
@@ -188,6 +188,7 @@ int keycodes_cachemap(lua_State* L) {
     if (![skin protectedCallAndTraceback:0 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.keycodes.inputSourceChanged() callback error: %s", errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
 }
 

--- a/extensions/location/internal.m
+++ b/extensions/location/internal.m
@@ -31,6 +31,7 @@ static NSMutableIndexSet *locationHandlers;
     if (![skin protectedCallAndTraceback:0 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.location.register() callback error: %s", errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
 
     return;

--- a/extensions/menubar/internal.m
+++ b/extensions/menubar/internal.m
@@ -948,6 +948,21 @@ static int menubar_returnToMenuBar(lua_State *L) {
     return 1 ;
 }
 
+/// hs.menubar:isInMenuBar() -> boolean
+/// Method
+/// Returns a boolean indicating whether or not the specified menu is currently in the OS X menubar.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a boolean indicating whether or not the specified menu is currently in the OS X menubar
+static int menubar_isInMenubar(lua_State *L) {
+    menubaritem_t *menuBarItem     = get_item_arg(L, 1);
+    lua_pushboolean(L, !(menuBarItem->removed)) ;
+    return 1;
+}
+
 /// hs.menubar:title([styled]) -> string | styledtextObject
 /// Method
 /// Returns the current title of the menubar item object.
@@ -1141,6 +1156,7 @@ static const luaL_Reg menubar_metalib[] = {
     {"stateImageSize",    menubarStateImageSize},
     {"_frame",            menubarFrame},
     {"priority",          menubarPriority},
+    {"isInMenubar",       menubar_isInMenubar},
 
     {"__tostring",        userdata_tostring},
     {"__gc",              menubaritem_gc},

--- a/extensions/menubar/internal.m
+++ b/extensions/menubar/internal.m
@@ -172,6 +172,8 @@ NSMutableArray *dynamicMenuDelegates;
 @implementation HSMenubarItemClickDelegate
 - (void) click:(id __unused)sender {
     [self callback_runner];
+    // error or return value (ignored in this case), we gotta cleanup
+    lua_pop(self.L, 1) ;
 }
 @end
 
@@ -191,6 +193,8 @@ NSMutableArray *dynamicMenuDelegates;
     } else {
         [skin logError:@"hs.menubar:setMenu() callback must return a valid table"];
     }
+    // error or return value, we gotta cleanup
+    lua_pop(self.L, 1) ;
 }
 @end
 

--- a/extensions/notify/internal.m
+++ b/extensions/notify/internal.m
@@ -154,6 +154,7 @@ int refTable ;
             if (![skin protectedCallAndTraceback:1 nresults:1]) {
                 const char *errorMsg = lua_tostring(skin.L, -1);
                 [skin logError:[NSString stringWithFormat:@"Unable to require('hs.notify'): %s", errorMsg]];
+                lua_pop(skin.L, 1) ; // remove error message
                 return;
             }
             lua_getfield(skin.L, -1, "_tag_handler") ;
@@ -169,6 +170,7 @@ int refTable ;
             if(![skin protectedCallAndTraceback:2 nresults:0]) {
                 const char *errorMsg = lua_tostring(skin.L, -1);
                 [skin logError:[NSString stringWithFormat:@"hs.notify callback error: %s", errorMsg]];
+                lua_pop(skin.L, 1) ; // remove error message
                 return;
             }
 

--- a/extensions/pathwatcher/internal.m
+++ b/extensions/pathwatcher/internal.m
@@ -34,6 +34,7 @@ void event_callback(ConstFSEventStreamRef __unused streamRef, void *clientCallBa
     if (![skin protectedCallAndTraceback:1 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.pathwatcher callback error: %s", errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
 }
 

--- a/extensions/socket/internal.m
+++ b/extensions/socket/internal.m
@@ -28,6 +28,7 @@ static void connectCallback(HSAsyncTcpSocket *asyncSocket) {
         if (![skin protectedCallAndTraceback:0 nresults:0]) {
             const char *errorMsg = lua_tostring(skin.L, -1);
             [LuaSkin logError:[NSString stringWithFormat:@"%s connect callback error: %s", USERDATA_TAG, errorMsg]];
+            lua_pop(skin.L, 1) ; // remove error message
         }
     );
 }
@@ -42,6 +43,7 @@ static void writeCallback(HSAsyncTcpSocket *asyncSocket, long tag) {
         if (![skin protectedCallAndTraceback:1 nresults:0]) {
             const char *errorMsg = lua_tostring(skin.L, -1);
             [LuaSkin logError:[NSString stringWithFormat:@"%s write callback error: %s", USERDATA_TAG, errorMsg]];
+            lua_pop(skin.L, 1) ; // remove error message
         }
     );
 }
@@ -56,6 +58,7 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
         if (![skin protectedCallAndTraceback:2 nresults:0]) {
             const char *errorMsg = lua_tostring(skin.L, -1);
             [LuaSkin logError:[NSString stringWithFormat:@"%s read callback error: %s", USERDATA_TAG, errorMsg]];
+            lua_pop(skin.L, 1) ; // remove error message
         }
     );
 }

--- a/extensions/socket/udp.m
+++ b/extensions/socket/udp.m
@@ -26,6 +26,7 @@ static void connectCallback(HSAsyncUdpSocket *asyncUdpSocket) {
         if (![skin protectedCallAndTraceback:0 nresults:0]) {
             const char *errorMsg = lua_tostring(skin.L, -1);
             [LuaSkin logError:[NSString stringWithFormat:@"%s connect callback error: %s", USERDATA_TAG, errorMsg]];
+            lua_pop(skin.L, 1) ; // remove error message
         }
     );
 }
@@ -40,6 +41,7 @@ static void writeCallback(HSAsyncUdpSocket *asyncUdpSocket, long tag) {
         if (![skin protectedCallAndTraceback:1 nresults:0]) {
             const char *errorMsg = lua_tostring(skin.L, -1);
             [LuaSkin logError:[NSString stringWithFormat:@"%s write callback error: %s", USERDATA_TAG, errorMsg]];
+            lua_pop(skin.L, 1) ; // remove error message
         }
     );
 }
@@ -54,6 +56,7 @@ static void readCallback(HSAsyncUdpSocket *asyncUdpSocket, NSData *data, NSData 
         if (![skin protectedCallAndTraceback:2 nresults:0]) {
             const char *errorMsg = lua_tostring(skin.L, -1);
             [LuaSkin logError:[NSString stringWithFormat:@"%s read callback error: %s", USERDATA_TAG, errorMsg]];
+            lua_pop(skin.L, 1) ; // remove error message
         }
     );
 }

--- a/extensions/spaces/watcher.m
+++ b/extensions/spaces/watcher.m
@@ -42,6 +42,7 @@ typedef struct _spacewatcher_t {
     if (![skin protectedCallAndTraceback:1 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.spaces.watcher callback error: %s", errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
 }
 

--- a/extensions/task/internal.m
+++ b/extensions/task/internal.m
@@ -153,6 +153,7 @@ void create_task(task_userdata_t *userData) {
                 if (![skin protectedCallAndTraceback:3 nresults:0]) {
                     const char *errorMsg = lua_tostring([skin L], -1);
                     [skin logError:[NSString stringWithFormat:@"hs.task callback error: %s", errorMsg]];
+                    lua_pop([skin L], 1);
                 }
             }
         });
@@ -934,6 +935,7 @@ int luaopen_hs_task_internal(lua_State* L) {
                     [fh readInBackgroundAndNotify];
                 }
             }
+            lua_pop(L, 1); // result or error
         }
 
     }];

--- a/extensions/task/internal.m
+++ b/extensions/task/internal.m
@@ -156,6 +156,7 @@ void create_task(task_userdata_t *userData) {
                     lua_pop([skin L], 1);
                 }
             }
+            userData->selfRef = [skin luaUnref:refTable ref:userData->selfRef];
         });
     };
 

--- a/extensions/uielement/internal.m
+++ b/extensions/uielement/internal.m
@@ -224,6 +224,7 @@ static void watcher_observer_callback(AXObserverRef observer __unused, AXUIEleme
     if (![skin protectedCallAndTraceback:4 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithUTF8String:errorMsg]];
+        lua_pop(L, 1) ; // remove error message
     }
 }
 

--- a/extensions/uielement/internal.m
+++ b/extensions/uielement/internal.m
@@ -7,6 +7,7 @@
 
 #define get_element(L, idx) *((AXUIElementRef*)lua_touserdata(L, idx))
 
+static int refTable = LUA_NOREF ;
 static const char* userdataTag = "hs.uielement";
 static const char* watcherUserdataTag = "hs.uielement.watcher.userdata";
 static const char* watcherTag = "hs.uielement.watcher";
@@ -172,12 +173,12 @@ static int uielement_newWatcher(lua_State* L) {
     memset(watcher, 0, sizeof(watcher_t));
 
     lua_pushvalue(L, 2);  // handler
-    watcher->handler_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    watcher->handler_ref = [skin luaRef:refTable];
     if (nargs >= 3)
         lua_pushvalue(L, 3);  // userData
     else
         lua_pushnil(L);
-    watcher->user_data_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    watcher->user_data_ref = [skin luaRef:refTable];
     watcher->watcher_ref = LUA_REFNIL;
     watcher->running = NO;
     watcher->element = (AXUIElementRef)CFRetain(element);
@@ -214,11 +215,11 @@ static void watcher_observer_callback(AXObserverRef observer __unused, AXUIEleme
 
     lua_State *L = skin.L;
 
-    lua_rawgeti(L, LUA_REGISTRYINDEX, watcher->handler_ref);
+    [skin pushLuaRef:refTable ref:watcher->handler_ref];
     push_element(L, element); // Parameter 1: element
     lua_pushstring(L, CFStringGetCStringPtr(notificationName, kCFStringEncodingASCII)); // Parameter 2: event
-    lua_rawgeti(L, LUA_REGISTRYINDEX, watcher->watcher_ref); // Parameter 3: watcher
-    lua_rawgeti(L, LUA_REGISTRYINDEX, watcher->user_data_ref); // Parameter 4: userData
+    [skin pushLuaRef:refTable ref:watcher->watcher_ref]; // Parameter 3: watcher
+    [skin pushLuaRef:refTable ref:watcher->user_data_ref]; // Parameter 4: userData
 
     if (![skin protectedCallAndTraceback:4 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
@@ -260,7 +261,7 @@ static int watcher_start(lua_State* L) {
     }
 
     lua_pushvalue(L, 1);  // Store a reference to the lua object inside watcher.
-    watcher->watcher_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    watcher->watcher_ref = [skin luaRef:refTable];
     watcher->observer = observer;
     watcher->running = YES;
 
@@ -273,15 +274,15 @@ static int watcher_start(lua_State* L) {
     return 1;
 }
 
-static void stop_watcher(lua_State* L, watcher_t* watcher) {
+static void stop_watcher(__unused lua_State* L, watcher_t* watcher) {
+    LuaSkin *skin = [LuaSkin shared];
     if (!watcher->running) return;
 
     CFRunLoopRemoveSource([[NSRunLoop currentRunLoop] getCFRunLoop],
                           AXObserverGetRunLoopSource(watcher->observer),
                           kCFRunLoopDefaultMode);
 
-    luaL_unref(L, LUA_REGISTRYINDEX, watcher->watcher_ref);
-    watcher->watcher_ref = LUA_NOREF;
+    watcher->watcher_ref = [skin luaUnref:refTable ref:watcher->watcher_ref];
     CFRelease(watcher->observer);
 
     watcher->running = NO;
@@ -321,13 +322,12 @@ static int uielement_focusedElement(lua_State* L) {
 
 // Perform cleanup if the watcher is not required anymore.
 static int watcher_gc(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared];
     watcher_t* watcher = get_watcher(L, 1);
 
     stop_watcher(L, watcher);  // For extra safety, make sure we're stopped.
-    luaL_unref(L, LUA_REGISTRYINDEX, watcher->handler_ref);
-    luaL_unref(L, LUA_REGISTRYINDEX, watcher->user_data_ref);
-    watcher->handler_ref = LUA_NOREF;
-    watcher->user_data_ref = LUA_NOREF;
+    watcher->handler_ref = [skin luaUnref:refTable ref:watcher->handler_ref];
+    watcher->user_data_ref = [skin luaUnref:refTable ref:watcher->user_data_ref];
     CFRelease(watcher->element);
 
     return 0;
@@ -350,6 +350,10 @@ static const luaL_Reg watcherlib[] = {
 
 int luaopen_hs_uielement_internal(lua_State* L) {
     eventNames = @[ @"AXMainWindowChanged", @"AXFocusedWindowChanged", @"AXFocusedUIElementChanged", @"AXApplicationActivated", @"AXApplicationDeactivated", @"AXApplicationHidden", @"AXApplicationShown", @"AXWindowCreated", @"AXWindowMoved", @"AXWindowResized", @"AXWindowMiniaturized", @"AXWindowDeminiaturized", @"AXUIElementDestroyed", @"AXTitleChanged" ];
+
+    // Non-traditional Hammerspoon setup for userdata types here, don't want to break anything, but to keep registry clean, still need to setup refTable...
+    lua_newtable(L);
+    refTable = luaL_ref(L, LUA_REGISTRYINDEX);
 
     luaL_newlib(L, watcherlib);
 

--- a/extensions/urlevent/internal.m
+++ b/extensions/urlevent/internal.m
@@ -132,6 +132,7 @@ static HSURLEventHandler *eventHandler;
     if (![skin protectedCallAndTraceback:4 nresults:0]) {
         const char *errorMsg = lua_tostring(skin.L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.urlevent callback error: %s for URL %@", errorMsg, [url absoluteString]]];
+        lua_pop(skin.L, 1) ; // remove error message
     }
 }
 @end

--- a/extensions/usb/watcher.m
+++ b/extensions/usb/watcher.m
@@ -70,6 +70,7 @@ void DeviceNotification(void *refCon, io_service_t service __unused, natural_t m
         if (![skin protectedCallAndTraceback:1 nresults:0]) {
             const char *errorMsg = lua_tostring(L, -1);
             [skin logError:[NSString stringWithFormat:@"hs.usb.watcher 'removed' callback error: %s", errorMsg]];
+            lua_pop(L, 1) ; // remove error message
         }
 
         // Free the USB private data
@@ -158,6 +159,7 @@ void DeviceAdded(void *refCon, io_iterator_t iterator) {
             if (![skin protectedCallAndTraceback:1 nresults:0]) {
                 const char *errorMsg = lua_tostring(L, -1);
                 [skin logError:[NSString stringWithFormat:@"hs.usb.watcher 'added' callback error: %s", errorMsg]];
+                lua_pop(L, 1) ; // remove error message
             }
         }
     }

--- a/extensions/wifi/watcher.m
+++ b/extensions/wifi/watcher.m
@@ -44,6 +44,7 @@ int refTable;
     if (![skin protectedCallAndTraceback:0 nresults:0]) {
         const char *errorMsg = lua_tostring(L, -1);
         [skin logError:[NSString stringWithFormat:@"hs.wifi.watcher callback error: %s", errorMsg]];
+        lua_pop(L, 1) ;
     }
 }
 @end


### PR DESCRIPTION
* uielement now uses refTable like other modules instead of LUA_REGISTRYINDEX
* timer clears metatable on __gc and logs info that may help in debugging when it fails

I'm hoping these can help in tracking down some of the recurring crashes we're seeing that are related to timerCallback... or at least give a better picture of which timer so we can figure out where to focus...

@cmsj, please take a look and if you have no objections, I'd like to get this in master so those that use developer builds can start chiming in... 

And if you can think of more checks to add or stuff to log, please let me know... this is vexing me in its inconsistency!

EDIT: also modified toNSObjectAtIndex: so that it returns nil rather than [NSNull null], if the function has not yet recursed, per #880.