### PR TITLE
hs.menubar fix for issue #909

### DIFF
--- a/extensions/menubar/internal.m
+++ b/extensions/menubar/internal.m
@@ -170,10 +170,13 @@ NSMutableArray *dynamicMenuDelegates;
 @interface HSMenubarItemClickDelegate : HSMenubarCallbackObject
 @end
 @implementation HSMenubarItemClickDelegate
-- (void) click:(id __unused)sender {
+- (void) click:(id)sender {
+    // Issue #909 -- if the callback causes the menu to be replaced, we crash if this delegate disappears from beneath us... this keeps it from being collected before the callback is done.
+    NSObject *myDelegate = [sender representedObject] ;
     [self callback_runner];
     // error or return value (ignored in this case), we gotta cleanup
     lua_pop(self.L, 1) ;
+    myDelegate = nil ;
 }
 @end
 
@@ -269,6 +272,7 @@ void parse_table(lua_State *L, int idx, NSMenu *menu, NSSize stateBoxImageSize) 
             }
             lua_pop(L, 1);
 
+// MARK: fn key
             // Inspect the menu item table at the top of the stack, fetch the value for the key "fn" and push the result to the top of the stack
             lua_getfield(L, -1, "fn");
             if (lua_isfunction(L, -1)) {


### PR DESCRIPTION
Should address #909 by ensuring delegate isn't collected by ARC before the callback completes.