### PR TITLE
make sure pasteboardItems isn't cleared between subsequent message calls

### DIFF
--- a/extensions/pasteboard/internal.m
+++ b/extensions/pasteboard/internal.m
@@ -196,8 +196,9 @@ static int pasteboard_pasteboardItemTypes(lua_State* L) {
 
     lua_newtable(L) ;
 // make sure there is something on the pasteboard...
-    if ([[thePasteboard pasteboardItems] count] > 0) {
-        NSPasteboardItem* item = [[thePasteboard pasteboardItems] objectAtIndex:0];
+    NSArray *items = [thePasteboard pasteboardItems] ;
+    if (items && [items count] > 0) {
+        NSPasteboardItem* item = [items objectAtIndex:0];
         for (NSString* type in [item types]) {
             lua_pushstring(L, [type UTF8String]) ; lua_rawseti(L, -2, luaL_len(L, -2) + 1) ;
         }


### PR DESCRIPTION
hs.pasteboard.contentTypes was invoking pasteboardItems message repeatedly rather than maintaining a strong reference, which allowed for the slight possibility of it being changed between object message sends.