### PR TITLE
raw data read/write to pasteboard

### DIFF
--- a/extensions/pasteboard/internal.m
+++ b/extensions/pasteboard/internal.m
@@ -408,7 +408,7 @@ static int readPropertyListForType(lua_State *L) {
     return 1 ;
 }
 
-/// hs.pasteboard.writeDataForUTI([name], uti, data) -> string
+/// hs.pasteboard.writeDataForUTI([name], uti, data) -> boolean
 /// Function
 /// Sets the pasteboard to the contents of the data and assigns its type to the specified UTI.
 ///


### PR DESCRIPTION
adds:
~~~
hs.pasteboard.readDataForUTI([name], uti) -> string
hs.pasteboard.readPListForUTI([name], uti) -> string
hs.pasteboard.writeDataForUTI([name], uti, data) -> string
~~~

Writing a property list is on hold until we can better understand the exact format expected; reading a property list is included for information purposes only at this time.  The docstrings reflect this.