### PR TITLE
image additions

### DIFF
--- a/extensions/image/init.lua
+++ b/extensions/image/init.lua
@@ -84,6 +84,8 @@ local module    = {
 local fnutils = require("hs.fnutils")
 
 local module = require("hs.image.internal")
+local objectMT = hs.getObjectMetatable("hs.image")
+
 require("hs.drawing.color") -- make sure that the conversion helpers required to support color are loaded
 
 -- local __tostring_for_arrays = function(self)
@@ -113,5 +115,34 @@ require("hs.drawing.color") -- make sure that the conversion helpers required to
 
 module.systemImageNames = _makeConstantsTable(module.systemImageNames)
 module.additionalImageNames = _makeConstantsTable(module.additionalImageNames)
+
+--- hs.image:setName(Name) -> boolean
+--- Method
+--- Assigns the name assigned to the hs.image object.
+---
+--- Parameters:
+---  * Name - the name to assign to the hs.image object.
+---
+--- Returns:
+---  * Status - a boolean value indicating success (true) or failure (false) when assigning the specified name.
+---
+--- Notes:
+---  * This method is included for backwards compatibility and is considered deprecated.  It is equivalent to `hs.image:name(name) and true or false`.
+objectMT.setName = function(self, ...) return self:name(...) and true or false end
+
+--- hs.image:setSize(size [, absolute]) -> object
+--- Method
+--- Returns a copy of the image resized to the height and width specified in the size table.
+---
+--- Parameters:
+---  * size     - a table with 'h' and 'w' keys specifying the size for the new image.
+---  * absolute - an optional boolean specifying whether or not the copied image should be resized to the height and width specified (true), or whether the copied image should be scaled proportionally to fit within the height and width specified (false).  Defaults to false.
+---
+--- Returns:
+---  * a copy of the image object at the new size
+---
+--- Notes:
+---  * This method is included for backwards compatibility and is considered deprecated.  It is equivalent to `hs.image:copy():size(size, [absolute])`.
+objectMT.setSize = function(self, ...) return self:copy():size(...) end
 
 return module


### PR DESCRIPTION
adds `hs.image:copy`, `hs.image:template`, `hs.image:croppedImage`, and reworks `:name` and `size` to work as both getter and setter.  `:setName` and `:setSize` retained with the old behavior for backwards compatibility.