### PR TITLE
Added the ability to add shadow to the webview windows

### DIFF
--- a/extensions/webview/internal.m
+++ b/extensions/webview/internal.m
@@ -2004,6 +2004,29 @@ static int webview_alpha(lua_State *L) {
     return 1 ;
 }
 
+/// hs.webview:shadow([value]) -> webviewObject | current value
+/// Method
+/// Get or set whether or not the webview window has shadows. Default to false.
+///
+/// Parameters:
+///  * `value` - an optional boolean value indicating whether or not the webview should have shadows.
+///
+/// Returns:
+///  * If a value is provided, then this method returns the webview object; otherwise the current value
+static int webview_shadow(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
+    HSWebViewWindow *theWindow = get_objectFromUserdata(__bridge HSWebViewWindow, L, 1, USERDATA_TAG) ;
+
+    if (lua_type(L, 2) == LUA_TNONE) {
+        lua_pushboolean(L, (BOOL)theWindow.hasShadow);
+    } else {
+        theWindow.hasShadow = lua_toboolean(L, 2);
+        lua_settop(L, 1);
+    }
+    return 1 ;
+}
+
 static int webview_orderHelper(lua_State *L, NSWindowOrderingMode mode) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG,
@@ -2716,6 +2739,7 @@ static const luaL_Reg userdata_metaLib[] = {
     {"deleteOnClose",              webview_deleteOnClose},
     {"bringToFront",               webview_bringToFront},
     {"sendToBack",                 webview_sendToBack},
+    {"shadow",                     webview_shadow},
     {"alpha",                      webview_alpha},
     {"orderAbove",                 webview_orderAbove},
     {"orderBelow",                 webview_orderBelow},


### PR DESCRIPTION
It is useful to have shadows in the floating webview window in several use-cases. This PR enables that.

## Usage:
```lua
webview:shadow(true)
```
**Preview**
![snip 2016-12-05 at 20 35 38](https://cloud.githubusercontent.com/assets/5663391/20890007/48c134de-bb2b-11e6-9ae3-6b9940eb7b75.jpg)
