### PR TITLE
hs.keycodes additions

### DIFF
--- a/extensions/keycodes/internal.m
+++ b/extensions/keycodes/internal.m
@@ -434,17 +434,18 @@ static int keycodes_currentMethod(__unused lua_State * L) {
     CFArrayRef methodRefs = getAllInputMethods();
     NSString * currentMethod = nil;
 
-    for (int i = 0 ; i < CFArrayGetCount(methodRefs); i ++ ) {
-        TISInputSourceRef method = (TISInputSourceRef)(CFArrayGetValueAtIndex(methodRefs, i));
-        CFBooleanRef selected = TISGetInputSourceProperty(method, kTISPropertyInputSourceIsSelected);
-        if (CFBooleanGetValue(selected) == YES) {
-            currentMethod = getLayoutName(method);
-            break;
+    if (methodRefs) {
+        for (int i = 0 ; i < CFArrayGetCount(methodRefs); i ++ ) {
+            TISInputSourceRef method = (TISInputSourceRef)(CFArrayGetValueAtIndex(methodRefs, i));
+            CFBooleanRef selected = TISGetInputSourceProperty(method, kTISPropertyInputSourceIsSelected);
+            if (CFBooleanGetValue(selected) == YES) {
+                currentMethod = getLayoutName(method);
+                break;
+            }
         }
+
+        CFRelease(methodRefs);
     }
-
-    CFRelease(methodRefs);
-
     [skin pushNSObject:currentMethod];
     return 1;
 }
@@ -465,17 +466,18 @@ static int keycodes_setLayout(lua_State* L) {
     CFArrayRef layoutRefs = getAllLayouts();
     BOOL found = NO;
 
-    for (int i = 0; i < CFArrayGetCount(layoutRefs); i++) {
-        TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(layoutRefs, i));
-        NSString *layoutName = getLayoutName(layout);
+    if (layoutRefs) {
+        for (int i = 0; i < CFArrayGetCount(layoutRefs); i++) {
+            TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(layoutRefs, i));
+            NSString *layoutName = getLayoutName(layout);
 
-        if ([layoutName isEqualToString:desiredLayout] && TISSelectInputSource(layout) == noErr) {
-            found = YES;
+            if ([layoutName isEqualToString:desiredLayout] && TISSelectInputSource(layout) == noErr) {
+                found = YES;
+            }
         }
+
+        CFRelease(layoutRefs);
     }
-
-    CFRelease(layoutRefs);
-
     lua_pushboolean(L, found);
     return 1;
 }
@@ -496,17 +498,18 @@ static int keycodes_setMethod(lua_State* L) {
     CFArrayRef layoutRefs = getAllInputMethods();
     BOOL found = NO;
 
-    for (int i = 0; i < CFArrayGetCount(layoutRefs); i++) {
-        TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(layoutRefs, i));
-        NSString *layoutName = getLayoutName(layout);
+    if (layoutRefs) {
+        for (int i = 0; i < CFArrayGetCount(layoutRefs); i++) {
+            TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(layoutRefs, i));
+            NSString *layoutName = getLayoutName(layout);
 
-        if ([layoutName isEqualToString:desiredLayout] && TISSelectInputSource(layout) == noErr) {
-            found = YES;
+            if ([layoutName isEqualToString:desiredLayout] && TISSelectInputSource(layout) == noErr) {
+                found = YES;
+            }
         }
+
+        CFRelease(layoutRefs);
     }
-
-    CFRelease(layoutRefs);
-
     lua_pushboolean(L, found);
     return 1;
 }
@@ -531,26 +534,29 @@ static int keycodes_getIcon(lua_State* L) {
     CFArrayRef methodRefs = getAllInputMethods();
     BOOL found = NO;
 
-    for (int i = 0; i < CFArrayGetCount(layoutRefs); i++) {
-        TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(layoutRefs, i));
-        NSString *layoutName = getLayoutName(layout);
-
-        if ([layoutName isEqualToString:sourceName]) {
-            pushSourceIcon(layout);
-            found = YES;
-            break;
-        }
-    }
-
-    if (!found) {
-        for (int i = 0; i < CFArrayGetCount(methodRefs); i++) {
-            TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(methodRefs, i));
+    if (layoutRefs) {
+        for (int i = 0; i < CFArrayGetCount(layoutRefs); i++) {
+            TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(layoutRefs, i));
             NSString *layoutName = getLayoutName(layout);
 
             if ([layoutName isEqualToString:sourceName]) {
                 pushSourceIcon(layout);
                 found = YES;
                 break;
+            }
+        }
+    }
+    if (!found) {
+        if (methodRefs) {
+            for (int i = 0; i < CFArrayGetCount(methodRefs); i++) {
+                TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(methodRefs, i));
+                NSString *layoutName = getLayoutName(layout);
+
+                if ([layoutName isEqualToString:sourceName]) {
+                    pushSourceIcon(layout);
+                    found = YES;
+                    break;
+                }
             }
         }
     }

--- a/extensions/keycodes/internal.m
+++ b/extensions/keycodes/internal.m
@@ -1,9 +1,9 @@
-#import <Cocoa/Cocoa.h>
-#import <Carbon/Carbon.h>
-#import <LuaSkin/LuaSkin.h>
+@import Cocoa ;
+@import Carbon ;
+@import LuaSkin ;
 
-#define USERDATA_TAG "hs.keycodes.callback"
-int refTable;
+static char *USERDATA_TAG  = "hs.keycodes.callback" ;
+static int refTable;
 
 static void pushkeycode(lua_State* L, int code, const char* key) {
     // t[key] = code
@@ -34,7 +34,7 @@ int keycodes_cachemap(lua_State* L) {
     CFDataRef layoutData = TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData);
 
     if (layoutData) {
-        const UCKeyboardLayout *keyboardLayout = (const UCKeyboardLayout *)CFDataGetBytePtr(layoutData);
+        const UCKeyboardLayout *keyboardLayout = (const void *)CFDataGetBytePtr(layoutData);
         UInt32 keysDown = 0;
         UniChar chars[4];
         UniCharCount realLength;
@@ -284,6 +284,39 @@ CFArrayRef getAllInputMethods() {
     return TISCreateInputSourceList((__bridge CFDictionaryRef)@{(__bridge NSString *)kTISPropertyInputSourceType : (__bridge NSString *)kTISTypeKeyboardInputMode}, false);
 }
 
+/// hs.keycodes.currentSourceID([sourceID]) -> string | boolean
+/// Function
+/// Get or set the source id for the keyboard input source
+///
+/// Parameters:
+///  * sourceID - an optional string specifying the input source to set for keyboard input
+///
+/// Returns:
+///  * if no parameter is provided, returns a string containing the source id for the current keyboard layout or input method; if a parameter is provided, returns true or false specifying whether or not the input source was able to be changed.
+static int keycodes_sourceID(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TSTRING | LS_TOPTIONAL, LS_TBREAK] ;
+
+    if (lua_gettop(L) == 0) {
+        TISInputSourceRef layout = TISCopyCurrentKeyboardInputSource();
+        [skin pushNSObject:(__bridge id)TISGetInputSourceProperty(layout, kTISPropertyInputSourceID)] ;
+        CFRelease(layout);
+    } else {
+        BOOL found = NO ;
+        NSString     *sourceID = [skin toNSObjectAtIndex:1] ;
+        NSDictionary *prop     = @{ (__bridge NSString *)kTISPropertyInputSourceID : sourceID } ;
+        CFArrayRef   sources   = TISCreateInputSourceList((__bridge CFDictionaryRef)prop, false);
+        if (sources) {
+            if (CFArrayGetCount(sources) > 0) {
+                found = (TISSelectInputSource((TISInputSourceRef)CFArrayGetValueAtIndex(sources, 0)) == noErr) ;
+            }
+            CFRelease(sources) ;
+        }
+        lua_pushboolean(L, found) ;
+    }
+    return 1;
+}
+
 /// hs.keycodes.currentLayout() -> string
 /// Function
 /// Gets the name of the current keyboard layout
@@ -293,7 +326,7 @@ CFArrayRef getAllInputMethods() {
 ///
 /// Returns:
 ///  * A string containing the name of the current keyboard layout
-static int keycodes_currentLayout(lua_State* L) {
+static int keycodes_currentLayout(__unused lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
     TISInputSourceRef layout = TISCopyCurrentKeyboardLayoutInputSource();
     [skin pushNSObject:getLayoutName(layout)];
@@ -310,7 +343,7 @@ static int keycodes_currentLayout(lua_State* L) {
 ///
 /// Returns:
 ///  * An hs.image object containing the icon, if available
-static int keycodes_currentLayoutIcon(lua_State* L) {
+static int keycodes_currentLayoutIcon(__unused lua_State* L) {
     TISInputSourceRef layout = TISCopyCurrentKeyboardInputSource();
 
     pushSourceIcon(layout);
@@ -318,61 +351,73 @@ static int keycodes_currentLayoutIcon(lua_State* L) {
     return 1;
 }
 
-/// hs.keycodes.layouts() -> table
+/// hs.keycodes.layouts([sourceID]) -> table
 /// Function
-/// Gets all of the enabled keyboard layouts
+/// Gets all of the enabled keyboard layouts that the keyboard input source can be switched to
 ///
 /// Parameters:
-///  * None
+///  * sourceID - an optional boolean, default false, indicating whether the keyboard layout names should be returned (false) or their source IDs (true).
 ///
 /// Returns:
 ///  * A table containing a list of keyboard layouts enabled in System Preferences
+///
+/// Notes:
+///  * Only those layouts which can be explicitly switched to will be included in the table.  Keyboard layouts which are part of input methods are not included.  See `hs.keycodes.methods`.
 static int keycodes_layouts(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
-    NSMutableArray *layouts = [[NSMutableArray alloc] init];
+    [skin checkArgs:LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
+    BOOL sourceIDsOnly = lua_gettop(L) == 1 ? (BOOL)lua_toboolean(L, 1) : NO ;
     CFArrayRef layoutRefs = getAllLayouts();
 
-    for (int i = 0; i < CFArrayGetCount(layoutRefs); i++) {
-        TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(layoutRefs, i));
-        [layouts addObject:getLayoutName(layout)];
+    lua_newtable(L) ;
+    if (layoutRefs) {
+        for (int i = 0; i < CFArrayGetCount(layoutRefs); i++) {
+            TISInputSourceRef layout = (TISInputSourceRef)(CFArrayGetValueAtIndex(layoutRefs, i));
+            if (sourceIDsOnly) {
+                [skin pushNSObject:(__bridge id)TISGetInputSourceProperty(layout, kTISPropertyInputSourceID)] ;
+            } else {
+                [skin pushNSObject:getLayoutName(layout)];
+            }
+            lua_rawseti(L, -2, luaL_len(L, -2) + 1) ;
+        }
+        CFRelease(layoutRefs);
     }
-
-    CFRelease(layoutRefs);
-
-    [skin pushNSObject:layouts];
     return 1;
 }
 
-/// hs.keycodes.methods() -> table
+/// hs.keycodes.methods([sourceID]) -> table
 /// Function
-/// Gets all of the enabled input methods
+/// Gets all of the enabled input methods that the keyboard input source can be switched to
 ///
 /// Parameters:
-///  * None
+///  * sourceID - an optional boolean, default false, indicating whether the keyboard input method names should be returned (false) or their source IDs (true).
+///
 ///
 /// Returns:
 ///  * A table containing a list of input methods enabled in System Preferences
+///
+/// Notes:
+///  * Keyboard layouts which are not part of an input method are not included in this table.  See `hs.keycodes.layouts`.
 static int keycodes_methods(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
-    NSMutableArray *methods = [[NSMutableArray alloc] init];
+    [skin checkArgs:LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
+    BOOL sourceIDsOnly = lua_gettop(L) == 1 ? (BOOL)lua_toboolean(L, 1) : NO ;
     CFArrayRef methodRefs = getAllInputMethods();
 
-    if (!methodRefs) {
-        lua_newtable(L);
-        return 1;
+    lua_newtable(L) ;
+    if (methodRefs) {
+        for (int i = 0; i < CFArrayGetCount(methodRefs); i++) {
+            TISInputSourceRef method = (TISInputSourceRef)(CFArrayGetValueAtIndex(methodRefs, i));
+            if (sourceIDsOnly) {
+                [skin pushNSObject:(__bridge id)TISGetInputSourceProperty(method, kTISPropertyInputSourceID)] ;
+            } else {
+                [skin pushNSObject:getLayoutName(method)];
+            }
+            lua_rawseti(L, -2, luaL_len(L, -2) + 1) ;
+        }
+        CFRelease(methodRefs);
     }
-
-    for (int i = 0; i < CFArrayGetCount(methodRefs); i++) {
-        TISInputSourceRef method = (TISInputSourceRef)(CFArrayGetValueAtIndex(methodRefs, i));
-        [methods addObject:getLayoutName(method)];
-    }
-
-    CFRelease(methodRefs);
-
-    [skin pushNSObject:methods];
     return 1;
-
-
 }
 
 /// hs.keycodes.currentMethod() -> string
@@ -384,7 +429,7 @@ static int keycodes_methods(lua_State* L) {
 ///
 /// Returns:
 ///  * Name of current input method, or nil
-static int keycodes_currentMethod(lua_State * L) {
+static int keycodes_currentMethod(__unused lua_State * L) {
     LuaSkin * skin = [LuaSkin shared];
     CFArrayRef methodRefs = getAllInputMethods();
     NSString * currentMethod = nil;
@@ -543,6 +588,7 @@ static const luaL_Reg keycodeslib[] = {
     {"setLayout", keycodes_setLayout},
     {"setMethod", keycodes_setMethod},
     {"iconForLayoutOrMethod", keycodes_getIcon},
+    {"currentSourceID", keycodes_sourceID},
 
     {NULL, NULL}
 };


### PR DESCRIPTION
Prompted by #1022 

* Adds `hs.keycodes.currentSourceID([sourceID])` to get/set keyboard input by layout or method source id
* add optional boolean `sourceID` parameter to `hs.keycodes.layouts` and `hs.keycodes.methods` to return names as source ids instead of localized string (default behavior is same as before)
* added some notes to clarify between layouts and methods in doc strings... I'm not 100% clear about it myself, so if anyone has better verbiage, then go for it.