### PR TITLE
fix hotkey.bind return value

### DIFF
--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -70,7 +70,8 @@ local function enable(self,force,isModal)
   local returnVal = self._hk:enable() --objc
   log[isModal and 'df' or 'f']('Enabled hotkey %s%s',self.msg,isModal and ' (in modal)' or '')
   tinsert(hotkeys[idx],self) -- bring to the top of the stack
-  return returnVal
+--   return returnVal
+    return self
 end
 
 --- hs.hotkey:disable() -> hs.hotkey object


### PR DESCRIPTION
Since hotkey now wraps everything in a table rather then use the raw userdata value, the bind wrapper should do the same rather than return the raw userdata.

Since hotkey has a lot of stuff added by @lowne, he should review to make sure that this doesn't break anything.

Should address #979 (it seems to on my system, but more testing is required and a clarification of the actual error behavior as requested in 979 already)