### PR TITLE
Console tweaks

### DIFF
--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -475,12 +475,21 @@ void MJLuaInit(void) {
     lua_pushboolean(L, [[NSFileManager defaultManager] fileExistsAtPath: MJConfigFileFullPath()]);
     lua_pushboolean(L, [[NSUserDefaults standardUserDefaults] boolForKey:HSAutoLoadExtensions]);
 
-    lua_pcall(L, 7, 2, 0);
-
-    evalfn = [MJLuaState luaRef:refTable];
-    completionsForWordFn = [MJLuaState luaRef:refTable];
-    MJLuaLogDelegate = [[MJLuaLogger alloc] initWithLua:L] ;
-    if (MJLuaLogDelegate) [MJLuaState setDelegate:MJLuaLogDelegate] ;
+    if (lua_pcall(L, 7, 2, 0) != LUA_OK) {
+        NSString *errorMessage = [NSString stringWithFormat:@"%s", lua_tostring(L, -1)] ;
+        CLSNSLog(@"Error running setup.lua:%@", errorMessage);
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert addButtonWithTitle:@"OK"];
+        [alert setMessageText:@"Hammerspoon initialization failed"];
+        [alert setInformativeText:errorMessage];
+        [alert setAlertStyle:NSCriticalAlertStyle];
+        [alert runModal];
+    } else {
+        evalfn = [MJLuaState luaRef:refTable];
+        completionsForWordFn = [MJLuaState luaRef:refTable];
+        MJLuaLogDelegate = [[MJLuaLogger alloc] initWithLua:L] ;
+        if (MJLuaLogDelegate) [MJLuaState setDelegate:MJLuaLogDelegate] ;
+    }
 }
 
 static int callShutdownCallback(lua_State *L) {

--- a/extensions/_coresetup/init.lua
+++ b/extensions/_coresetup/init.lua
@@ -264,6 +264,19 @@ return {setup=function(...)
   -- load init.lua
 
   local function runstring(s)
+    if hs._consoleInputPreparser then
+      if type(hs._consoleInputPreparser) == "function" then
+        local status, s2 = pcall(hs._consoleInputPreparser, s)
+        if status then
+          s = s2
+        else
+          hs.luaSkinLog.ef("console preparse error: %s", s2)
+        end
+      else
+          hs.luaSkinLog.e("console preparser must be a function or nil")
+      end
+    end
+
     --print("runstring")
     local fn, err = load("return " .. s)
     if not fn then fn, err = load(s) end


### PR DESCRIPTION
* adds console input pre-parser function `hs. _consoleInputPreparser`, addresses #103 

Adding the following to your `init.lua` file

~~~lua
hs._consoleInputPreparser = function(s)
    local helpWhat = s:match("^help%s*%((.*)%)%s*$")
    if helpWhat then
        if helpWhat == "" then
            s = "help"
        else
            s = "help." .. helpWhat
        end
    end
    return s
end
~~~

will allow typing `help(hs.foo)` as an alternative to `help.hs.foo`.  The pre-parser is invoked on the raw input typed into the console input field and if it is not a function (or nil) or if the function generates an error, an error is logged to the console, and the input is passed on through `runstring` un-modified.

* errors that occur during Hammerspoon initialization (i.e. processing setup.lua) before reaching user `init.lua` now pop up alert

This primarily impacts module developers that are making adjustments to core modules which may be used by `setup.lua` before loading the users `init.lua` file (which is already wrapped with `xpcall`).  Instead of getting a non-responsive console with just the welcome message when, for example, `hs.doc` generates a run-time error, it causes an alert with the error text to be shown.

![screen shot 2016-06-19 at 1 14 28 am](https://cloud.githubusercontent.com/assets/8139480/16175663/4e3bde96-35bb-11e6-974b-551ca7947c8b.png)
