### PR TITLE
Luaskin table w call

### DIFF
--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -377,6 +377,20 @@ NSString *specMaskToString(int spec);
  */
 - (void)checkArgs:(int)firstArg, ...;
 
+/*!
+ @abstract Returns the effective Lua type for the item at the specified stack index.
+
+ @discussion This method returns the Lua type for the item at the specified index.
+
+ At present, the only difference between this and the Lua API function `lua_type` is that a table with a __call metamethod is considered a function and will return LUA_TFUNCTION, since [LuaSkin protectedCallAndTraceback:nresults:] can accept such a table as the function to invoke.
+
+ @param idx the index on lua stack which contains the data to return a type for
+
+ @returns An integer which will be one of the following: LUA_TNIL, LUA_TNUMBER, LUA_TBOOLEAN, LUA_TSTRING, LUA_TTABLE, LUA_TFUNCTION, LUA_TUSERDATA, LUA_TTHREAD, or LUA_TLIGHTUSERDATA.
+
+ */
+- (int)luaTypeAtIndex:(int)idx ;
+
 #pragma mark - Conversion from NSObjects into Lua objects
 
 /*! @methodgroup Converting NSObject objects into Lua variables */

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -389,12 +389,12 @@ NSString *specMaskToString(int spec) {
                 } else if (spec & LS_TFUNCTION) {
                 // they want a function, so let's see if this table can mimic a function
                     if (luaL_getmetafield(self.L, idx, "__call") != LUA_TNIL) {
+                        lua_pop(self.L, 1) ;
                         lsType = LS_TFUNCTION ;
                     } else {
                 // no, so allow normal error handling to catch this
                         lsType = LS_TTABLE ;
                     }
-                    lua_pop(self.L, 1) ;
                 } else {
                     lsType = LS_TTABLE;
                 }

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -386,6 +386,15 @@ NSString *specMaskToString(int spec) {
                     if (!actualTableTag || !(strcmp(actualTableTag, expectedTableTag) == 0)) {
                         luaL_error(self.L, "ERROR: incorrect LuaSkin typed table for argument %d (expected %s)", idx, expectedTableTag) ;
                     }
+                } else if (spec & LS_TFUNCTION) {
+                // they want a function, so let's see if this table can mimic a function
+                    if (luaL_getmetafield(self.L, idx, "__call") != LUA_TNIL) {
+                        lsType = LS_TFUNCTION ;
+                    } else {
+                // no, so allow normal error handling to catch this
+                        lsType = LS_TTABLE ;
+                    }
+                    lua_pop(self.L, 1) ;
                 } else {
                     lsType = LS_TTABLE;
                 }

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -434,6 +434,17 @@ nextarg:
     }
 }
 
+- (int)luaTypeAtIndex:(int)idx {
+    int foundType = lua_type(self.L, idx) ;
+    if (foundType == LUA_TTABLE) {
+        if (luaL_getmetafield(self.L, idx, "__call") != LUA_TNIL) {
+            lua_pop(self.L, 1) ;
+            foundType = LUA_TFUNCTION ;
+        }
+    }
+    return foundType ;
+}
+
 #pragma mark - Conversion from NSObjects into Lua objects
 
 - (int)pushNSObject:(id)obj { return [self pushNSObject:obj withOptions:LS_NSNone] ; }

--- a/LuaSkin/LuaSkinTests/LuaSkinTests.m
+++ b/LuaSkin/LuaSkinTests/LuaSkinTests.m
@@ -494,6 +494,26 @@ static int pushTestUserData(lua_State *L, id object) {
     // It seems like we need to set a lua_atpanic() function and have that long jump to safety to prevent the abort(), but what can we jump to?
 }
 
+- (void)testLuaTypeAtIndex {
+    lua_State *L = self.skin.L ;
+
+    lua_newtable(L) ;
+    lua_newtable(L) ;
+    luaL_loadstring(L, "function foo() end") ;
+    lua_setfield(L, -2, "__call") ;
+    lua_setmetatable(L, -2) ;
+    XCTAssertEqual(LUA_TFUNCTION, [self.skin luaTypeAtIndex:-1]) ;
+    lua_pop(L, 1) ;
+
+    lua_newtable(L) ;
+    lua_newtable(L) ;
+    luaL_loadstring(L, "function foo() end") ;
+    lua_setfield(L, -2, "__notcall") ;
+    lua_setmetatable(L, -2) ;
+    XCTAssertEqual(LUA_TTABLE, [self.skin luaTypeAtIndex:-1]) ;
+    lua_pop(L, 1) ;
+}
+
 - (void)testPushNSObject {
     LSTestDelegate *testDelegate = [[LSTestDelegate alloc] init];
     self.skin.delegate = testDelegate;


### PR DESCRIPTION
This pull allows LuaSkin's `checkArgs:` method to recognize a table with a __call metamethod as a valid candidate for the LS_TFUNCTION type.

Note that this does not change the type actually on the stack... if your function/method (e.g. `hs.tasks.new`) does it's own check of the parameter type to determine internal logic, it will still see this argument as a table... this update *only* addresses LuaSkin's `checkArgs:`.

This pull was test with the `hs.timer` module and worked as expected:

~~~lua
> t = hs.timer.doAfter(1, function(...) print((hs.inspect(table.pack(...)):gsub("%s+", " "))) end)
{ n = 0 }

> t = hs.timer.doAfter(1, setmetatable({}, { __call = function(...) print((hs.inspect(table.pack(...)):gsub("%s+", " "))) end } ))
{ {}, n = 1 } -- the __call metamethod expects the table itself as the first argument (i.e. `self`)

> t = hs.timer.doAfter(1, setmetatable({}, { __notcall = function(...) print((hs.inspect(table.pack(...)):gsub("%s+", " "))) end } ))
[string "t = hs.timer.doAfter(1, setmetatable({}, { __..."]:1: ERROR: incorrect type 'table' for argument 2 (expected function)
stack traceback:
	[C]: in function 'hs.timer.internal.doAfter'
	[string "t = hs.timer.doAfter(1, setmetatable({}, { __..."]:1: in main chunk
	[C]: in function 'xpcall'
	...app/Contents/Resources/extensions/hs/_coresetup/init.lua:321: in function <...app/Contents/Resources/extensions/hs/_coresetup/init.lua:301>
~~~

A review of modules for which this is insufficient should be made at some point, but this should be independent of this pull, since each module will have to be reviewed to determine what, if any, implications adding additional logic may involve.

For the record, the following modules are known to require updates to take advantage of this pull (this is by no means complete, just what I encountered while trying to identify a reliable test):
* `hs.hotkey` - currently uses its own internal logic to identify such tables... a "reversion" is possible once this lands, but is certainly not required.
* `hs.eventtap` - does not currently use LuaSkin's `checkArgs:` method for parameter validation.
* `hs.task` - uses the parameter type as identified with `lua_gettype` in the `new` function for internal logic... while the `checkArgs:` method will accept a table with a __call metamethod as a function, the internal logic will still see it as a table and a fix should be considered.
