### PR TITLE
hs.network.ping submodule

### DIFF
--- a/Hammerspoon.xcodeproj/project.pbxproj
+++ b/Hammerspoon.xcodeproj/project.pbxproj
@@ -240,6 +240,10 @@
 		D64B03401BA954780006C468 /* LuaSkin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F9850E81B722CBF00F7E909 /* LuaSkin.framework */; };
 		D64B03421BA954780006C468 /* webview.h in Headers */ = {isa = PBXBuildFile; fileRef = D64B03361BA9541E0006C468 /* webview.h */; };
 		D64B03471BA954A20006C468 /* usercontent.m in Sources */ = {isa = PBXBuildFile; fileRef = D64B03381BA954660006C468 /* usercontent.m */; };
+		D677760D1DDA4A5400DFB530 /* LuaSkin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F9850E81B722CBF00F7E909 /* LuaSkin.framework */; };
+		D67776131DDA4A8C00DFB530 /* internal.m in Sources */ = {isa = PBXBuildFile; fileRef = D67776031DDA4A1500DFB530 /* internal.m */; };
+		D67776141DDA4A8C00DFB530 /* SimplePing.m in Sources */ = {isa = PBXBuildFile; fileRef = D67776051DDA4A1500DFB530 /* SimplePing.m */; };
+		D67776151DDA4A9C00DFB530 /* SimplePing.h in Headers */ = {isa = PBXBuildFile; fileRef = D67776041DDA4A1500DFB530 /* SimplePing.h */; };
 		D6B9464C1D139C7D00177E0C /* LuaSkin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F9850E81B722CBF00F7E909 /* LuaSkin.framework */; };
 		D6B9464E1D139C7D00177E0C /* webview.h in Headers */ = {isa = PBXBuildFile; fileRef = D64B03361BA9541E0006C468 /* webview.h */; };
 		D6B946531D139CB800177E0C /* datastore.m in Sources */ = {isa = PBXBuildFile; fileRef = D6B946431D139C4900177E0C /* datastore.m */; };
@@ -722,6 +726,13 @@
 			remoteGlobalIDString = D6F310E51BDF110500045CCD;
 			remoteInfo = styledtext;
 		};
+		D67776161DDA4ADC00DFB530 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9445CA0319083251002568BB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D67776091DDA4A5400DFB530;
+			remoteInfo = networkping;
+		};
 		D6B946601D139D1600177E0C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9445CA0319083251002568BB /* Project object */;
@@ -1112,6 +1123,11 @@
 		D64B03381BA954660006C468 /* usercontent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = usercontent.m; path = extensions/webview/usercontent.m; sourceTree = "<group>"; };
 		D64B03461BA954780006C468 /* libwebviewusercontent.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libwebviewusercontent.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		D66B763A1DD6FD1400CA12E6 /* geocoder.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = geocoder.lua; path = extensions/location/geocoder.lua; sourceTree = "<group>"; };
+		D67776021DDA4A1500DFB530 /* init.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = init.lua; path = extensions/network/ping/init.lua; sourceTree = "<group>"; };
+		D67776031DDA4A1500DFB530 /* internal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = internal.m; path = extensions/network/ping/internal.m; sourceTree = "<group>"; };
+		D67776041DDA4A1500DFB530 /* SimplePing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SimplePing.h; path = extensions/network/ping/SimplePing.h; sourceTree = "<group>"; };
+		D67776051DDA4A1500DFB530 /* SimplePing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SimplePing.m; path = extensions/network/ping/SimplePing.m; sourceTree = "<group>"; };
+		D67776121DDA4A5400DFB530 /* libnetworkping.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libnetworkping.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6B772981CCB544B00908A59 /* cgilua_compatibility_functions.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = cgilua_compatibility_functions.lua; path = extensions/httpserver/cgilua_compatibility_functions.lua; sourceTree = "<group>"; };
 		D6B772991CCB544B00908A59 /* hsminweb.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = hsminweb.lua; path = extensions/httpserver/hsminweb.lua; sourceTree = "<group>"; };
 		D6B946431D139C4900177E0C /* datastore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = datastore.m; path = extensions/webview/datastore.m; sourceTree = "<group>"; };
@@ -1655,6 +1671,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				D64B03401BA954780006C468 /* LuaSkin.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D677760C1DDA4A5400DFB530 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D677760D1DDA4A5400DFB530 /* LuaSkin.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2679,6 +2703,7 @@
 				D6B9465E1D139CC500177E0C /* libwebviewtoolbar.dylib */,
 				6AE181271D36E90B0097211C /* libnoises.dylib */,
 				D61F4A2F1DCFA67900AEE223 /* libsharing.dylib */,
+				D67776121DDA4A5400DFB530 /* libnetworkping.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2840,6 +2865,7 @@
 		D6477BFB1C5ED57400F67BBC /* network */ = {
 			isa = PBXGroup;
 			children = (
+				D67776011DDA49F500DFB530 /* ping */,
 				D6477BFC1C5ED5A600F67BBC /* configuration.lua */,
 				D6477BFD1C5ED5A600F67BBC /* configurationinternal.m */,
 				D6477BFE1C5ED5A600F67BBC /* host.lua */,
@@ -2857,6 +2883,17 @@
 				D64B03381BA954660006C468 /* usercontent.m */,
 			);
 			name = webviewusercontent;
+			sourceTree = "<group>";
+		};
+		D67776011DDA49F500DFB530 /* ping */ = {
+			isa = PBXGroup;
+			children = (
+				D67776021DDA4A1500DFB530 /* init.lua */,
+				D67776031DDA4A1500DFB530 /* internal.m */,
+				D67776041DDA4A1500DFB530 /* SimplePing.h */,
+				D67776051DDA4A1500DFB530 /* SimplePing.m */,
+			);
+			name = ping;
 			sourceTree = "<group>";
 		};
 		D6BB4FA61C169500000DC0A2 /* speech */ = {
@@ -3358,6 +3395,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				D64B03421BA954780006C468 /* webview.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D677760E1DDA4A5400DFB530 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D67776151DDA4A9C00DFB530 /* SimplePing.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4391,6 +4436,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				D67776171DDA4ADC00DFB530 /* PBXTargetDependency */,
 				D61F4A361DCFA71E00AEE223 /* PBXTargetDependency */,
 				6AE181301D36E9A30097211C /* PBXTargetDependency */,
 				D6B946611D139D1600177E0C /* PBXTargetDependency */,
@@ -4603,6 +4649,23 @@
 			productReference = D64B03461BA954780006C468 /* libwebviewusercontent.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
+		D67776091DDA4A5400DFB530 /* networkping */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D677760F1DDA4A5400DFB530 /* Build configuration list for PBXNativeTarget "networkping" */;
+			buildPhases = (
+				D677760A1DDA4A5400DFB530 /* Sources */,
+				D677760C1DDA4A5400DFB530 /* Frameworks */,
+				D677760E1DDA4A5400DFB530 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = networkping;
+			productName = alert;
+			productReference = D67776121DDA4A5400DFB530 /* libnetworkping.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
 		D6B946481D139C7D00177E0C /* webviewdatastore */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D6B9464F1D139C7D00177E0C /* Build configuration list for PBXNativeTarget "webviewdatastore" */;
@@ -4803,6 +4866,7 @@
 				4F6B3EF11B73E7C200B2A4DE /* mouse */,
 				D6477C0A1C5ED5D000F67BBC /* networkconfiguration */,
 				D6477C2D1C5ED83C00F67BBC /* networkhost */,
+				D67776091DDA4A5400DFB530 /* networkping */,
 				D6477C1E1C5ED82200F67BBC /* networkreachability */,
 				6AE1811E1D36E90B0097211C /* noises */,
 				4F6B3F021B73E98E00B2A4DE /* notify */,
@@ -5615,6 +5679,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D677760A1DDA4A5400DFB530 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D67776131DDA4A8C00DFB530 /* internal.m in Sources */,
+				D67776141DDA4A8C00DFB530 /* SimplePing.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D6B946491D139C7D00177E0C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -6003,6 +6076,11 @@
 			isa = PBXTargetDependency;
 			target = D6F310E51BDF110500045CCD /* styledtext */;
 			targetProxy = D675906E1BDF12DA00EE9F75 /* PBXContainerItemProxy */;
+		};
+		D67776171DDA4ADC00DFB530 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D67776091DDA4A5400DFB530 /* networkping */;
+			targetProxy = D67776161DDA4ADC00DFB530 /* PBXContainerItemProxy */;
 		};
 		D6B946611D139D1600177E0C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -14735,6 +14813,140 @@
 			};
 			name = Release;
 		};
+		D67776101DDA4A5400DFB530 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = "$(inherited)";
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = "$(inherited)";
+				CLANG_WARN_ASSIGN_ENUM = "$(inherited)";
+				CLANG_WARN_BOOL_CONVERSION = "$(inherited)";
+				CLANG_WARN_CONSTANT_CONVERSION = "$(inherited)";
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = "$(inherited)";
+				CLANG_WARN_EMPTY_BODY = "$(inherited)";
+				CLANG_WARN_ENUM_CONVERSION = "$(inherited)";
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = "$(inherited)";
+				CLANG_WARN_INT_CONVERSION = "$(inherited)";
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = "$(inherited)";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = "$(inherited)";
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = "$(inherited)";
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = "$(inherited)";
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = "$(inherited)";
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = "$(inherited)";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = "$(inherited)";
+				ENABLE_TESTABILITY = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = "$(inherited)";
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = "$(inherited)";
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = "$(inherited)";
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = "$(inherited)";
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = "$(inherited)";
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = "$(inherited)";
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = "$(inherited)";
+				GCC_WARN_MISSING_PARENTHESES = "$(inherited)";
+				GCC_WARN_MULTIPLE_DEFINITION_TYPES_FOR_SELECTOR = "$(inherited)";
+				GCC_WARN_PEDANTIC = "$(inherited)";
+				GCC_WARN_SHADOW = "$(inherited)";
+				GCC_WARN_SIGN_COMPARE = "$(inherited)";
+				GCC_WARN_STRICT_SELECTOR_MATCH = "$(inherited)";
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = "$(inherited)";
+				GCC_WARN_UNDECLARED_SELECTOR = "$(inherited)";
+				GCC_WARN_UNKNOWN_PRAGMAS = "$(inherited)";
+				GCC_WARN_UNUSED_FUNCTION = "$(inherited)";
+				GCC_WARN_UNUSED_LABEL = "$(inherited)";
+				GCC_WARN_UNUSED_PARAMETER = "$(inherited)";
+				GCC_WARN_UNUSED_VALUE = "$(inherited)";
+				GCC_WARN_UNUSED_VARIABLE = "$(inherited)";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_CLANG_STATIC_ANALYZER = "$(inherited)";
+				SDKROOT = "$(inherited)";
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Debug;
+		};
+		D67776111DDA4A5400DFB530 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = "$(inherited)";
+				CLANG_ANALYZER_DEADCODE_DEADSTORES = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = "$(inherited)";
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = "$(inherited)";
+				CLANG_WARN_ASSIGN_ENUM = "$(inherited)";
+				CLANG_WARN_BOOL_CONVERSION = "$(inherited)";
+				CLANG_WARN_CONSTANT_CONVERSION = "$(inherited)";
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = "$(inherited)";
+				CLANG_WARN_EMPTY_BODY = "$(inherited)";
+				CLANG_WARN_ENUM_CONVERSION = "$(inherited)";
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = "$(inherited)";
+				CLANG_WARN_INT_CONVERSION = "$(inherited)";
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = "$(inherited)";
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = "$(inherited)";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = "$(inherited)";
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = "$(inherited)";
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = "$(inherited)";
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = "$(inherited)";
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = "$(inherited)";
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = "$(inherited)";
+				EXECUTABLE_PREFIX = lib;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = "$(inherited)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = "$(inherited)";
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = "$(inherited)";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = "$(inherited)";
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = "$(inherited)";
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = "$(inherited)";
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = "$(inherited)";
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = "$(inherited)";
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = "$(inherited)";
+				GCC_WARN_MISSING_PARENTHESES = "$(inherited)";
+				GCC_WARN_MULTIPLE_DEFINITION_TYPES_FOR_SELECTOR = "$(inherited)";
+				GCC_WARN_PEDANTIC = "$(inherited)";
+				GCC_WARN_SHADOW = "$(inherited)";
+				GCC_WARN_SIGN_COMPARE = "$(inherited)";
+				GCC_WARN_STRICT_SELECTOR_MATCH = "$(inherited)";
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = "$(inherited)";
+				GCC_WARN_UNDECLARED_SELECTOR = "$(inherited)";
+				GCC_WARN_UNKNOWN_PRAGMAS = "$(inherited)";
+				GCC_WARN_UNUSED_FUNCTION = "$(inherited)";
+				GCC_WARN_UNUSED_LABEL = "$(inherited)";
+				GCC_WARN_UNUSED_PARAMETER = "$(inherited)";
+				GCC_WARN_UNUSED_VALUE = "$(inherited)";
+				GCC_WARN_UNUSED_VARIABLE = "$(inherited)";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUN_CLANG_STATIC_ANALYZER = "$(inherited)";
+				SDKROOT = "$(inherited)";
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Release;
+		};
 		D6B946501D139C7D00177E0C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -16262,6 +16474,15 @@
 			buildConfigurations = (
 				D64B03441BA954780006C468 /* Debug */,
 				D64B03451BA954780006C468 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		D677760F1DDA4A5400DFB530 /* Build configuration list for PBXNativeTarget "networkping" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D67776101DDA4A5400DFB530 /* Debug */,
+				D67776111DDA4A5400DFB530 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/extensions/network/init.lua
+++ b/extensions/network/init.lua
@@ -4,9 +4,28 @@
 
 local USERDATA_TAG   = "hs.network"
 local module         = {}
-module.reachability  = require(USERDATA_TAG..".reachability")
-module.host          = require(USERDATA_TAG..".host")
-module.configuration = require(USERDATA_TAG..".configuration")
+-- module.reachability  = require(USERDATA_TAG..".reachability")
+-- module.host          = require(USERDATA_TAG..".host")
+-- module.configuration = require(USERDATA_TAG..".configuration")
+-- module.ping          = require(USERDATA_TAG..".ping")
+
+-- auto-load submodules as needed
+local submodules = {
+    reachability  = USERDATA_TAG..".reachability",
+    host          = USERDATA_TAG..".host",
+    configuration = USERDATA_TAG..".configuration",
+    ping          = USERDATA_TAG..".ping",
+}
+setmetatable(module, {
+    __index = function(self, key)
+        if submodules[key] then
+            self[key] = require(submodules[key])
+            return self[key]
+        else
+            return nil
+        end
+    end,
+})
 
 local inspect        = require("hs.inspect")
 local fnutils        = require("hs.fnutils")

--- a/extensions/network/ping/LICENSE
+++ b/extensions/network/ping/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Aaron Magill
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/extensions/network/ping/LICENSE.SimplePing
+++ b/extensions/network/ping/LICENSE.SimplePing
@@ -1,0 +1,52 @@
+/*
+
+    SimplePing.h and SimplePing.m are part of Apple's Developer Guides and Sample Code
+    project SimplePing which can be found at:
+        https://developer.apple.com/library/content/samplecode/SimplePing/
+
+    It is licensed by Apple Inc. as follows:
+
+*/
+
+Sample code project: SimplePing
+Version: 5.0
+
+IMPORTANT:  This Apple software is supplied to you by Apple
+Inc. ("Apple") in consideration of your agreement to the following
+terms, and your use, installation, modification or redistribution of
+this Apple software constitutes acceptance of these terms.  If you do
+not agree with these terms, please do not use, install, modify or
+redistribute this Apple software.
+
+In consideration of your agreement to abide by the following terms, and
+subject to these terms, Apple grants you a personal, non-exclusive
+license, under Apple's copyrights in this original Apple software (the
+"Apple Software"), to use, reproduce, modify and redistribute the Apple
+Software, with or without modifications, in source and/or binary forms;
+provided that if you redistribute the Apple Software in its entirety and
+without modifications, you must retain this notice and the following
+text and disclaimers in all such redistributions of the Apple Software.
+Neither the name, trademarks, service marks or logos of Apple Inc. may
+be used to endorse or promote products derived from the Apple Software
+without specific prior written permission from Apple.  Except as
+expressly stated in this notice, no other rights or licenses, express or
+implied, are granted by Apple herein, including but not limited to any
+patent rights that may be infringed by your derivative works or by other
+works in which the Apple Software may be incorporated.
+
+The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+
+IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (C) 2016 Apple Inc. All Rights Reserved.

--- a/extensions/network/ping/SimplePing.h
+++ b/extensions/network/ping/SimplePing.h
@@ -1,0 +1,272 @@
+/*
+    Copyright (C) 2016 Apple Inc. All Rights Reserved.
+    See LICENSE.txt for this sample’s licensing information
+    
+    Abstract:
+    An object wrapper around the low-level BSD Sockets ping function.
+ */
+
+@import Foundation;
+
+#include <AssertMacros.h>           // for __Check_Compile_Time
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SimplePingDelegate;
+
+/*! Controls the IP address version used by SimplePing instances.
+ */
+
+typedef NS_ENUM(NSInteger, SimplePingAddressStyle) {
+    SimplePingAddressStyleAny,          ///< Use the first IPv4 or IPv6 address found; the default.
+    SimplePingAddressStyleICMPv4,       ///< Use the first IPv4 address found.
+    SimplePingAddressStyleICMPv6        ///< Use the first IPv6 address found.
+};
+
+/*! An object wrapper around the low-level BSD Sockets ping function.
+ *  \details To use the class create an instance, set the delegate and call `-start` 
+ *      to start the instance on the current run loop.  If things go well you'll soon get the 
+ *      `-simplePing:didStartWithAddress:` delegate callback.  From there you can can call 
+ *      `-sendPingWithData:` to send a ping and you'll receive the 
+ *      `-simplePing:didReceivePingResponsePacket:sequenceNumber:` and 
+ *      `-simplePing:didReceiveUnexpectedPacket:` delegate callbacks as ICMP packets arrive.
+ *
+ *      The class can be used from any thread but the use of any single instance must be 
+ *      confined to a specific thread and that thread must run its run loop.
+ */
+
+@interface SimplePing : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/*! Initialise the object to ping the specified host.
+ *  \param hostName The DNS name of the host to ping; an IPv4 or IPv6 address in string form will 
+ *      work here.
+ *  \returns The initialised object.
+ */
+
+- (instancetype)initWithHostName:(NSString *)hostName NS_DESIGNATED_INITIALIZER;
+
+/*! A copy of the value passed to `-initWithHostName:`.
+ */
+
+@property (nonatomic, copy, readonly) NSString * hostName;
+
+/*! The delegate for this object.
+ *  \details Delegate callbacks are schedule in the default run loop mode of the run loop of the 
+ *      thread that calls `-start`.
+ */
+
+@property (nonatomic, weak, readwrite, nullable) id<SimplePingDelegate> delegate;
+
+/*! Controls the IP address version used by the object.
+ *  \details You should set this value before starting the object.
+ */
+
+@property (nonatomic, assign, readwrite) SimplePingAddressStyle addressStyle;
+
+/*! The address being pinged.
+ *  \details The contents of the NSData is a (struct sockaddr) of some form.  The 
+ *      value is nil while the object is stopped and remains nil on start until 
+ *      `-simplePing:didStartWithAddress:` is called.
+ */
+ 
+@property (nonatomic, copy, readonly, nullable) NSData * hostAddress;
+
+/*! The address family for `hostAddress`, or `AF_UNSPEC` if that's nil.
+ */
+
+@property (nonatomic, assign, readonly) sa_family_t hostAddressFamily;
+
+/*! The identifier used by pings by this object.
+ *  \details When you create an instance of this object it generates a random identifier 
+ *      that it uses to identify its own pings.
+ */
+
+@property (nonatomic, assign, readonly) uint16_t identifier;
+
+/*! The next sequence number to be used by this object.
+ *  \details This value starts at zero and increments each time you send a ping (safely 
+ *      wrapping back to zero if necessary).  The sequence number is included in the ping, 
+ *      allowing you to match up requests and responses, and thus calculate ping times and 
+ *      so on.
+ */
+
+@property (nonatomic, assign, readonly) uint16_t nextSequenceNumber;
+
+/*! Starts the object.
+ *  \details You should set up the delegate and any ping parameters before calling this.
+ *      
+ *      If things go well you'll soon get the `-simplePing:didStartWithAddress:` delegate 
+ *      callback, at which point you can start sending pings (via `-sendPingWithData:`) and 
+ *      will start receiving ICMP packets (either ping responses, via the 
+ *      `-simplePing:didReceivePingResponsePacket:sequenceNumber:` delegate callback, or 
+ *      unsolicited ICMP packets, via the `-simplePing:didReceiveUnexpectedPacket:` delegate 
+ *      callback).
+ *
+ *      If the object fails to start, typically because `hostName` doesn't resolve, you'll get 
+ *      the `-simplePing:didFailWithError:` delegate callback.
+ *
+ *      It is not correct to start an already started object.
+ */
+
+- (void)start;
+
+/*! Sends a ping packet containing the specified data.
+ *  \details Sends an actual ping.
+ *
+ *      The object must be started when you call this method and, on starting the object, you must 
+ *      wait for the `-simplePing:didStartWithAddress:` delegate callback before calling it.
+ *  \param data Some data to include in the ping packet, after the ICMP header, or nil if you 
+ *      want the packet to include a standard 56 byte payload (resulting in a standard 64 byte 
+ *      ping).
+ */
+
+- (void)sendPingWithData:(nullable NSData *)data;
+
+/*! Stops the object.
+ *  \details You should call this when you're done pinging.
+ *      
+ *      It's safe to call this on an object that's stopped.
+ */
+
+- (void)stop;
+
+@end
+
+/*! A delegate protocol for the SimplePing class.
+ */
+
+@protocol SimplePingDelegate <NSObject>
+
+@optional
+
+/*! A SimplePing delegate callback, called once the object has started up.
+ *  \details This is called shortly after you start the object to tell you that the 
+ *      object has successfully started.  On receiving this callback, you can call 
+ *      `-sendPingWithData:` to send pings.
+ *
+ *      If the object didn't start, `-simplePing:didFailWithError:` is called instead.
+ *  \param pinger The object issuing the callback.
+ *  \param address The address that's being pinged; at the time this delegate callback 
+ *      is made, this will have the same value as the `hostAddress` property.
+ */
+
+- (void)simplePing:(SimplePing *)pinger didStartWithAddress:(NSData *)address;
+
+/*! A SimplePing delegate callback, called if the object fails to start up.
+ *  \details This is called shortly after you start the object to tell you that the 
+ *      object has failed to start.  The most likely cause of failure is a problem 
+ *      resolving `hostName`.
+ *
+ *      By the time this callback is called, the object has stopped (that is, you don't 
+ *      need to call `-stop` yourself).
+ *  \param pinger The object issuing the callback.
+ *  \param error Describes the failure.
+ */
+    
+- (void)simplePing:(SimplePing *)pinger didFailWithError:(NSError *)error;
+
+/*! A SimplePing delegate callback, called when the object has successfully sent a ping packet. 
+ *  \details Each call to `-sendPingWithData:` will result in either a 
+ *      `-simplePing:didSendPacket:sequenceNumber:` delegate callback or a 
+ *      `-simplePing:didFailToSendPacket:sequenceNumber:error:` delegate callback (unless you 
+ *      stop the object before you get the callback).  These callbacks are currently delivered 
+ *      synchronously from within `-sendPingWithData:`, but this synchronous behaviour is not 
+ *      considered API.
+ *  \param pinger The object issuing the callback.
+ *  \param packet The packet that was sent; this includes the ICMP header (`ICMPHeader`) and the 
+ *      data you passed to `-sendPingWithData:` but does not include any IP-level headers.
+ *  \param sequenceNumber The ICMP sequence number of that packet.
+ */
+
+- (void)simplePing:(SimplePing *)pinger didSendPacket:(NSData *)packet sequenceNumber:(uint16_t)sequenceNumber;
+
+/*! A SimplePing delegate callback, called when the object fails to send a ping packet. 
+ *  \details Each call to `-sendPingWithData:` will result in either a 
+ *      `-simplePing:didSendPacket:sequenceNumber:` delegate callback or a 
+ *      `-simplePing:didFailToSendPacket:sequenceNumber:error:` delegate callback (unless you 
+ *      stop the object before you get the callback).  These callbacks are currently delivered 
+ *      synchronously from within `-sendPingWithData:`, but this synchronous behaviour is not 
+ *      considered API.
+ *  \param pinger The object issuing the callback.
+ *  \param packet The packet that was not sent; see `-simplePing:didSendPacket:sequenceNumber:` 
+ *      for details.
+ *  \param sequenceNumber The ICMP sequence number of that packet.
+ *  \param error Describes the failure.
+ */
+
+- (void)simplePing:(SimplePing *)pinger didFailToSendPacket:(NSData *)packet sequenceNumber:(uint16_t)sequenceNumber error:(NSError *)error;
+
+/*! A SimplePing delegate callback, called when the object receives a ping response.
+ *  \details If the object receives an ping response that matches a ping request that it 
+ *      sent, it informs the delegate via this callback.  Matching is primarily done based on 
+ *      the ICMP identifier, although other criteria are used as well.
+ *  \param pinger The object issuing the callback.
+ *  \param packet The packet received; this includes the ICMP header (`ICMPHeader`) and any data that 
+ *      follows that in the ICMP message but does not include any IP-level headers.
+ *  \param sequenceNumber The ICMP sequence number of that packet.
+ */
+
+- (void)simplePing:(SimplePing *)pinger didReceivePingResponsePacket:(NSData *)packet sequenceNumber:(uint16_t)sequenceNumber;
+
+/*! A SimplePing delegate callback, called when the object receives an unmatched ICMP message.
+ *  \details If the object receives an ICMP message that does not match a ping request that it 
+ *      sent, it informs the delegate via this callback.  The nature of ICMP handling in a 
+ *      BSD kernel makes this a common event because, when an ICMP message arrives, it is 
+ *      delivered to all ICMP sockets.
+ *
+ *      IMPORTANT: This callback is especially common when using IPv6 because IPv6 uses ICMP 
+ *      for important network management functions.  For example, IPv6 routers periodically 
+ *      send out Router Advertisement (RA) packets via Neighbor Discovery Protocol (NDP), which 
+ *      is implemented on top of ICMP.
+ *
+ *      For more on matching, see the discussion associated with 
+ *      `-simplePing:didReceivePingResponsePacket:sequenceNumber:`.
+ *  \param pinger The object issuing the callback.
+ *  \param packet The packet received; this includes the ICMP header (`ICMPHeader`) and any data that 
+ *      follows that in the ICMP message but does not include any IP-level headers.
+ */
+
+- (void)simplePing:(SimplePing *)pinger didReceiveUnexpectedPacket:(NSData *)packet;
+
+@end
+
+#pragma mark * ICMP On-The-Wire Format
+
+/*! Describes the on-the-wire header format for an ICMP ping.
+ *  \details This defines the header structure of ping packets on the wire.  Both IPv4 and 
+ *      IPv6 use the same basic structure.  
+ *  
+ *      This is declared in the header because clients of SimplePing might want to use 
+ *      it parse received ping packets.
+ */
+
+struct ICMPHeader {
+    uint8_t     type;
+    uint8_t     code;
+    uint16_t    checksum;
+    uint16_t    identifier;
+    uint16_t    sequenceNumber;
+    // data...
+};
+typedef struct ICMPHeader ICMPHeader;
+
+__Check_Compile_Time(sizeof(ICMPHeader) == 8);
+__Check_Compile_Time(offsetof(ICMPHeader, type) == 0);
+__Check_Compile_Time(offsetof(ICMPHeader, code) == 1);
+__Check_Compile_Time(offsetof(ICMPHeader, checksum) == 2);
+__Check_Compile_Time(offsetof(ICMPHeader, identifier) == 4);
+__Check_Compile_Time(offsetof(ICMPHeader, sequenceNumber) == 6);
+
+enum {
+    ICMPv4TypeEchoRequest = 8,          ///< The ICMP `type` for a ping request; in this case `code` is always 0.
+    ICMPv4TypeEchoReply   = 0           ///< The ICMP `type` for a ping response; in this case `code` is always 0.
+};
+
+enum {
+    ICMPv6TypeEchoRequest = 128,        ///< The ICMP `type` for a ping request; in this case `code` is always 0.
+    ICMPv6TypeEchoReply   = 129         ///< The ICMP `type` for a ping response; in this case `code` is always 0.
+};
+
+NS_ASSUME_NONNULL_END

--- a/extensions/network/ping/SimplePing.m
+++ b/extensions/network/ping/SimplePing.m
@@ -1,0 +1,782 @@
+/*
+    Copyright (C) 2016 Apple Inc. All Rights Reserved.
+    See LICENSE.txt for this sample’s licensing information
+    
+    Abstract:
+    An object wrapper around the low-level BSD Sockets ping function.
+ */
+
+#import "SimplePing.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <errno.h>
+
+#pragma mark * IPv4 and ICMPv4 On-The-Wire Format
+
+/*! Describes the on-the-wire header format for an IPv4 packet.
+ *  \details This defines the header structure of IPv4 packets on the wire.  We need 
+ *      this in order to skip this header in the IPv4 case, where the kernel passes 
+ *      it to us for no obvious reason.
+ */
+ 
+struct IPv4Header {
+    uint8_t     versionAndHeaderLength;
+    uint8_t     differentiatedServices;
+    uint16_t    totalLength;
+    uint16_t    identification;
+    uint16_t    flagsAndFragmentOffset;
+    uint8_t     timeToLive;
+    uint8_t     protocol;
+    uint16_t    headerChecksum;
+    uint8_t     sourceAddress[4];
+    uint8_t     destinationAddress[4];
+    // options...
+    // data...
+};
+typedef struct IPv4Header IPv4Header;
+
+__Check_Compile_Time(sizeof(IPv4Header) == 20);
+__Check_Compile_Time(offsetof(IPv4Header, versionAndHeaderLength) == 0);
+__Check_Compile_Time(offsetof(IPv4Header, differentiatedServices) == 1);
+__Check_Compile_Time(offsetof(IPv4Header, totalLength) == 2);
+__Check_Compile_Time(offsetof(IPv4Header, identification) == 4);
+__Check_Compile_Time(offsetof(IPv4Header, flagsAndFragmentOffset) == 6);
+__Check_Compile_Time(offsetof(IPv4Header, timeToLive) == 8);
+__Check_Compile_Time(offsetof(IPv4Header, protocol) == 9);
+__Check_Compile_Time(offsetof(IPv4Header, headerChecksum) == 10);
+__Check_Compile_Time(offsetof(IPv4Header, sourceAddress) == 12);
+__Check_Compile_Time(offsetof(IPv4Header, destinationAddress) == 16);
+
+/*! Calculates an IP checksum.
+ *  \details This is the standard BSD checksum code, modified to use modern types.
+ *  \param buffer A pointer to the data to checksum.
+ *  \param bufferLen The length of that data.
+ *  \returns The checksum value, in network byte order.
+ */
+
+static uint16_t in_cksum(const void *buffer, size_t bufferLen) {
+    // 
+	size_t              bytesLeft;
+    int32_t             sum;
+	const uint16_t *    cursor;
+	union {
+		uint16_t        us;
+		uint8_t         uc[2];
+	} last;
+	uint16_t            answer;
+
+	bytesLeft = bufferLen;
+	sum = 0;
+	cursor = buffer;
+
+	/*
+	 * Our algorithm is simple, using a 32 bit accumulator (sum), we add
+	 * sequential 16 bit words to it, and at the end, fold back all the
+	 * carry bits from the top 16 bits into the lower 16 bits.
+	 */
+	while (bytesLeft > 1) {
+		sum += *cursor;
+        cursor += 1;
+		bytesLeft -= 2;
+	}
+
+	/* mop up an odd byte, if necessary */
+	if (bytesLeft == 1) {
+		last.uc[0] = * (const uint8_t *) cursor;
+		last.uc[1] = 0;
+		sum += last.us;
+	}
+
+	/* add back carry outs from top 16 bits to low 16 bits */
+	sum = (sum >> 16) + (sum & 0xffff);	/* add hi 16 to low 16 */
+	sum += (sum >> 16);			/* add carry */
+	answer = (uint16_t) ~sum;   /* truncate to 16 bits */
+
+	return answer;
+}
+
+#pragma mark * SimplePing
+
+@interface SimplePing ()
+
+// read/write versions of public properties
+
+@property (nonatomic, copy,   readwrite, nullable) NSData *     hostAddress;
+@property (nonatomic, assign, readwrite          ) uint16_t     nextSequenceNumber;
+
+// private properties
+
+/*! True if nextSequenceNumber has wrapped from 65535 to 0.
+ */
+ 
+@property (nonatomic, assign, readwrite)           BOOL         nextSequenceNumberHasWrapped;
+
+/*! A host object for name-to-address resolution.
+ */
+
+@property (nonatomic, strong, readwrite, nullable) CFHostRef host __attribute__ ((NSObject));
+
+/*! A socket object for ICMP send and receive.
+ */
+
+@property (nonatomic, strong, readwrite, nullable) CFSocketRef socket __attribute__ ((NSObject));
+
+@end
+
+@implementation SimplePing
+
+- (instancetype)initWithHostName:(NSString *)hostName {
+    NSParameterAssert(hostName != nil);
+    self = [super init];
+    if (self != nil) {
+        self->_hostName   = [hostName copy];
+        self->_identifier = (uint16_t) arc4random();
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [self stop];
+    // Double check that -stop took care of _host and _socket.
+    assert(self->_host == NULL);
+    assert(self->_socket == NULL);
+}
+
+- (sa_family_t)hostAddressFamily {
+    sa_family_t     result;
+    
+    result = AF_UNSPEC;
+    if ( (self.hostAddress != nil) && (self.hostAddress.length >= sizeof(struct sockaddr)) ) {
+        result = ((const struct sockaddr *) self.hostAddress.bytes)->sa_family;
+    }
+    return result;
+}
+
+/*! Shuts down the pinger object and tell the delegate about the error.
+ *  \param error Describes the failure.
+ */
+
+- (void)didFailWithError:(NSError *)error {
+    id<SimplePingDelegate>  strongDelegate;
+    
+    assert(error != nil);
+    
+    // We retain ourselves temporarily because it's common for the delegate method 
+    // to release its last reference to us, which causes -dealloc to be called here. 
+    // If we then reference self on the return path, things go badly.  I don't think 
+    // that happens currently, but I've got into the habit of doing this as a 
+    // defensive measure.
+    
+    CFAutorelease( CFBridgingRetain( self ));
+    
+    [self stop];
+    strongDelegate = self.delegate;
+    if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didFailWithError:)] ) {
+        [strongDelegate simplePing:self didFailWithError:error];
+    }
+}
+
+/*! Shuts down the pinger object and tell the delegate about the error.
+ *  \details This converts the CFStreamError to an NSError and then call through to 
+ *      -didFailWithError: to do the real work.
+ *  \param streamError Describes the failure.
+ */
+
+- (void)didFailWithHostStreamError:(CFStreamError)streamError {
+    NSDictionary *  userInfo;
+    NSError *       error;
+
+    if (streamError.domain == kCFStreamErrorDomainNetDB) {
+        userInfo = @{(id) kCFGetAddrInfoFailureKey: @(streamError.error)};
+    } else {
+        userInfo = nil;
+    }
+    error = [NSError errorWithDomain:(NSString *) kCFErrorDomainCFNetwork code:kCFHostErrorUnknown userInfo:userInfo];
+
+    [self didFailWithError:error];
+}
+
+/*! Builds a ping packet from the supplied parameters.
+ *  \param type The packet type, which is different for IPv4 and IPv6.
+ *  \param payload Data to place after the ICMP header.
+ *  \param requiresChecksum Determines whether a checksum is calculated (IPv4) or not (IPv6).
+ *  \returns A ping packet suitable to be passed to the kernel.
+ */
+
+- (NSData *)pingPacketWithType:(uint8_t)type payload:(NSData *)payload requiresChecksum:(BOOL)requiresChecksum {
+    NSMutableData *         packet;
+    ICMPHeader *            icmpPtr;
+
+    packet = [NSMutableData dataWithLength:sizeof(*icmpPtr) + payload.length];
+    assert(packet != nil);
+
+    icmpPtr = packet.mutableBytes;
+    icmpPtr->type = type;
+    icmpPtr->code = 0;
+    icmpPtr->checksum = 0;
+    icmpPtr->identifier     = OSSwapHostToBigInt16(self.identifier);
+    icmpPtr->sequenceNumber = OSSwapHostToBigInt16(self.nextSequenceNumber);
+    memcpy(&icmpPtr[1], [payload bytes], [payload length]);
+    
+    if (requiresChecksum) {
+        // The IP checksum routine returns a 16-bit number that's already in correct byte order 
+        // (due to wacky 1's complement maths), so we just put it into the packet as a 16-bit unit.
+        
+        icmpPtr->checksum = in_cksum(packet.bytes, packet.length);
+    }
+    
+    return packet;
+}
+
+- (void)sendPingWithData:(NSData *)data {
+    int                     err;
+    NSData *                payload;
+    NSData *                packet;
+    ssize_t                 bytesSent;
+    id<SimplePingDelegate>  strongDelegate;
+    
+    // data may be nil
+    NSParameterAssert(self.hostAddress != nil);     // gotta wait for -simplePing:didStartWithAddress:
+    
+    // Construct the ping packet.
+    
+    payload = data;
+    if (payload == nil) {
+        payload = [[NSString stringWithFormat:@"%28zd bottles of beer on the wall", (ssize_t) 99 - (size_t) (self.nextSequenceNumber % 100) ] dataUsingEncoding:NSASCIIStringEncoding];
+        assert(payload != nil);
+        
+        // Our dummy payload is sized so that the resulting ICMP packet, including the ICMPHeader, is 
+        // 64-bytes, which makes it easier to recognise our packets on the wire.
+        
+        assert([payload length] == 56);
+    }
+    
+    switch (self.hostAddressFamily) {
+        case AF_INET: {
+            packet = [self pingPacketWithType:ICMPv4TypeEchoRequest payload:payload requiresChecksum:YES];
+        } break;
+        case AF_INET6: {
+            packet = [self pingPacketWithType:ICMPv6TypeEchoRequest payload:payload requiresChecksum:NO];
+        } break;
+        default: {
+            assert(NO);
+        } break;
+    }
+    assert(packet != nil);
+
+    // Send the packet.
+    
+    if (self.socket == NULL) {
+        bytesSent = -1;
+        err = EBADF;
+    } else {
+        bytesSent = sendto(
+            CFSocketGetNative(self.socket),
+            packet.bytes,
+            packet.length, 
+            0,
+            self.hostAddress.bytes, 
+            (socklen_t) self.hostAddress.length
+        );
+        err = 0;
+        if (bytesSent < 0) {
+            err = errno;
+        }
+    }
+
+    // Handle the results of the send.
+    
+    strongDelegate = self.delegate;
+    if ( (bytesSent > 0) && (((NSUInteger) bytesSent) == packet.length) ) {
+
+        // Complete success.  Tell the client.
+
+        if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didSendPacket:sequenceNumber:)] ) {
+            [strongDelegate simplePing:self didSendPacket:packet sequenceNumber:self.nextSequenceNumber];
+        }
+    } else {
+        NSError *   error;
+        
+        // Some sort of failure.  Tell the client.
+        
+        if (err == 0) {
+            err = ENOBUFS;          // This is not a hugely descriptor error, alas.
+        }
+        error = [NSError errorWithDomain:NSPOSIXErrorDomain code:err userInfo:nil];
+        if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didFailToSendPacket:sequenceNumber:error:)] ) {
+            [strongDelegate simplePing:self didFailToSendPacket:packet sequenceNumber:self.nextSequenceNumber error:error];
+        }
+    }
+    
+    self.nextSequenceNumber += 1;
+    if (self.nextSequenceNumber == 0) {
+        self.nextSequenceNumberHasWrapped = YES;
+    }
+}
+
+/*! Calculates the offset of the ICMP header within an IPv4 packet.
+ *  \details In the IPv4 case the kernel returns us a buffer that includes the 
+ *      IPv4 header.  We're not interested in that, so we have to skip over it. 
+ *      This code does a rough check of the IPv4 header and, if it looks OK, 
+ *      returns the offset of the ICMP header.
+ *  \param packet The IPv4 packet, as returned to us by the kernel.
+ *  \returns The offset of the ICMP header, or NSNotFound.
+ */
+
++ (NSUInteger)icmpHeaderOffsetInIPv4Packet:(NSData *)packet {
+    // Returns the offset of the ICMPv4Header within an IP packet.
+    NSUInteger                  result;
+    const struct IPv4Header *   ipPtr;
+    size_t                      ipHeaderLength;
+    
+    result = NSNotFound;
+    if (packet.length >= (sizeof(IPv4Header) + sizeof(ICMPHeader))) {
+        ipPtr = (const IPv4Header *) packet.bytes;
+        if ( ((ipPtr->versionAndHeaderLength & 0xF0) == 0x40) &&            // IPv4
+             ( ipPtr->protocol == IPPROTO_ICMP ) ) {
+            ipHeaderLength = (ipPtr->versionAndHeaderLength & 0x0F) * sizeof(uint32_t);
+            if (packet.length >= (ipHeaderLength + sizeof(ICMPHeader))) {
+                result = ipHeaderLength;
+            }
+        }
+    }
+    return result;
+}
+
+/*! Checks whether the specified sequence number is one we sent.
+ *  \param sequenceNumber The incoming sequence number.
+ *  \returns YES if the sequence number looks like one we sent.
+ */
+ 
+- (BOOL)validateSequenceNumber:(uint16_t)sequenceNumber {
+    if (self.nextSequenceNumberHasWrapped) {
+        // If the sequence numbers have wrapped that we can't reliably check 
+        // whether this is a sequence number we sent.  Rather, we check to see 
+        // whether the sequence number is within the last 120 sequence numbers 
+        // we sent.  Note that the uint16_t subtraction here does the right 
+        // thing regardless of the wrapping.
+        // 
+        // Why 120?  Well, if we send one ping per second, 120 is 2 minutes, which 
+        // is the standard "max time a packet can bounce around the Internet" value.
+        return ((uint16_t) (self.nextSequenceNumber - sequenceNumber)) < (uint16_t) 120;
+    } else {
+        return sequenceNumber < self.nextSequenceNumber;
+    }
+}
+
+/*! Checks whether an incoming IPv4 packet looks like a ping response.
+ *  \details This routine modifies this `packet` data!  It does this for two reasons:
+ *
+ *      * It needs to zero out the `checksum` field of the ICMPHeader in order to do 
+ *          its checksum calculation.
+ *
+ *      * It removes the IPv4 header from the front of the packet.
+ *  \param packet The IPv4 packet, as returned to us by the kernel.
+ *  \param sequenceNumberPtr A pointer to a place to start the ICMP sequence number.
+ *  \returns YES if the packet looks like a reasonable IPv4 ping response.
+ */
+
+- (BOOL)validatePing4ResponsePacket:(NSMutableData *)packet sequenceNumber:(uint16_t *)sequenceNumberPtr {
+    BOOL                result;
+    NSUInteger          icmpHeaderOffset;
+    ICMPHeader *        icmpPtr;
+    uint16_t            receivedChecksum;
+    uint16_t            calculatedChecksum;
+    
+    result = NO;
+    
+    icmpHeaderOffset = [[self class] icmpHeaderOffsetInIPv4Packet:packet];
+    if (icmpHeaderOffset != NSNotFound) {
+        icmpPtr = (struct ICMPHeader *) (((uint8_t *) packet.mutableBytes) + icmpHeaderOffset);
+
+        receivedChecksum   = icmpPtr->checksum;
+        icmpPtr->checksum  = 0;
+        calculatedChecksum = in_cksum(icmpPtr, packet.length - icmpHeaderOffset);
+        icmpPtr->checksum  = receivedChecksum;
+        
+        if (receivedChecksum == calculatedChecksum) {
+            if ( (icmpPtr->type == ICMPv4TypeEchoReply) && (icmpPtr->code == 0) ) {
+                if ( OSSwapBigToHostInt16(icmpPtr->identifier) == self.identifier ) {
+                    uint16_t    sequenceNumber;
+                    
+                    sequenceNumber = OSSwapBigToHostInt16(icmpPtr->sequenceNumber);
+                    if ([self validateSequenceNumber:sequenceNumber]) {
+
+                        // Remove the IPv4 header off the front of the data we received, leaving us with 
+                        // just the ICMP header and the ping payload.
+                        [packet replaceBytesInRange:NSMakeRange(0, icmpHeaderOffset) withBytes:NULL length:0];
+
+                        *sequenceNumberPtr = sequenceNumber;
+                        result = YES;
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+/*! Checks whether an incoming IPv6 packet looks like a ping response.
+ *  \param packet The IPv6 packet, as returned to us by the kernel; note that this routine
+ *      could modify this data but does not need to in the IPv6 case.
+ *  \param sequenceNumberPtr A pointer to a place to start the ICMP sequence number.
+ *  \returns YES if the packet looks like a reasonable IPv4 ping response.
+ */
+
+- (BOOL)validatePing6ResponsePacket:(NSMutableData *)packet sequenceNumber:(uint16_t *)sequenceNumberPtr {
+    BOOL                    result;
+    const ICMPHeader *      icmpPtr;
+    
+    result = NO;
+    
+    if (packet.length >= sizeof(*icmpPtr)) {
+        icmpPtr = packet.bytes;
+        
+        // In the IPv6 case we don't check the checksum because that's hard (we need to 
+        // cook up an IPv6 pseudo header and we don't have the ingredients) and unnecessary 
+        // (the kernel has already done this check).
+        
+        if ( (icmpPtr->type == ICMPv6TypeEchoReply) && (icmpPtr->code == 0) ) {
+            if ( OSSwapBigToHostInt16(icmpPtr->identifier) == self.identifier ) {
+                uint16_t    sequenceNumber;
+                
+                sequenceNumber = OSSwapBigToHostInt16(icmpPtr->sequenceNumber);
+                if ([self validateSequenceNumber:sequenceNumber]) {
+                    *sequenceNumberPtr = sequenceNumber;
+                    result = YES;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+/*! Checks whether an incoming packet looks like a ping response.
+ *  \param packet The packet, as returned to us by the kernel; note that may end up modifying 
+ *      this data.
+ *  \param sequenceNumberPtr A pointer to a place to start the ICMP sequence number.
+ *  \returns YES if the packet looks like a reasonable IPv4 ping response.
+ */
+
+- (BOOL)validatePingResponsePacket:(NSMutableData *)packet sequenceNumber:(uint16_t *)sequenceNumberPtr {
+    BOOL        result;
+    
+    switch (self.hostAddressFamily) {
+        case AF_INET: {
+            result = [self validatePing4ResponsePacket:packet sequenceNumber:sequenceNumberPtr];
+        } break;
+        case AF_INET6: {
+            result = [self validatePing6ResponsePacket:packet sequenceNumber:sequenceNumberPtr];
+        } break;
+        default: {
+            assert(NO);
+            result = NO;
+        } break;
+    }
+    return result;
+}
+
+/*! Reads data from the ICMP socket.
+ *  \details Called by the socket handling code (SocketReadCallback) to process an ICMP 
+ *      message waiting on the socket.
+ */
+
+- (void)readData {
+    int                     err;
+    struct sockaddr_storage addr;
+    socklen_t               addrLen;
+    ssize_t                 bytesRead;
+    void *                  buffer;
+    enum { kBufferSize = 65535 };
+
+    // 65535 is the maximum IP packet size, which seems like a reasonable bound 
+    // here (plus it's what <x-man-page://8/ping> uses).
+    
+    buffer = malloc(kBufferSize);
+    assert(buffer != NULL);
+    
+    // Actually read the data.  We use recvfrom(), and thus get back the source address, 
+    // but we don't actually do anything with it.  It would be trivial to pass it to 
+    // the delegate but we don't need it in this example.
+    
+    addrLen = sizeof(addr);
+    bytesRead = recvfrom(CFSocketGetNative(self.socket), buffer, kBufferSize, 0, (struct sockaddr *) &addr, &addrLen);
+    err = 0;
+    if (bytesRead < 0) {
+        err = errno;
+    }
+    
+    // Process the data we read.
+    
+    if (bytesRead > 0) {
+        NSMutableData *         packet;
+        id<SimplePingDelegate>  strongDelegate;
+        uint16_t                sequenceNumber;
+
+        packet = [NSMutableData dataWithBytes:buffer length:(NSUInteger) bytesRead];
+        assert(packet != nil);
+
+        // We got some data, pass it up to our client.
+
+        strongDelegate = self.delegate;
+        if ( [self validatePingResponsePacket:packet sequenceNumber:&sequenceNumber] ) {
+            if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didReceivePingResponsePacket:sequenceNumber:)] ) {
+                [strongDelegate simplePing:self didReceivePingResponsePacket:packet sequenceNumber:sequenceNumber];
+            }
+        } else {
+            if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didReceiveUnexpectedPacket:)] ) {
+                [strongDelegate simplePing:self didReceiveUnexpectedPacket:packet];
+            }
+        }
+    } else {
+    
+        // We failed to read the data, so shut everything down.
+        
+        if (err == 0) {
+            err = EPIPE;
+        }
+        [self didFailWithError:[NSError errorWithDomain:NSPOSIXErrorDomain code:err userInfo:nil]];
+    }
+    
+    free(buffer);
+    
+    // Note that we don't loop back trying to read more data.  Rather, we just 
+    // let CFSocket call us again.
+}
+
+/*! The callback for our CFSocket object.
+ *  \details This simply routes the call to our `-readData` method.
+ *  \param s See the documentation for CFSocketCallBack.
+ *  \param type See the documentation for CFSocketCallBack.
+ *  \param address See the documentation for CFSocketCallBack.
+ *  \param data See the documentation for CFSocketCallBack.
+ *  \param info See the documentation for CFSocketCallBack; this is actually a pointer to the 
+ *      'owning' object.
+ */
+
+static void SocketReadCallback(CFSocketRef s, CFSocketCallBackType type, CFDataRef address, const void *data, void *info) {
+    // This C routine is called by CFSocket when there's data waiting on our 
+    // ICMP socket.  It just redirects the call to Objective-C code.
+    SimplePing *    obj;
+    
+    obj = (__bridge SimplePing *) info;
+    assert([obj isKindOfClass:[SimplePing class]]);
+    
+    #pragma unused(s)
+    assert(s == obj.socket);
+    #pragma unused(type)
+    assert(type == kCFSocketReadCallBack);
+    #pragma unused(address)
+    assert(address == nil);
+    #pragma unused(data)
+    assert(data == nil);
+    
+    [obj readData];
+}
+
+/*! Starts the send and receive infrastructure.
+ *  \details This is called once we've successfully resolved `hostName` in to 
+ *      `hostAddress`.  It's responsible for setting up the socket for sending and 
+ *      receiving pings.
+ */
+
+- (void)startWithHostAddress {
+    int                     err;
+    int                     fd;
+
+    assert(self.hostAddress != nil);
+
+    // Open the socket.
+    
+    fd = -1;
+    err = 0;
+    switch (self.hostAddressFamily) {
+        case AF_INET: {
+            fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+            if (fd < 0) {
+                err = errno;
+            }
+        } break;
+        case AF_INET6: {
+            fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_ICMPV6);
+            if (fd < 0) {
+                err = errno;
+            }
+        } break;
+        default: {
+            err = EPROTONOSUPPORT;
+        } break;
+    }
+    
+    if (err != 0) {
+        [self didFailWithError:[NSError errorWithDomain:NSPOSIXErrorDomain code:err userInfo:nil]];
+    } else {
+        CFSocketContext         context = {0, (__bridge void *)(self), NULL, NULL, NULL};
+        CFRunLoopSourceRef      rls;
+        id<SimplePingDelegate>  strongDelegate;
+        
+        // Wrap it in a CFSocket and schedule it on the runloop.
+        
+        self.socket = (CFSocketRef) CFAutorelease( CFSocketCreateWithNative(NULL, fd, kCFSocketReadCallBack, SocketReadCallback, &context) );
+        assert(self.socket != NULL);
+        
+        // The socket will now take care of cleaning up our file descriptor.
+        
+        assert( CFSocketGetSocketFlags(self.socket) & kCFSocketCloseOnInvalidate );
+        fd = -1;
+        
+        rls = CFSocketCreateRunLoopSource(NULL, self.socket, 0);
+        assert(rls != NULL);
+        
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), rls, kCFRunLoopDefaultMode);
+        
+        CFRelease(rls);
+
+        strongDelegate = self.delegate;
+        if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didStartWithAddress:)] ) {
+            [strongDelegate simplePing:self didStartWithAddress:self.hostAddress];
+        }
+    }
+    assert(fd == -1);
+}
+
+/*! Processes the results of our name-to-address resolution.
+ *  \details Called by our CFHost resolution callback (HostResolveCallback) when host 
+ *      resolution is complete.  We just latch the first appropriate address and kick 
+ *      off the send and receive infrastructure.
+ */
+
+- (void)hostResolutionDone {
+    Boolean     resolved;
+    NSArray *   addresses;
+    
+    // Find the first appropriate address.
+    
+    addresses = (__bridge NSArray *) CFHostGetAddressing(self.host, &resolved);
+    if ( resolved && (addresses != nil) ) {
+        resolved = false;
+        for (NSData * address in addresses) {
+            const struct sockaddr * addrPtr;
+            
+            addrPtr = (const struct sockaddr *) address.bytes;
+            if ( address.length >= sizeof(struct sockaddr) ) {
+                switch (addrPtr->sa_family) {
+                    case AF_INET: {
+                        if (self.addressStyle != SimplePingAddressStyleICMPv6) {
+                            self.hostAddress = address;
+                            resolved = true;
+                        }
+                    } break;
+                    case AF_INET6: {
+                        if (self.addressStyle != SimplePingAddressStyleICMPv4) {
+                            self.hostAddress = address;
+                            resolved = true;
+                        }
+                    } break;
+                }
+            }
+            if (resolved) {
+                break;
+            }
+        }
+    }
+
+    // We're done resolving, so shut that down.
+    
+    [self stopHostResolution];
+    
+    // If all is OK, start the send and receive infrastructure, otherwise stop.
+    
+    if (resolved) {
+        [self startWithHostAddress];
+    } else {
+        [self didFailWithError:[NSError errorWithDomain:(NSString *)kCFErrorDomainCFNetwork code:kCFHostErrorHostNotFound userInfo:nil]];
+    }
+}
+
+/*! The callback for our CFHost object.
+ *  \details This simply routes the call to our `-hostResolutionDone` or 
+ *      `-didFailWithHostStreamError:` methods.
+ *  \param theHost See the documentation for CFHostClientCallBack.
+ *  \param typeInfo See the documentation for CFHostClientCallBack.
+ *  \param error See the documentation for CFHostClientCallBack.
+ *  \param info See the documentation for CFHostClientCallBack; this is actually a pointer to 
+ *      the 'owning' object.
+ */
+
+static void HostResolveCallback(CFHostRef theHost, CFHostInfoType typeInfo, const CFStreamError *error, void *info) {
+    // This C routine is called by CFHost when the host resolution is complete. 
+    // It just redirects the call to the appropriate Objective-C method.
+    SimplePing *    obj;
+
+    obj = (__bridge SimplePing *) info;
+    assert([obj isKindOfClass:[SimplePing class]]);
+    
+    #pragma unused(theHost)
+    assert(theHost == obj.host);
+    #pragma unused(typeInfo)
+    assert(typeInfo == kCFHostAddresses);
+    
+    if ( (error != NULL) && (error->domain != 0) ) {
+        [obj didFailWithHostStreamError:*error];
+    } else {
+        [obj hostResolutionDone];
+    }
+}
+
+- (void)start {
+    Boolean             success;
+    CFHostClientContext context = {0, (__bridge void *)(self), NULL, NULL, NULL};
+    CFStreamError       streamError;
+    
+    assert(self.host == NULL);
+    assert(self.hostAddress == nil);
+
+    self.host = (CFHostRef) CFAutorelease( CFHostCreateWithName(NULL, (__bridge CFStringRef) self.hostName) );
+    assert(self.host != NULL);
+    
+    CFHostSetClient(self.host, HostResolveCallback, &context);
+    
+    CFHostScheduleWithRunLoop(self.host, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+    
+    success = CFHostStartInfoResolution(self.host, kCFHostAddresses, &streamError);
+    if ( ! success ) {
+        [self didFailWithHostStreamError:streamError];
+    }
+}
+
+/*! Stops the name-to-address resolution infrastructure.
+ */
+
+- (void)stopHostResolution {
+    // Shut down the CFHost.
+    if (self.host != NULL) {
+        CFHostSetClient(self.host, NULL, NULL);
+        CFHostUnscheduleFromRunLoop(self.host, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        self.host = NULL;
+    }
+}
+
+/*! Stops the send and receive infrastructure.
+ */
+
+- (void)stopSocket {
+    if (self.socket != NULL) {
+        CFSocketInvalidate(self.socket);
+        self.socket = NULL;
+    }
+}
+
+- (void)stop {
+    [self stopHostResolution];
+    [self stopSocket];
+    
+    // Junk the host address on stop.  If the client calls -start again, we'll 
+    // re-resolve the host name.
+    
+    self.hostAddress = NULL;
+}
+
+@end

--- a/extensions/network/ping/init.lua
+++ b/extensions/network/ping/init.lua
@@ -1,0 +1,497 @@
+
+--- === hs.network.ping ===
+---
+--- This module provides a basic ping function which can test host availability. Ping is a network diagnostic tool commonly found in most operating systems which can be used to test if a route to a specified host exists and if that host is responding to network traffic.
+
+local USERDATA_TAG = "hs.network.ping"
+local module       = {}
+module.echoRequest = setmetatable(require(USERDATA_TAG..".internal"), {
+    __call = function(self, ...) return self.echoRequest(...) end
+})
+
+local fnutils      = require("hs.fnutils")
+local timer        = require("hs.timer")
+local inspect      = require("hs.inspect")
+
+local log          = require"hs.logger".new(USERDATA_TAG, "warning")
+module.log = log
+
+-- private variables and methods -----------------------------------------
+
+local validClasses = { "any", "IPv4", "IPv6" }
+
+local internals = setmetatable({}, { __mode = "k" })
+
+local basicPingCompletionFunction = function(self)
+    -- most likely this has already happened, unless called through cancel method
+    if getmetatable(internals[self].pingTimer) then internals[self].pingTimer:stop() end
+    internals[self].pingTimer = nil
+    internals[self].callback(self, "didFinish")
+    -- theoretically a packet could be received out of order, but since we're ending,
+    -- clear callback to make sure it can't be invoked again by something in the queue
+    internals[self].pingObject:setCallback(nil):stop()
+    internals[self].pingObject = nil
+    -- use pairs just in case we're missing a sequence number...
+    for k, v in pairs(internals[self].timeouts) do
+        if getmetatable(v) then v:stop() end
+    end
+    internals[self].timeouts = {}
+end
+
+local basicPingSummary = function(self)
+    local packets, results, transmitted, received = self:packets(), "", 0, 0
+    local min, max, avg = math.huge, -math.huge, 0
+    for i, v in pairs(packets) do
+        transmitted = transmitted + 1
+        if v.recv then
+            received = received + 1
+            local rt = v.recv - v.sent
+            min = math.min(min, rt)
+            max = math.max(max, rt)
+            avg = avg + rt
+        end
+    end
+    avg = avg / transmitted
+    min, max, avg = min * 1000, max * 1000, avg * 1000
+    results = results .. "--- " .. self:server() .. " ping statistics ---\n" ..
+            string.format("%d packets transmitted, %d packets received, %.1f packet loss\n",
+                transmitted, received, 100.0 * ((transmitted - received) / transmitted)
+            ) ..
+            string.format("round-trip min/avg/max = %.3f/%.3f/%.3f ms", min, avg, max)
+    return results
+end
+
+local pingObjectMT
+pingObjectMT = {
+--- hs.network.ping:pause() -> pingObject | nil
+--- Method
+--- Pause an in progress ping process.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * if the ping process is currently active, returns the pingObject; if the process has already completed, returns nil.
+    pause = function(self)
+        if getmetatable(internals[self].pingTimer) then
+            internals[self].paused = true
+            return self
+        else
+            return nil
+        end
+    end,
+
+--- hs.network.ping:resume() -> pingObject | nil
+--- Method
+--- Resume an in progress ping process, if it has been paused.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * if the ping process is currently active, returns the pingObject; if the process has already completed, returns nil.
+    resume = function(self)
+        if getmetatable(internals[self].pingTimer) then
+            internals[self].paused = nil
+            return self
+        else
+            return nil
+        end
+    end,
+
+--- hs.network.ping:count([count]) -> integer | pingObject | nil
+--- Method
+--- Get or set the number of ICMP Echo Requests that will be sent by the ping process
+---
+--- Parameters:
+---  * `count` - an optional integer specifying the total number of echo requests that the ping process should send. If specified, this number must be greater than the number of requests already sent.
+---
+--- Returns:
+---  * if no argument is specified, returns the current number of echo requests the ping process will send; if an argument is specified and the ping process has not completed, returns the pingObject; if the ping process has already completed, then this method returns nil.
+    count = function(self, num)
+        if type(num) == "nil" then
+            return internals[self].maxCount
+        elseif getmetatable(internals[self].pingTimer) then
+            if math.type(num) == "integer" and num > internals[self].sentCount then
+                internals[self].maxCount = num
+                internals[self].allSent = false
+                return self
+            else
+                error(string.format("must be an integer > %d", internals[self].sentCount), 2)
+            end
+        else
+            return nil
+        end
+    end,
+
+--- hs.network.ping:sent() -> integer
+--- Method
+--- Returns the number of ICMP Echo Requests which have been sent.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The number of echo requests which have been sent so far.
+    sent = function(self)
+        return internals[self].sentCount
+    end,
+
+--- hs.network.ping:server() -> string
+--- Method
+--- Returns the hostname or ip address string given to the [hs.network.ping.ping](#ping) constructor.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * A string matching the hostname or ip address given to the [hs.network.ping.ping](#ping) constructor for this object.
+    server = function(self)
+        return internals[self].hostname
+    end,
+
+--- hs.network.ping:isRunning() -> boolean
+--- Method
+--- Returns whether or not the ping process is currently active.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * A boolean indicating if the ping process is active (true) or not (false)
+---
+--- Notes:
+---  * This method will return false only if the ping process has finished sending all echo requests or if it has been cancelled with [hs.network.ping:cancel](#cancel).  To determine if the process is currently sending out echo requests, see [hs.network.ping:isPaused](#isPaused).
+    isRunning = function(self)
+        return not internals[self].allSent
+    end,
+
+--- hs.network.ping:isPaused() -> boolean
+--- Method
+--- Returns whether or not the ping process is currently paused.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * A boolean indicating if the ping process is paused (true) or not (false)
+    isPaused = function(self)
+        return not internals[self].paused
+    end,
+
+--- hs.network.ping:address() -> string
+--- Method
+--- Returns a string containing the resolved IPv4 or IPv6 address this pingObject is sending echo requests to.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * A string containing the IPv4 or IPv6 address this pingObject is sending echo requests to or "<unresolved address>" if the address cannot be resolved.
+    address = function(self)
+        return internals[self].address
+    end,
+
+--- hs.network.ping:packets([sequenceNumber]) -> table
+--- Method
+--- Returns a table containing information about the ICMP Echo packets sent by this pingObject.
+---
+--- Parameters:
+---  * `sequenceNumber` - an optional integer specifying the sequence number of the ICMP Echo packet to return information about.
+---
+--- Returns:
+---  * If `sequenceNumber` is specified, returns a table with key-value pairs containing information about the specific ICMP Echo packet with that sequence number, or an empty table if no packet with that sequence number has been sent yet. If no sequence number is specified, returns an array table of all ICMP Echo packets this object has sent.
+---
+--- Notes:
+---  * Sequence numbers start at 0 while Lua array tables are indexed starting at 1. If you do not specify a `sequenceNumber` to this method, index 1 of the array table returned will contain a table describing the ICMP Echo packet with sequence number 0, index 2 will describe the ICMP Echo packet with sequence number 1, etc.
+---
+---  * An ICMP Echo packet table will have the following key-value pairs:
+---    * `sent`           - a number specifying the time at which the echo request for this packet was sent. This number is the number of seconds since January 1, 1970 at midnight, GMT, and is a floating point number, so you should use `math.floor` on this number before using it as an argument to Lua's `os.date` function.
+---    * `recv`           - a number specifying the time at which the echo reply for this packet was received. This number is the number of seconds since January 1, 1970 at midnight, GMT, and is a floating point number, so you should use `math.floor` on this number before using it as an argument to Lua's `os.date` function.
+---    * `icmp`           - a table provided by the `hs.network.ping.echoRequest` object which contains the details about the specific ICMP packet this entry corresponds to. It will contain the following keys:
+---      * `checksum`       - The ICMP packet checksum used to ensure data integrity.
+---      * `code`           - ICMP Control Message Code. Should always be 0.
+---      * `identifier`     - The ICMP Identifier generated internally for matching request and reply packets.
+---      * `payload`        - A string containing the ICMP payload for this packet. This has been constructed to cause the ICMP packet to be exactly 64 bytes to match the convention for ICMP Echo Requests.
+---      * `sequenceNumber` - The ICMP Sequence Number for this packet.
+---      * `type`           - ICMP Control Message Type. For ICMPv4, this will be 0 if a reply has been received or 8 no reply has been received yet. For ICMPv6, this will be 129 if a reply has been received or 128 if no reply has been received yet.
+---      * `_raw`           - A string containing the ICMP packet as raw data.
+    packets = function(self, sequence)
+        if sequence then
+            return internals[self].packets[sequence + 1] or {}
+        else
+            return internals[self].packets
+        end
+    end,
+
+--- hs.network.ping:summary() -> string
+--- Method
+--- Returns a string containing summary information about the ping process.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * a summary string for the current state of the ping process
+---
+--- Notes:
+---  * The summary string will look similar to the following:
+--- ~~~
+--- --- hostname ping statistics ---
+--- 5 packets transmitted, 5 packets received, 0.0 packet loss
+--- round-trip min/avg/max = 2.282/4.133/4.926 ms
+--- ~~~
+---  * The numer of packets received will match the number that has currently been sent, not necessarily the value returned by [hs.network.ping:count](#count).
+    summary = basicPingSummary,
+
+--- hs.network.ping:cancel() -> none
+--- Method
+--- Cancels an in progress ping process, terminating it immediately
+---
+--- Paramters:
+---  * None
+---
+--- Returns:
+---  * None
+---
+--- Notes:
+---  * the `didFinish` message will be sent to the callback function as its final message.
+    cancel  = basicPingCompletionFunction,
+
+    __name = USERDATA_TAG,
+    __type = USERDATA_TAG,
+    __index = function(self, key)
+        return pingObjectMT[key] or nil
+    end,
+    __tostring = function(self)
+        return string.format("%s: %s (%s)", USERDATA_TAG, internals[self].hostname, internals[self].label)
+    end,
+}
+
+local _defaultCallback = function(self, msg, ...)
+    if msg == "didStart" then
+        print("PING: " .. self:server() .. " (" .. self:address() .. "):")
+    elseif msg == "didFail" then
+        local err = ...
+        print("PING: " .. self:address() .. " error: " .. err)
+        print(basicPingSummary(self))
+    elseif msg == "sendPacketFailed" then
+        local seq, err = ...
+        local singleStat = self:packets(seq)
+        print(string.format("%d bytes to   %s: icmp_seq=%d %s.",
+            #singleStat.icmp._raw,
+            self:address(),
+            singleStat.icmp.sequenceNumber,
+            err
+        ))
+    elseif msg == "receivedPacket" then
+        local seq = ...
+        local singleStat = self:packets(seq)
+        print(string.format("%d bytes from %s: icmp_seq=%d time=%.3f ms",
+            #singleStat.icmp._raw,
+            self:address(),
+            singleStat.icmp.sequenceNumber,
+            (singleStat.recv - singleStat.sent) * 1000
+        ))
+    elseif msg == "didFinish" then
+        print(basicPingSummary(self))
+    end
+end
+
+-- Public interface ------------------------------------------------------
+
+--- hs.network.ping.ping(server, [count], [interval], [timeout], [class], [fn]) -> pingObject
+--- Constructor
+--- Test server availability by pinging it with ICMP Echo Requests.
+---
+--- Parameters:
+---  * `server`   - a string containing the hostname or ip address of the server to test. Both IPv4 and IPv6 addresses are supported.
+---  * `count`    - an optional integer, default 5, specifying the number of ICMP Echo Requests to send to the server.
+---  * `interval` - an optional number, default 1.0, in seconds specifying the delay between the sending of each echo request. To set this parameter, you must supply `count` as well.
+---  * `timeout`  - an optional number, default 2.0, in seconds specifying how long before an echo reply is considered to have timed-out. To set this parameter, you must supply `count` and `interval` as well.
+---  * `class`    - an optional string, default "any", specifying whether IPv4 or IPv6 should be used to send the ICMP packets. The string must be one of the following:
+---    * `any`  - uses the IP version which corresponds to the first address the `server` resolves to
+---    * `IPv4` - use IPv4; if `server` cannot resolve to an IPv4 address, or if IPv4 traffic is not supported on the network, the ping will fail with an error.
+---    * `IPv6` - use IPv6; if `server` cannot resolve to an IPv6 address, or if IPv6 traffic is not supported on the network, the ping will fail with an error.
+---  * `fn`       - the callback function which receives update messages for the ping process. See the Notes for details regarding the callback function.
+---
+--- Returns:
+---  * a pingObject
+---
+--- Notes:
+---  * For convenience, you can call this constructor as `hs.network.ping(server, ...)`
+---  * the full ping process will take at most `count` * `interval` + `timeout` seconds from `didStart` to `didFinish`.
+---
+---  * the default callback function, if `fn` is not specified, prints the results of each echo reply as they are received to the Hammerspoon console and a summary once completed. The output should be familiar to anyone who has used `ping` from the command line.
+---
+---  * If you provide your own callback function, it should expect between 2 and 4 arguments and return none. The possible arguments which are sent will be one of the following:
+---
+---    * "didStart" - indicates that address resolution has completed and the ping will begin sending ICMP Echo Requests.
+---      * `object`  - the ping object the callback is for
+---      * `message` - the message to the callback, in this case "didStart"
+---
+---    * "didFail" - indicates that the ping process has failed, most likely due to a failure in address resolution or because the network connection has dropped.
+---      * `object`  - the ping object the callback is for
+---      * `message` - the message to the callback, in this case "didFail"
+---      * `error`   - a string containing the error message that has occurred
+---
+---    * "sendPacketFailed" - indicates that a specific ICMP Echo Request has failed for some reason.
+---      * `object`         - the ping object the callback is for
+---      * `message`        - the message to the callback, in this case "sendPacketFailed"
+---      * `sequenceNumber` - the sequence number of the ICMP packet which has failed to send
+---      * `error`          - a string containing the error message that has occurred
+---
+---    * "receivedPacket" - indicates that an ICMP Echo Request has received the expected ICMP Echo Reply
+---      * `object`         - the ping object the callback is for
+---      * `message`        - the message to the callback, in this case "receivedPacket"
+---      * `sequenceNumber` - the sequence number of the ICMP packet received
+---
+---    * "didFinish" - indicates that the ping has finished sending all ICMP Echo Requests or has been cancelled
+---      * `object`  - the ping object the callback is for
+---      * `message` - the message to the callback, in this case "didFinish"
+module.ping = function(server, ...)
+    assert(type(server) == "string", "server must be a string")
+    local count, interval, timeout, class, fn = 5, 1, 2, "any", module._defaultCallback
+
+    local args = table.pack(...)
+    local seenCount, seenInterval, seenTimeout, seenClass, seenFn = false, false, false, false
+    while #args > 0 do
+        local this = table.remove(args, 1)
+        if type(this) == "number" then
+            if not seenCount then
+                count = this
+                assert(math.type(count) == "integer" and count > 0, "count must be an integer > 0")
+                seenCount = true
+            elseif not seenInterval then
+                interval = this
+                assert(type(interval) == "number" and interval > 0, "interval must be a number > 0")
+                seenInterval = true
+            elseif not seenTimeout then
+                timeout = this
+                assert(type(timeout) == "number" and timeout > 0, "timeout must be a number > 0")
+                seenTimeout = true
+            else
+                error("unexpected numerical argument", 2)
+            end
+        elseif type(this) == "string" then
+            if not seenClass then
+                class = this
+                assert(fnutils.contains(validClasses, class),
+                    "class must be one of '" .. table.concat(validClasses, "', '") .. "'")
+                seenClass = true
+            else
+                error("unexpected string argument", 2)
+            end
+    -- this also allows a table or userdata with a __call metamethod to be considered a function
+        elseif (getmetatable(this) or {}).__call or type(this) == "function" then
+            if not seenFn then
+                fn = this
+                seenfn = true
+            else
+                error("unexpected function argument", 2)
+            end
+        else
+            error("unexpected " .. type(this) .. " argument", 2)
+        end
+    end
+
+    local self = { "placeholder for pingObject" }
+    internals[self] = {
+        packets   = {},
+        hostname  = server,
+        address   = "<unresolved address>",
+        allSent   = false,
+        callback  = fn,
+        label     = tostring(self):match("^table: (.+)$"),
+        sentCount = 0,
+        maxCount  = count,
+        timeouts  = {},
+    }
+
+    internals[self].pingObject = module.echoRequest(server):acceptAddressFamily(class):setCallback(function(obj, msg, ...)
+        if msg == "didStart" then
+            local address = ...
+            internals[self].address = address
+            internals[self].callback(self, msg)
+        elseif msg == "didFail" then
+            local err = ...
+            if getmetatable(internals[self].pingTimer) then internals[self].pingTimer:stop() end
+            internals[self].pingTimer = nil
+            -- we don't have to stop because the fail callback has already done it for us
+            internals[self].pingObject = nil
+            internals[self].callback(self, msg, err)
+        elseif msg == "sendPacket" then
+            local icmp, seq = ...
+            internals[self].packets[seq + 1] = {
+                sent           = timer.secondsSinceEpoch(),
+                icmp           = icmp,
+            }
+            internals[self].timeouts[seq + 1] = timer.doAfter(timeout, function()
+                internals[self].packets[seq + 1].err = "packet timeout exceeded"
+                internals[self].timeouts[seq + 1] = nil
+                if internals[self].allSent then basicPingCompletionFunction(self) end
+            end)
+            -- no callback in simplified version
+        elseif msg == "sendPacketFailed" then
+            local icmp, seq, err = ...
+            internals[self].packets[seq + 1] = {
+                sent = timer.secondsSinceEpoch(),
+                err  = err,
+                icmp = icmp,
+            }
+            internals[self].callback(self, msg, seq, err)
+        elseif msg == "receivedPacket" then
+            local icmp, seq = ...
+            internals[self].packets[seq + 1].recv = timer.secondsSinceEpoch()
+            internals[self].packets[seq + 1].icmp = icmp
+            internals[self].packets[seq + 1].err  = nil -- in case a late packet finally arrived
+            if getmetatable(internals[self].timeouts[seq + 1]) then
+                internals[self].timeouts[seq + 1]:stop()
+            end
+            internals[self].timeouts[seq + 1] = nil
+            internals[self].callback(self, msg, seq)
+            if internals[self].allSent then basicPingCompletionFunction(self) end
+        elseif msg == "receivedUnexpectedPacket" then
+            local icmp = ...
+            -- log it, but the ping callback doesn't need to know about it
+            log.vf("unexpected packet when pinging %s:%s", obj:hostName(), (inspect(icmp):gsub("%s+", " ")))
+        end
+    end):start()
+    internals[self].pingTimer  = timer.doEvery(interval, function()
+        if not internals[self].paused then
+            if internals[self].sentCount < internals[self].maxCount then
+                internals[self].pingObject:sendPayload()
+                internals[self].sentCount = internals[self].sentCount + 1
+                if internals[self].sentCount == internals[self].maxCount then internals[self].allSent = true end
+            else
+                internals[self].pingTimer:stop()
+                internals[self].pingTimer = nil
+            end
+        end
+    end)
+
+    return setmetatable(self, pingObjectMT)
+end
+
+-- Return Module Object --------------------------------------------------
+
+-- assign to the registry in case we ever need to access the metatable from the C side
+debug.getregistry()[USERDATA_TAG] = pingObjectMT
+
+-- allows referring to the default callback as module._defaultCallback here and also supports
+-- overriding it  with a new one if we need to for debugging purposes since the lack of a
+-- __newindex does not prevent assigning one to the module directly.
+setmetatable(module, {
+    __index = function(self, key)
+        if key == "_defaultCallback" then
+            return _defaultCallback
+        elseif key == "_internals" then
+            return internals
+        else
+            return nil
+        end
+    end,
+    __call = function(self, ...) return self.ping(...) end,
+})
+
+return module

--- a/extensions/network/ping/internal.m
+++ b/extensions/network/ping/internal.m
@@ -1,0 +1,713 @@
+
+/// === hs.network.ping.echoRequest ===
+///
+/// Provides lower-level access to the ICMP Echo Request infrastructure used by the hs.network.ping module. In general, you should not need to use this module directly unless you have specific requirements not met by the hs.network.ping module and the `hs.network.ping` object methods.
+///
+/// This module is based heavily on Apple's SimplePing sample project which can be found at https://developer.apple.com/library/content/samplecode/SimplePing/Introduction/Intro.html.
+///
+/// When a callback function argument is specified as an ICMP table, the Lua table returned will contain the following key-value pairs:
+///  * `checksum`       - The ICMP packet checksum used to ensure data integrity.
+///  * `code`           - ICMP Control Message Code. This should always be 0 unless the callback has received a "receivedUnexpectedPacket" message.
+///  * `identifier`     - The ICMP packet identifier.  This should match the results of [hs.network.ping.echoRequest:identifier](#identifier) unless the callback has received a "receivedUnexpectedPacket" message.
+///  * `payload`        - A string containing the ICMP payload for this packet. The default payload has been constructed to cause the ICMP packet to be exactly 64 bytes to match the convention for ICMP Echo Requests.
+///  * `sequenceNumber` - The ICMP Sequence Number for this packet.
+///  * `type`           - ICMP Control Message Type. Unless the callback has received a "receivedUnexpectedPacket" message, this will be 0 (ICMPv4) or 129 (ICMPv6) for packets we receive and 8 (ICMPv4) or 128 (ICMPv6) for packets we send.
+///      * `_raw`           - A string containing the ICMP packet as raw data.
+///
+/// In cases where the callback receives a "receivedUnexpectedPacket" message because the packet is corrupted or truncated, this table may only contain the `_raw` field.
+
+@import Cocoa ;
+@import LuaSkin ;
+
+@import Darwin.POSIX.netdb ;
+
+#include "SimplePing.h"
+
+#define USERDATA_TAG "hs.network.ping.echoRequest"
+static int refTable = LUA_NOREF;
+
+#define get_objectFromUserdata(objType, L, idx, tag) (objType*)*((void**)luaL_checkudata(L, idx, tag))
+// #define get_structFromUserdata(objType, L, idx, tag) ((objType *)luaL_checkudata(L, idx, tag))
+// #define get_cfobjectFromUserdata(objType, L, idx, tag) *((objType *)luaL_checkudata(L, idx, tag))
+
+#define ADDRESS_STYLES @{ \
+    @"any"  : @(SimplePingAddressStyleAny), \
+    @"IPv4" : @(SimplePingAddressStyleICMPv4), \
+    @"IPv6" : @(SimplePingAddressStyleICMPv6), \
+}
+
+#pragma mark - Support Functions and Classes
+
+static int pushParsedAddress(NSData *addressData) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    int  err;
+    char addrStr[NI_MAXHOST];
+    err = getnameinfo([addressData bytes], (unsigned int)[addressData length], addrStr, sizeof(addrStr), NULL, 0, NI_NUMERICHOST | NI_WITHSCOPEID | NI_NUMERICSERV);
+    if (err == 0) {
+        [skin pushNSObject:[NSString stringWithFormat:@"%s", addrStr]] ;
+    } else {
+        [skin pushNSObject:[NSString stringWithFormat:@"** address parse error:%s **", gai_strerror(err)]] ;
+    }
+    return 1;
+}
+
+static int pushParsedICMPPayload(NSData *payloadData) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    lua_State *L = [skin L] ;
+    size_t packetLength = [payloadData length] ;
+
+    lua_newtable(L) ;
+    size_t headerSize = sizeof(ICMPHeader) ;
+    if (packetLength >= headerSize) {
+        ICMPHeader payloadHeader ;
+        [payloadData getBytes:&payloadHeader length:headerSize] ;
+        lua_pushinteger(L, payloadHeader.type) ;           lua_setfield(L, -2, "type") ;
+        lua_pushinteger(L, payloadHeader.code) ;           lua_setfield(L, -2, "code") ;
+        lua_pushinteger(L, OSSwapHostToBigInt16(payloadHeader.checksum)) ;
+        lua_setfield(L, -2, "checksum") ;
+        lua_pushinteger(L, OSSwapHostToBigInt16(payloadHeader.identifier)) ;
+        lua_setfield(L, -2, "identifier") ;
+        lua_pushinteger(L, OSSwapHostToBigInt16(payloadHeader.sequenceNumber)) ;
+        lua_setfield(L, -2, "sequenceNumber") ;
+        if (packetLength > headerSize) {
+            [skin pushNSObject:[payloadData subdataWithRange:NSMakeRange(headerSize, packetLength - headerSize)]] ;
+            lua_setfield(L, -2, "payload") ;
+        }
+    } else {
+        [skin logDebug:[NSString stringWithFormat:@"malformed ICMP data:%@", payloadData]] ;
+        lua_pushstring(L, "ICMP header is too short -- malformed ICMP packet") ;
+        lua_setfield(L, -2, "error") ;
+    }
+    [skin pushNSObject:payloadData] ;
+    lua_setfield(L, -2, "_raw") ;
+
+    return 1 ;
+}
+
+@interface PingableObject : SimplePing <SimplePingDelegate>
+@property int  callbackRef ;
+@property int  selfRef ;
+@end
+
+@implementation PingableObject
+
+- (instancetype)initWithHostName:(NSString *)hostName {
+    if (!hostName) {
+        [LuaSkin logError:[NSString stringWithFormat:@"%s:initWithHostName, hostname cannot be nil", USERDATA_TAG]] ;
+        return nil ;
+    }
+
+    self = [super initWithHostName:hostName] ;
+    if (self) {
+        _callbackRef  = LUA_NOREF ;
+        _selfRef      = LUA_NOREF ;
+
+        self.delegate = self ;
+    }
+    return self ;
+}
+
+#pragma mark * SimplePingDelegate Methods
+
+- (void)simplePing:(SimplePing *)pinger didStartWithAddress:(NSData *)address {
+    if (_callbackRef != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared] ;
+        [skin pushLuaRef:refTable ref:_callbackRef] ;
+        [skin pushNSObject:pinger] ;
+        [skin pushNSObject:@"didStart"] ;
+        pushParsedAddress(address) ;
+        if (![skin protectedCallAndTraceback:3 nresults:0]) {
+            NSString *errorMessage = [skin toNSObjectAtIndex:-1] ;
+            lua_pop(skin.L, 1) ;
+            [skin logError:[NSString stringWithFormat:@"%s:didStartWithAddress callback error:%@", USERDATA_TAG, errorMessage]] ;
+        }
+    }
+}
+
+- (void)simplePing:(SimplePing *)pinger didFailWithError:(NSError *)error {
+    LuaSkin *skin = [LuaSkin shared] ;
+    NSString *errorReason = [error localizedDescription] ;
+    [skin logDebug:[NSString stringWithFormat:@"%s:didFailWithError:%@ - ping stopped.", USERDATA_TAG, errorReason]] ;
+    if (_callbackRef != LUA_NOREF) {
+        [skin pushLuaRef:refTable ref:_callbackRef] ;
+        [skin pushNSObject:pinger] ;
+        [skin pushNSObject:@"didFail"] ;
+        [skin pushNSObject:errorReason] ;
+        if (![skin protectedCallAndTraceback:3 nresults:0]) {
+            NSString *errorMessage = [skin toNSObjectAtIndex:-1] ;
+            lua_pop(skin.L, 1) ;
+            [skin logError:[NSString stringWithFormat:@"%s:didFailWithError callback error:%@", USERDATA_TAG, errorMessage]] ;
+        }
+    }
+
+    // by the time this method is invoked, SimplePing has already stopped us, so let's make sure
+    // we reflect that.
+    _selfRef = [skin luaUnref:refTable ref:_selfRef] ;
+}
+
+- (void)simplePing:(SimplePing *)pinger didSendPacket:(NSData *)packet
+                                       sequenceNumber:(uint16_t)sequenceNumber {
+    if (_callbackRef != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared] ;
+        [skin pushLuaRef:refTable ref:_callbackRef] ;
+        [skin pushNSObject:pinger] ;
+        [skin pushNSObject:@"sendPacket"] ;
+        pushParsedICMPPayload(packet) ;
+        lua_pushinteger([skin L], sequenceNumber) ;
+        if (![skin protectedCallAndTraceback:4 nresults:0]) {
+            NSString *errorMessage = [skin toNSObjectAtIndex:-1] ;
+            lua_pop(skin.L, 1) ;
+            [skin logError:[NSString stringWithFormat:@"%s:didSendPacket callback error:%@", USERDATA_TAG, errorMessage]] ;
+        }
+    }
+}
+
+- (void)simplePing:(SimplePing *)pinger didFailToSendPacket:(NSData *)packet
+                                             sequenceNumber:(uint16_t)sequenceNumber
+                                                      error:(NSError *)error {
+    if (_callbackRef != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared] ;
+        [skin pushLuaRef:refTable ref:_callbackRef] ;
+        [skin pushNSObject:pinger] ;
+        [skin pushNSObject:@"sendPacketFailed"] ;
+        pushParsedICMPPayload(packet) ;
+        lua_pushinteger([skin L], sequenceNumber) ;
+        [skin pushNSObject:[error localizedDescription]] ;
+        if (![skin protectedCallAndTraceback:5 nresults:0]) {
+            NSString *errorMessage = [skin toNSObjectAtIndex:-1] ;
+            lua_pop(skin.L, 1) ;
+            [skin logError:[NSString stringWithFormat:@"%s:didFailToSendPacket callback error:%@", USERDATA_TAG, errorMessage]] ;
+        }
+    }
+}
+
+- (void)simplePing:(SimplePing *)pinger didReceivePingResponsePacket:(NSData *)packet
+                                                      sequenceNumber:(uint16_t)sequenceNumber {
+    if (_callbackRef != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared] ;
+        [skin pushLuaRef:refTable ref:_callbackRef] ;
+        [skin pushNSObject:pinger] ;
+        [skin pushNSObject:@"receivedPacket"] ;
+        pushParsedICMPPayload(packet) ;
+        lua_pushinteger([skin L], sequenceNumber) ;
+        if (![skin protectedCallAndTraceback:4 nresults:0]) {
+            NSString *errorMessage = [skin toNSObjectAtIndex:-1] ;
+            lua_pop(skin.L, 1) ;
+            [skin logError:[NSString stringWithFormat:@"%s:didReceivePingResponsePacket callback error:%@", USERDATA_TAG, errorMessage]] ;
+        }
+    }
+}
+
+- (void)simplePing:(SimplePing *)pinger didReceiveUnexpectedPacket:(NSData *)packet {
+    if (_callbackRef != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared] ;
+        [skin pushLuaRef:refTable ref:_callbackRef] ;
+        [skin pushNSObject:pinger] ;
+        [skin pushNSObject:@"receivedUnexpectedPacket"] ;
+        pushParsedICMPPayload(packet) ;
+        if (![skin protectedCallAndTraceback:3 nresults:0]) {
+            NSString *errorMessage = [skin toNSObjectAtIndex:-1] ;
+            lua_pop(skin.L, 1) ;
+            [skin logError:[NSString stringWithFormat:@"%s:didReceiveUnexpectedPacket callback error:%@", USERDATA_TAG, errorMessage]] ;
+        }
+    }
+}
+
+@end
+
+#pragma mark - Module Functions
+
+/// hs.network.ping.echoRequest.echoRequest(server) -> echoRequestObject
+/// Constructor
+/// Creates a new ICMP Echo Request object for the server specified.
+///
+/// Parameters:
+///  * `server` - a string containing the hostname or ip address of the server to communicate with. Both IPv4 and IPv6 style addresses are supported.
+///
+/// Returns:
+///  * an echoRequest object
+///
+/// Notes:
+///  * This constructor returns a lower-level object than the `hs.network.ping.ping` constructor and is more difficult to use. It is recommended that you use this constructor only if `hs.network.ping.ping` is not sufficient for your needs.
+///
+///  * For convenience, you can call this constructor as `hs.network.ping.echoRequest(server)`
+static int echoRequest_new(__unused lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TSTRING, LS_TBREAK] ;
+    PingableObject *pinger = [[PingableObject alloc] initWithHostName:[skin toNSObjectAtIndex:1]] ;
+    [skin pushNSObject:pinger] ;
+    return 1 ;
+}
+
+#pragma mark - Module Methods
+
+/// hs.network.ping.echoRequest:setCallback(fn | nil) -> echoRequestObject
+/// Method
+/// Set or remove the object callback function
+///
+/// Parameters:
+///  * `fn` - a function to set as the callback function for this object, or nil if you wish to remove any existing callback function.
+///
+/// Returns:
+///  * the echoRequestObject
+///
+/// Notes:
+///  * The callback function should expect between 3 and 5 arguments and return none. The possible arguments which are sent will be one of the following:
+///
+///    * "didStart" - indicates that the object has resolved the address of the server and is ready to begin sending and receiving ICMP Echo packets.
+///      * `object`  - the echoRequestObject itself
+///      * `message` - the message to the callback, in this case "didStart"
+///      * `address` - a string representation of the IPv4 or IPv6 address of the server specified to the constructor.
+///
+///    * "didFail" - indicates that the object has failed, either because the address could not be resolved or a network error has occurred.
+///      * `object`  - the echoRequestObject itself
+///      * `message` - the message to the callback, in this case "didFail"
+///      * `error`   - a string describing the error that occurred.
+///    * Notes:
+///      * When this message is received, you do not need to call [hs.network.ping.echoRequest:stop](#stop) -- the object will already have been stopped.
+///
+///    * "sendPacket" - indicates that the object has sent an ICMP Echo Request packet.
+///      * `object`  - the echoRequestObject itself
+///      * `message` - the message to the callback, in this case "sendPacket"
+///      * `icmp`    - an ICMP packet table representing the packet which has been sent as described in the header of this module's documentation.
+///      * `seq`     - the sequence number for this packet. Sequence numbers always start at 0 and increase by 1 every time the [hs.network.ping.echoRequest:sendPayload](#sendPayload) method is called.
+///
+///    * "sendPacketFailed" - indicates that the object failed to send the ICMP Echo Request packet.
+///      * `object`  - the echoRequestObject itself
+///      * `message` - the message to the callback, in this case "sendPacketFailed"
+///      * `icmp`    - an ICMP packet table representing the packet which was to be sent.
+///      * `seq`     - the sequence number for this packet.
+///      * `error`   - a string describing the error that occurred.
+///    * Notes:
+///      * Unlike "didFail", the echoRequestObject is not stopped when this message occurs; you can try to send another payload if you wish without restarting the object first.
+///
+///    * "receivedPacket" - indicates that an expected ICMP Echo Reply packet has been received by the object.
+///      * `object`  - the echoRequestObject itself
+///      * `message` - the message to the callback, in this case "receivedPacket"
+///      * `icmp`    - an ICMP packet table representing the packet received.
+///      * `seq`     - the sequence number for this packet.
+///
+///    * "receivedUnexpectedPacket" - indicates that an unexpected ICMP packet was received
+///      * `object`  - the echoRequestObject itself
+///      * `message` - the message to the callback, in this case "receivedUnexpectedPacket"
+///      * `icmp`    - an ICMP packet table representing the packet received.
+///    * Notes:
+///      * This message can occur for a variety of reasons, the most common being:
+///        * the ICMP packet is corrupt or truncated and cannot be parsed
+///        * the ICMP Identifier does not match ours and the sequence number is not one we have sent
+///        * the ICMP type does not match an ICMP Echo Reply
+///        * When using IPv6, this is especially common because IPv6 uses ICMP for network management functions like Router Advertisement and Neighbor Discovery.
+///      * In general, it is reasonably safe to ignore these messages, unless you are having problems receiving anything else, in which case it could indicate problems on your network that need addressing.
+static int echoRequest_setCallback(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION | LS_TNIL, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+
+    // We're either removing a callback, or setting a new one. Either way, remove existing.
+    pinger.callbackRef = [skin luaUnref:refTable ref:pinger.callbackRef];
+    if (lua_type(L, 2) == LUA_TFUNCTION) {
+        lua_pushvalue(L, 2);
+        pinger.callbackRef = [skin luaRef:refTable] ;
+    }
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
+/// hs.network.ping.echoRequest:hostName() -> string
+/// Method
+/// Returns the name of the target host as provided to the echoRequestObject's constructor
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a string containing the hostname as specified when the object was created.
+static int echoRequest_hostName(__unused lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+    [skin pushNSObject:pinger.hostName] ;
+    return 1 ;
+}
+
+/// hs.network.ping.echoRequest:identifier() -> integer
+/// Method
+/// Returns the identifier number for the echoRequestObject.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * an integer specifying the identifier which is embedded in the ICMP packets this object sends.
+///
+/// Notes:
+///  * ICMP Echo Replies which include this identifier will generate a "receivedPacket" message to the object callback, while replies which include a different identifier will generate a "receivedUnexpectedPacket" message.
+static int echoRequest_identifier(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+    lua_pushinteger(L, pinger.identifier) ;
+    return 1 ;
+}
+
+/// hs.network.ping.echoRequest:nextSequenceNumber() -> integer
+/// Method
+/// The sequence number that will be used for the next ICMP packet sent by this object.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * an integer specifying the sequence number that will be embedded in the next ICMP message sent by this object when [hs.network.ping.echoRequest:sendPayload](#sendPayload) is invoked.
+///
+/// Notes:
+///  * ICMP Echo Replies which are expected by this object should always be less than this number, with the caveat that this number is a 16-bit integer which will wrap around to 0 after sending a packet with the sequence number 65535.
+///  * Because of this wrap around effect, this module will generate a "receivedPacket" message to the object callback whenever the received packet has a sequence number that is within the last 120 sequence numbers we've sent and a "receivedUnexpectedPacket" otherwise.
+///    * Per the comments in Apple's SimplePing.m file: Why 120?  Well, if we send one ping per second, 120 is 2 minutes, which is the standard "max time a packet can bounce around the Internet" value.
+static int echoRequest_nextSequenceNumber(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+    lua_pushinteger(L, pinger.nextSequenceNumber) ;
+    return 1 ;
+}
+
+/// hs.network.ping.echoRequest:acceptAddressFamily([family]) -> echoRequestObject | current value
+/// Method
+/// Get or set the address family the echoRequestObject should communicate with.
+///
+/// Parameters:
+///  * `family` - an optional string, default "any", which specifies the address family used by this object.  Valid values are "any", "IPv4", and "IPv6".
+///
+/// Returns:
+///  * if an argument is provided, returns the echoRequestObject, otherwise returns the current value.
+///
+/// Notes:
+///  * Setting this value to "IPv6" or "IPv4" will cause the echoRequestObject to attempt to resolve the server's name into an IPv6 address or an IPv4 address and communicate via ICMPv6 or ICMP(v4) when the [hs.network.ping.echoRequest:start](#start) method is invoked.  A callback with the message "didFail" will occur if the server could not be resolved to an address in the specified family.
+///  * If this value is set to "any", then the first address which is discovered for the server's name will determine whether ICMPv6 or ICMP(v4) is used, based upon the family of the address.
+///
+///  * Setting a value with this method will have no immediate effect on an echoRequestObject which has already been started with [hs.network.ping.echoRequest:start](#start). You must first stop and then restart the object for any change to have an effect.
+static int echoRequest_addressStyle(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TOPTIONAL, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+
+    if (lua_gettop(L) == 1) {
+        NSNumber *addressStyle = @(pinger.addressStyle) ;
+        NSArray *temp = [ADDRESS_STYLES allKeysForObject:addressStyle];
+        NSString *answer = [temp firstObject] ;
+        if (answer) {
+            [skin pushNSObject:answer] ;
+        } else {
+            [skin logError:[NSString stringWithFormat:@"%s:unrecognized address style %@ -- notify developers", USERDATA_TAG, addressStyle]] ;
+            lua_pushnil(L) ;
+        }
+    } else {
+        NSString *key = [skin toNSObjectAtIndex:2] ;
+        NSNumber *addressStyle = ADDRESS_STYLES[key] ;
+        if (addressStyle) {
+            pinger.addressStyle = [addressStyle integerValue] ;
+            lua_pushvalue(L, 1) ;
+        } else {
+            return luaL_argerror(L, 1, [[NSString stringWithFormat:@"must be one of %@", [[ADDRESS_STYLES allKeys] componentsJoinedByString:@", "]] UTF8String]) ;
+        }
+    }
+    return 1 ;
+}
+
+/// hs.network.ping.echoRequest:start() -> echoRequestObject
+/// Method
+/// Start the echoRequestObject by resolving the server's address and start listening for ICMP Echo Reply packets.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the echoRequestObject
+static int echoRequest_start(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+
+    if (pinger.selfRef == LUA_NOREF) {
+        [pinger start] ;
+
+        // assign a self ref to keep __gc from stopping us inadvertantly
+        lua_pushvalue(L, 1) ;
+        pinger.selfRef = [skin luaRef:refTable] ;
+    }
+    lua_pushvalue(L, 1) ;
+    return 1 ;
+}
+
+/// hs.network.ping.echoRequest:stop() -> echoRequestObject
+/// Method
+/// Start listening for ICMP Echo Reply packets with this object.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * the echoRequestObject
+static int echoRequest_stop(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+
+    if (pinger.selfRef != LUA_NOREF) {
+        [pinger stop] ;
+
+        // we no longer need a self ref to keep __gc from stopping us inadvertantly
+        pinger.selfRef = [skin luaUnref:refTable ref:pinger.selfRef] ;
+    }
+    lua_pushvalue(L, 1) ;
+    return 1 ;
+}
+
+/// hs.network.ping.echoRequest:isRunning() -> boolean
+/// Method
+/// Returns a boolean indicating whether or not this echoRequestObject is currently listening for ICMP Echo Replies.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * true if the object is currently listening for ICMP Echo Replies, or false if it is not.
+static int echoRequest_isRunning(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+
+    // we only have a self ref when we've been started
+    lua_pushboolean(L, (pinger.selfRef != LUA_NOREF)) ;
+    return 1 ;
+}
+
+/// hs.network.ping.echoRequest:hostAddress() -> string | false | nil
+/// Method
+/// Returns a string representation for the server's IP address, or a boolean if address resolution has not completed yet.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * If the object has been started and address resolution has completed, then the string representation of the server's IP address is returned.
+///  * If the object has been started, but resolution is still pending, returns a boolean value of false.
+///  * If the object has not been started, returns nil.
+static int echoRequest_hostAddress(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+    if (pinger.hostAddress) {
+        pushParsedAddress(pinger.hostAddress) ;
+    } else {
+        if (pinger.selfRef != LUA_NOREF) {
+            lua_pushboolean(L, NO) ;
+        } else {
+            lua_pushnil(L) ;
+        }
+    }
+    return 1 ;
+}
+
+/// hs.network.ping.echoRequest:sendPayload([payload]) -> echoRequestObject | false | nil
+/// Method
+/// Sends a single ICMP Echo Request packet.
+///
+/// Parameters:
+///  * `payload` - an optional string containing the data to include in the ICMP Echo Request as the packet payload.
+///
+/// Returns:
+///  * If the object has been started and address resolution has completed, then the ICMP Echo Packet is sent and this method returns the echoRequestObject
+///  * If the object has been started, but resolution is still pending, the packet is not sent and this method returns a boolean value of false.
+///  * If the object has not been started, the packet is not sent and this method returns nil.
+///
+/// Notes:
+///  * By convention, unless you are trying to test for specific network fragmentation or congestion problems, ICMP Echo Requests are generally 64 bytes in length (this includes the 8 byte header, giving 56 bytes of payload data).  If you do not specify a payload, a default payload which will result in a packet size of 64 bytes is constructed.
+static int echoRequest_sendPayload(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TOPTIONAL, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+    NSData *payload = (lua_gettop(L) == 2) ?
+        [skin toNSObjectAtIndex:2 withOptions:LS_NSLuaStringAsDataOnly] : nil ;
+
+    if (!payload) {
+        payload = [[NSString stringWithFormat:@"Hammerspoon %s %*s0x%04x:%04x", USERDATA_TAG, (int)(56 - 24 - strlen(USERDATA_TAG)), " ", pinger.identifier, pinger.nextSequenceNumber] dataUsingEncoding:NSASCIIStringEncoding] ;
+    }
+
+    if (pinger.hostAddress) {
+        [pinger sendPingWithData:payload] ;
+        lua_pushvalue(L, 1) ;
+    } else {
+        if (pinger.selfRef != LUA_NOREF) {
+            lua_pushboolean(L, NO) ;
+        } else {
+            lua_pushnil(L) ;
+        }
+    }
+    return 1 ;
+}
+
+/// hs.network.ping.echoRequest:hostAddressFamily() -> string
+/// Method
+/// Returns the host address family currently in use by this echoRequestObject.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a string indicating the IP address family currently used by this echoRequestObject.  It will be one of the following values:
+///    * "IPv4"       - indicates that ICMP(v4) packets are being sent and listened for.
+///    * "IPv6"       - indicates that ICMPv6 packets are being sent and listened for.
+///    * "unresolved" - indicates that the echoRequestObject has not been started or that address resolution is still in progress.
+static int echoRequest_addressFamily(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    PingableObject *pinger = [skin toNSObjectAtIndex:1] ;
+
+    switch (pinger.hostAddressFamily) {
+        case AF_INET:
+            [skin pushNSObject:@"IPv4"] ;
+            break ;
+        case AF_INET6:
+            [skin pushNSObject:@"IPv6"] ;
+            break ;
+        case AF_UNSPEC:
+            [skin pushNSObject:@"unresolved"] ;
+            break ;
+        default:
+            [skin logError:[NSString stringWithFormat:@"%s:unrecognized address family %d -- notify developers", USERDATA_TAG, pinger.hostAddressFamily]] ;
+            lua_pushnil(L) ;
+            break ;
+    }
+    return 1 ;
+}
+
+#pragma mark - Lua<->NSObject Conversion Functions
+// These must not throw a lua error to ensure LuaSkin can safely be used from Objective-C
+// delegates and blocks.
+
+static int pushPingableObject(lua_State *L, id obj) {
+    PingableObject *value = obj;
+
+    // honor selfRef if it's been assigned
+    if (value.selfRef != LUA_NOREF) {
+        [[LuaSkin shared] pushLuaRef:refTable ref:value.selfRef] ;
+
+    // otherwise, treat this like any other NSObject -> lua userdata
+    } else {
+        void** valuePtr = lua_newuserdata(L, sizeof(PingableObject *));
+        *valuePtr = (__bridge_retained void *)value;
+        luaL_getmetatable(L, USERDATA_TAG);
+        lua_setmetatable(L, -2);
+    }
+    return 1;
+}
+
+id toPingableObjectFromLua(lua_State *L, int idx) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    PingableObject *value ;
+    if (luaL_testudata(L, idx, USERDATA_TAG)) {
+        value = get_objectFromUserdata(__bridge PingableObject, L, idx, USERDATA_TAG) ;
+    } else {
+        [skin logError:[NSString stringWithFormat:@"expected %s object, found %s", USERDATA_TAG,
+                                                   lua_typename(L, lua_type(L, idx))]] ;
+    }
+    return value ;
+}
+
+#pragma mark - Hammerspoon/Lua Infrastructure
+
+static int userdata_tostring(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    PingableObject *obj = [skin luaObjectAtIndex:1 toClass:"PingableObject"] ;
+    NSString *title = obj.hostName ;
+    [skin pushNSObject:[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, title, lua_topointer(L, 1)]] ;
+    return 1 ;
+}
+
+static int userdata_eq(lua_State* L) {
+// can't get here if at least one of us isn't a userdata type, and we only care if both types are ours,
+// so use luaL_testudata before the macro causes a lua error
+    if (luaL_testudata(L, 1, USERDATA_TAG) && luaL_testudata(L, 2, USERDATA_TAG)) {
+        LuaSkin *skin = [LuaSkin shared] ;
+        PingableObject *obj1 = [skin luaObjectAtIndex:1 toClass:"PingableObject"] ;
+        PingableObject *obj2 = [skin luaObjectAtIndex:2 toClass:"PingableObject"] ;
+        lua_pushboolean(L, [obj1 isEqualTo:obj2]) ;
+    } else {
+        lua_pushboolean(L, NO) ;
+    }
+    return 1 ;
+}
+
+static int userdata_gc(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    PingableObject *obj = get_objectFromUserdata(__bridge_transfer PingableObject, L, 1, USERDATA_TAG) ;
+    if (obj) {
+        obj.callbackRef = [skin luaUnref:refTable ref:obj.callbackRef] ;
+
+        // because the self ref means we have a reference in the registry, the only way we should ever
+        // actually have to do this is during a reload/quit... and even then, it's not guaranteed
+        // depending upon purge ordering and possible object resurrection, but lets be "correct" if we can
+        if (obj.selfRef != LUA_NOREF) {
+            [obj stop] ;
+            obj.selfRef = [skin luaUnref:refTable ref:obj.selfRef] ;
+        }
+        obj = nil ;
+    }
+
+    // Remove the Metatable so future use of the variable in Lua won't think its valid
+    lua_pushnil(L) ;
+    lua_setmetatable(L, 1) ;
+    return 0 ;
+}
+
+// static int meta_gc(lua_State* __unused L) {
+//     return 0 ;
+// }
+
+// Metatable for userdata objects
+static const luaL_Reg userdata_metaLib[] = {
+    {"hostName",            echoRequest_hostName},
+    {"identifier",          echoRequest_identifier},
+    {"nextSequenceNumber",  echoRequest_nextSequenceNumber},
+    {"setCallback",         echoRequest_setCallback},
+    {"acceptAddressFamily", echoRequest_addressStyle},
+    {"start",               echoRequest_start},
+    {"stop",                echoRequest_stop},
+    {"isRunning",           echoRequest_isRunning},
+    {"hostAddress",         echoRequest_hostAddress},
+    {"hostAddressFamily",   echoRequest_addressFamily},
+    {"sendPayload",         echoRequest_sendPayload},
+
+    {"__tostring",          userdata_tostring},
+    {"__eq",                userdata_eq},
+    {"__gc",                userdata_gc},
+    {NULL,                  NULL}
+};
+
+// Functions for returned object when module loads
+static luaL_Reg moduleLib[] = {
+    {"echoRequest", echoRequest_new},
+    {NULL,  NULL}
+};
+
+// // Metatable for module, if needed
+// static const luaL_Reg module_metaLib[] = {
+//     {"__gc", meta_gc},
+//     {NULL,   NULL}
+// };
+
+int luaopen_hs_network_ping_internal(lua_State* __unused L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    refTable = [skin registerLibraryWithObject:USERDATA_TAG
+                                     functions:moduleLib
+                                 metaFunctions:nil    // or module_metaLib
+                               objectFunctions:userdata_metaLib];
+
+    [skin registerPushNSHelper:pushPingableObject         forClass:"PingableObject"];
+    [skin registerLuaObjectHelper:toPingableObjectFromLua forClass:"PingableObject"
+                                             withUserdataMapping:USERDATA_TAG];
+
+    return 1;
+}

--- a/scripts/copy_extensions_to_bundle.sh
+++ b/scripts/copy_extensions_to_bundle.sh
@@ -138,6 +138,9 @@ cp -av "${SRCROOT}/extensions/network/host.lua" "${HS_DST}/network/host.lua"
 cp -av "${BUILT_PRODUCTS_DIR}/libnetworkhost.dylib" "${HS_DST}/network/hostinternal.so"
 cp -av "${SRCROOT}/extensions/network/reachability.lua" "${HS_DST}/network/reachability.lua"
 cp -av "${BUILT_PRODUCTS_DIR}/libnetworkreachability.dylib" "${HS_DST}/network/reachabilityinternal.so"
+mkdir -pv "${HS_DST}/network/ping"
+cp -av "${SRCROOT}/extensions/network/ping/init.lua" "${HS_DST}/network/ping/init.lua"
+cp -av "${BUILT_PRODUCTS_DIR}/libnetworkping.dylib" "${HS_DST}/network/ping/internal.so"
 
 # Special copier for hs.socket.udp
 cp -av "${BUILT_PRODUCTS_DIR}/libsocketudp.dylib" "${HS_DST}/socket/udp.so"


### PR DESCRIPTION
Adds `hs.network.ping` and `hs.network.ping.echoRequest`

The ping submodule adds a basic ping function to the hs.network module, e.g.

~~~lua
-- Using built in callback function
> hs.network.ping("www.google.com")
hs.network.ping: www.google.com (0x60000186bec0)
PING: www.google.com (173.194.219.147):
64 bytes from 173.194.219.147: icmp_seq=0 time=24.569 ms
64 bytes from 173.194.219.147: icmp_seq=1 time=24.115 ms
64 bytes from 173.194.219.147: icmp_seq=2 time=36.364 ms
64 bytes from 173.194.219.147: icmp_seq=3 time=21.403 ms
64 bytes from 173.194.219.147: icmp_seq=4 time=18.777 ms
--- www.google.com ping statistics ---
5 packets transmitted, 5 packets received, 0.0 packet loss
round-trip min/avg/max = 18.777/25.046/36.364 ms

-- using a user-defined callback function
> hs.network.ping("www.google.com", function(...) print(hs.timer.secondsSinceEpoch(), ...) end)
hs.network.ping: www.google.com (0x608000464780)
1479153644.1827	hs.network.ping: www.google.com (0x608000464780)	didStart
1479153645.202	hs.network.ping: www.google.com (0x608000464780)	receivedPacket	0
1479153646.2567	hs.network.ping: www.google.com (0x608000464780)	receivedPacket	1
1479153647.1887	hs.network.ping: www.google.com (0x608000464780)	receivedPacket	2
1479153648.1887	hs.network.ping: www.google.com (0x608000464780)	receivedPacket	3
1479153649.203	hs.network.ping: www.google.com (0x608000464780)	receivedPacket	4
1479153649.2054	hs.network.ping: www.google.com (0x608000464780)	didFinish
~~~

The `hs.network.ping.echoRequest` submodule provides the actual ICMP Echo Request/Reply code, but is less user friendly to use and I suspect few will need to.

If you wish to test this without merging and building a local Hammerspoon, check out https://github.com/asmagill/hammerspoon_asm/tree/master/ping