### PR TITLE
Fix two hs.screen GC bugs - screen_gc wasn't actually releasing hs.screen userdata objects, screens_gc was expecting userdata even though it's a module level function

### DIFF
--- a/extensions/screen/internal.m
+++ b/extensions/screen/internal.m
@@ -684,7 +684,7 @@ void screen_gammaReapply(CGDirectDisplayID display) {
 }
 
 static int screen_gc(lua_State* L) {
-    NSScreen* screen __unused = get_screen_arg(L, 1);
+    NSScreen* screen __unused = (__bridge_transfer NSScreen*)*((void**)luaL_checkudata(L, 1, USERDATA_TAG));
     return 0;
 }
 
@@ -1025,9 +1025,6 @@ static int screen_desktopImageURL(lua_State *L) {
 }
 
 static int screens_gc(lua_State* L __unused) {
-    LuaSkin *skin = [LuaSkin shared];
-    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
-
     CGDisplayRemoveReconfigurationCallback(displayReconfigurationCallback, NULL);
     screen_gammaRestore(nil);
 


### PR DESCRIPTION
@asmagill I'd appreciate an eye on this. I'm pretty sure the `screens_gc` one is right, that should never have been looking for `LS_TUSERDATA` and the error is only hidden because Lua is in the process of being destroyed, but if you hook a breakpoint into `checkArgs` without this patch, you'll see it's expecting `LS_TUSERDATA`, but being given `LUA_TABLE` because `screens_gc` is the module-level GC, not the screen object GC, so our `checkArgs` call seems pointless and wrong (and probably my fault!)

The second one I'm less sure about - it looks like in `screen_gc` we should do `__bridge_transfer` because `new_screen()` is doing a `__bridge_retained`.