### PR TITLE
hs.chooser ensure correct types for choices keys during display and search

### DIFF
--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -374,6 +374,7 @@
 #pragma mark - Choice management methods
 
 - (void)updateChoices {
+    [self controlTextDidChange:nil] ;
     if (self.window.visible) {
         [self.choicesTableView reloadData];
     } else {

--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -224,6 +224,10 @@
     NSString *shortcutText = @"";
     NSImage  *image        = [choice objectForKey:@"image"];
 
+    if (text    && ![text isKindOfClass:[NSString class]])    text    = [NSString stringWithFormat:@"%@", text] ;
+    if (subText && ![subText isKindOfClass:[NSString class]]) subText = [NSString stringWithFormat:@"%@", subText] ;
+    if (image   && ![image isKindOfClass:[NSImage class]])    image   = nil ;
+
     if (row >= 0 && row < 9) {
         shortcutText = [NSString stringWithFormat:@"⌘%ld", (long)row + 1];
     } else {
@@ -316,10 +320,16 @@
             NSMutableArray *filteredChoices = [[NSMutableArray alloc] init];
 
             for (NSDictionary *choice in [self getChoicesWithOptions:NO]) {
-                if ([[[choice objectForKey:@"text"] lowercaseString] containsString:[queryString lowercaseString]]) {
+                NSString *text = [choice objectForKey:@"text"];
+                if (text && ![text isKindOfClass:[NSString class]]) text = [NSString stringWithFormat:@"%@", text] ;
+                if (!text) text = @"" ;
+                if ([[text lowercaseString] containsString:[queryString lowercaseString]]) {
                     [filteredChoices addObject: choice];
                 } else if (self.searchSubText) {
-                    if ([[[choice objectForKey:@"subText"] lowercaseString] containsString:[queryString lowercaseString]]) {
+                    NSString *subText = [choice objectForKey:@"subText"];
+                    if (subText && ![subText isKindOfClass:[NSString class]]) subText = [NSString stringWithFormat:@"%@", subText] ;
+                    if (!subText) subText = @"" ;
+                    if ([[subText lowercaseString] containsString:[queryString lowercaseString]]) {
                         [filteredChoices addObject:choice];
                     }
                 }


### PR DESCRIPTION
addresses fabric issue 468

`text` and `subText` key values can still be any type, but for display and string search purposes they will now be converted to a string with `[NSString stringWithFormat:@"%@", value]` when they exist but are not strings.  This seemed easier (and maybe slightly more useful) then validating each dictionary to make sure `text` and `subText` were in fact strings within `hs.chooser:choices`.

`image` will be treated as nil for display purposes when it exists but is not an `hs.image` object.

This pull is separate from #1140 because I ran into merge conflicts when including it and trying a local merge back to master, but as separate pulls they both merge as separate merges back into master... whatever, this works :-)