### PR TITLE
hs.webview and -999 errors

### DIFF
--- a/extensions/webview/datastore.m
+++ b/extensions/webview/datastore.m
@@ -102,7 +102,11 @@ static int datastore_fromWebview(lua_State *L) {
     HSWebViewWindow        *theWindow = get_objectFromUserdata(__bridge HSWebViewWindow, L, 1, "hs.webview") ;
     HSWebViewView          *theView = theWindow.contentView ;
     WKWebViewConfiguration *theConfiguration = [theView configuration] ;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
     [skin pushNSObject:[theConfiguration websiteDataStore]] ;
+#pragma clang diagnostic pop
+
     return 1 ;
 }
 
@@ -407,7 +411,11 @@ static int pushWKWebsiteDataStore(lua_State *L, id obj) {
 
 static int pushWKWebsiteDataRecord(lua_State *L, id obj) {
     LuaSkin             *skin  = [LuaSkin shared] ;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
     WKWebsiteDataRecord *value = obj;
+#pragma clang diagnostic pop
+
 
     lua_newtable(L) ;
     [skin pushNSObject:[value displayName]] ; lua_setfield(L, -2, "displayName") ;


### PR DESCRIPTION
This pull cleans up warnings during compile and moves the actual rendering for `hs.webview:url`, `hs.webview:reload`, and `hs.webview:html` into an async queue to prevent errors (-999) when trying to go to a new page when the old one hasn't finished rendering yet (or is doing an AJAX/Javascript request)

@cmsj, this does change the previous behavior in the following way (I think it's worth it, but want your input before merging this):

These methods no longer return the navigation id because it won't be known until the current page is cancelled and the new one is rendered by the threaded queue.  If you need the navigation id for your own tracking purposes, setup an `hs.webview:navigationalCallback` and capture it there, or at least wait until the navigational callback has passed at least the `didStartProvisionalNavigation` message and then use `hs.webview:navigationID`.

Addresses #1151