### PR TITLE
Color patterns

### DIFF
--- a/extensions/drawing/color/init.lua
+++ b/extensions/drawing/color/init.lua
@@ -26,11 +26,15 @@ local module = require("hs.drawing.color.internal")
 ---   * list - the name of a system color list or a collection list defined in `hs.drawing.color`
 ---   * name - the color name within the specified color list
 ---
+--- * From an image to be used as a tiled pattern:
+---   * image - an `hs.image` object representing the image to be used as a tiled pattern
+---
 --- Any combination of the above keys may be specified within the color table and they will be evaluated in the following order:
----   1. If the `list` and `name` keys are specified, and if they can be matched to an existing color within the system color lists, that color is used.
----   2. If the `hue` key is provided, then the color is generated as an HSB color
----   3. If the `white` key is provided, then the color is generated as a Grayscale color
----   4. Otherwise, an RGB color is generated.
+---   1. if the `image` key is specified, it will be used to create a tiling pattern.
+---   2. If the `list` and `name` keys are specified, and if they can be matched to an existing color within the system color lists, that color is used.
+---   3. If the `hue` key is provided, then the color is generated as an HSB color
+---   4. If the `white` key is provided, then the color is generated as a Grayscale color
+---   5. Otherwise, an RGB color is generated.
 ---
 --- Except where specified above to indicate the color model being used, any key which is not provided defaults to a value of 0.0, except for `alpha`, which defaults to 1.0.  This means that specifying an empty table as the color will result in an opaque black color.
 

--- a/extensions/styledtext/internal.m
+++ b/extensions/styledtext/internal.m
@@ -1845,7 +1845,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
                 thePS.baseWritingDirection = NSWritingDirectionLeftToRight;
             } else if ([theString isEqualToString:@"rightToLeft"]) {
                 thePS.baseWritingDirection = NSWritingDirectionRightToLeft;
-            } else if (![theString isEqualToString:@"natural"]) {
+            } else if ([theString isEqualToString:@"natural"]) {
                 thePS.baseWritingDirection = NSWritingDirectionNatural;
             } else {
                 [skin logAtLevel:LS_LOG_WARN


### PR DESCRIPTION
Allows setting an image to a color for use as a tiling pattern... e.g.

~~~lua
d = hs.drawing.rectangle(hs.screen.mainScreen():fullFrame())
        :setFill(true)
        :setStroke(false)
        :setFillColor({ image = hs.image.imageFromASCII([[
.........1.........3.........5.........7.........N
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
A................................................A
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
C................................................C
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
E................................................E
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
G................................................G
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
..................................................
L........1.........3.........5.........7.........M
]],
{
    [9]  = { strokeColor = { blue = 1, alpha = 1 } },
    [10] = { strokeColor = { white = .25, alpha = 1 }, fillColor = { alpha = 0 }, shouldClose = false },
})}):show()
~~~

gives an almost instantaneous graph paper like overlay to the screen:

![screen shot 2016-07-04 at 2 55 52 am](https://cloud.githubusercontent.com/assets/8139480/16554216/ee81f880-4192-11e6-861f-aabec06807fb.png)


Also includes adjustments to LuaSkin to ensure proper absolute index is used for table conversions when passed pseudo-indexes as arguments.