### PR TITLE
`setMuted` now returns `true` on success

### DIFF
--- a/extensions/audiodevice/internal.m
+++ b/extensions/audiodevice/internal.m
@@ -497,7 +497,7 @@ static int audiodevice_setmuted(lua_State* L) {
         kAudioObjectPropertyElementMaster
     };
 
-    if (AudioObjectHasProperty(deviceId, &propertyAddress) && (AudioObjectSetPropertyData(deviceId, &propertyAddress, 0, NULL, mutedSize, &muted) != noErr)) {
+    if (AudioObjectHasProperty(deviceId, &propertyAddress) && (AudioObjectSetPropertyData(deviceId, &propertyAddress, 0, NULL, mutedSize, &muted) == noErr)) {
         lua_pushboolean(L, TRUE);
     } else {
         lua_pushboolean(L, FALSE);


### PR DESCRIPTION
I noticed that any call of `setMuted` returned `false`, even on built-in devices.
Referring to the docs, False should only be returned if the devices can not be muted, so I assumed it was an error, and discovered the typo fixed by the commit.