### PR TITLE
Console input field resizes properly in 10.12

### DIFF
--- a/Hammerspoon/HSGrowingTextField.m
+++ b/Hammerspoon/HSGrowingTextField.m
@@ -32,23 +32,24 @@
 
 -(NSSize)intrinsicContentSize {
     NSSize intrinsicSize = _lastIntrinsicSize;
-    
+
     // Only update the size if we’re editing the text, or if we’ve not set it yet
     // If we try and update it while another text field is selected, it may shrink back down to only the size of one line (for some reason?)
     if(_isEditing || !_hasLastIntrinsicSize) {
         intrinsicSize = [super intrinsicContentSize];
-        
+
         // If we’re being edited, get the shared NSTextView field editor, so we can get more info
         NSText *fieldEditor = [self.window fieldEditor:NO forObject:self];
         if([fieldEditor isKindOfClass:[NSTextView class]]) {
             NSTextView *textView = (NSTextView *)fieldEditor;
+            [textView.textContainer.layoutManager ensureLayoutForTextContainer:textView.textContainer] ;
             NSRect usedRect = [textView.textContainer.layoutManager usedRectForTextContainer:textView.textContainer];
-            
+
             usedRect.size.height += 5.0; // magic number! (the field editor TextView is offset within the NSTextField. It’s easy to get the space above (it’s origin), but it’s difficult to get the default spacing for the bottom, as we may be changing the height
-            
+
             intrinsicSize.height = usedRect.size.height;
         }
-        
+
         if (intrinsicSize.height > 100) {
             intrinsicSize.height = 100;
         } else {
@@ -56,7 +57,7 @@
             _hasLastIntrinsicSize = YES;
         }
     }
-    
+
     return intrinsicSize;
 }
 

--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -174,7 +174,10 @@ static int push_hammerAppInfo(lua_State* L) {
 // Take this out of hs.settings?
         lua_pushstring(L, [[[NSBundle mainBundle] bundleIdentifier] UTF8String]) ;
         lua_setfield(L, -2, "bundleID") ;
-
+#ifdef DEBUG
+        lua_pushstring(L, __DATE__ ", " __TIME__) ; lua_setfield(L, -2, "buildTime") ;
+        lua_pushboolean(L, YES) ; lua_setfield(L, -2, "debugBuild") ;
+#endif
     return 1;
 }
 

--- a/extensions/console/internal.m
+++ b/extensions/console/internal.m
@@ -392,6 +392,47 @@ static int console_behavior(lua_State *L) {
     return 1 ;
 }
 
+/// hs.console.titleVisibility([state]) -> current value
+/// Function
+/// Get or set whether or not the "Hammerspoon Console" text appears in the Hammerspoon console titlebar.
+///
+/// Parameters:
+///  * state - an optional string containing the text "visible" or "hidden", specifying whether or not the console window's title text appears.
+///
+/// Returns:
+///  * a string of "visible" or "hidden" specifying the current (possibly changed) state of the window title's visibility.
+///
+/// Notes:
+///  * When a toolbar is attached to the Hammerspoon console (see the `hs.webview.toolbar` module documentation), this function can be used to specify whether the Toolbar appears underneath the console window's title ("visible") or in the window's title bar itself, as seen in applications like Safari ("hidden").
+static int console_titleVisibility(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TSTRING | LS_TOPTIONAL, LS_TBREAK] ;
+    NSWindow *console = [[MJConsoleWindowController singleton] window];
+    NSDictionary *mapping = @{
+        @"visible" : @(NSWindowTitleVisible),
+        @"hidden"  : @(NSWindowTitleHidden),
+    } ;
+
+    if (lua_gettop(L) == 1) {
+        NSNumber *value = mapping[[skin toNSObjectAtIndex:1]] ;
+        if (value) {
+            console.titleVisibility = [value intValue] ;
+            lua_pushvalue(L, 1) ;
+        } else {
+            return luaL_argerror(L, 2, [[NSString stringWithFormat:@"must be one of '%@'", [[mapping allKeys] componentsJoinedByString:@"', '"]] UTF8String]) ;
+        }
+    }
+    NSNumber *titleVisibility = @(console.titleVisibility) ;
+    NSString *value = [[mapping allKeysForObject:titleVisibility] firstObject] ;
+    if (value) {
+        [skin pushNSObject:value] ;
+    } else {
+        [skin logWarn:[NSString stringWithFormat:@"unrecognized titleVisibility %@ -- notify developers", titleVisibility]] ;
+        lua_pushnil(L) ;
+    }
+    return 1 ;
+}
+
 // static int meta_gc(__unused lua_State *L) {
 //     return 0;
 // }
@@ -410,6 +451,8 @@ static const luaL_Reg extrasLib[] = {
 
     {"getConsole", console_getConsole},
     {"setConsole", console_setConsole},
+
+    {"titleVisibility", console_titleVisibility},
 
     {"level", console_level},
     {"alpha", console_alpha},

--- a/extensions/doc/hsdocs/init.lua
+++ b/extensions/doc/hsdocs/init.lua
@@ -347,7 +347,7 @@ local makeBrowser = function()
       :closeOnEscape(true)
       :navigationCallback(function(a, w, n, e)
           if e then
-              hs.luaSkinLog.ef("%s browser navigation for %s error:%s", USERDATA_TAG, a, e)
+              hs.luaSkinLog.ef("%s browser navigation for %s error:%s", USERDATA_TAG, a, e.localizedDescription)
               return true
           end
           if a == "didFinishNavigation" then updateToolbarIcons(w:toolbar(), w) end


### PR DESCRIPTION
Actually, two minor things in this pull:
* console input field resizes properly in 10.12 - issue #976
* added `hs.console.titleVisibility` so `hs.webview.toolbar` can mimic Safari like toolbar in the titlebar area when a toolbar is added to the console (a future pull will include this and additional tweaks to `hs.webview`).

I need someone running 10.11 to verify that the first doesn't change the console input field behavior in 10.11 -- my 10.11 machine ate itself over the weekend and I haven't had a chance to rebuild it yet.