### PR TITLE
add websocket capability to hs.httpserver

### DIFF
--- a/extensions/httpserver/internal.m
+++ b/extensions/httpserver/internal.m
@@ -82,6 +82,8 @@ int refTable;
         } else {
             response = [skin toNSObjectAtIndex:-1];
         }
+
+        lua_pop(skin.L, 1);
     };
 
     // Make sure we do all the above Lua work on the main thread


### PR DESCRIPTION
Adds websocket capability to `hs.httpserver`
```lua
server = hs.httpserver.new();
server:setCallback(function() return "hello", 200, {} end);
server:setPort(8888);
server:websocket("/ws", function(msg) return msg.."!!!!!" end)
server:start();
```
Browser console:
```js
var ws = new WebSocket("ws://localhost:8888/ws") //if https: wss://localhost:8888/ws
ws.onmessage = (e => console.log(e.data))
ws.send('asdo')
> asdo!!!!!
```
Can also send messages directly:
`hs.timer.doEvery(1,function() server:send(tostring(math.random())) end)`
Browser console:
```
0.39438292663544
0.78309922339395
0.79844003310427
0.91164735751227
...
```