### PR TITLE
Let `hs.chooser` match macOS configured theme (light/dark)

### DIFF
--- a/extensions/chooser/HSChooser.h
+++ b/extensions/chooser/HSChooser.h
@@ -55,6 +55,9 @@
 // A pointer to the hs.chooser module's references table
 @property(nonatomic) int *refTable;
 
+// Keep track of whether we are observing macOS interface theme (light/dark)
+@property(nonatomic) BOOL isObservingThemeChanges;
+
 // Initialiser
 - (id)initWithRefTable:(int *)refTable completionCallbackRef:(int)completionCallbackRef;
 
@@ -87,6 +90,6 @@
 - (NSArray *)getChoicesWithOptions:(BOOL)includeFiltered;
 
 // UI customisation methods
-- (void)setBgLightDark:(BOOL)isDark;
+- (void)setBgLightDark:(NSNumber *)isDark;
 - (BOOL)isBgLightDark;
 @end

--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -57,9 +57,15 @@
         if (![self setupWindow]) {
             return nil;
         }
+        
+        [[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(setBgLightDark) name:@"AppleInterfaceThemeChangedNotification" object:nil];
     }
 
     return self;
+}
+
+- (void)dealloc {
+    [[NSDistributedNotificationCenter defaultCenter] removeObserver:self name:@"AppleInterfaceThemeChangedNotification" object:nil];
 }
 
 #pragma mark - Window related methods
@@ -68,8 +74,8 @@
     [super windowDidLoad];
 
     [self.queryField setFocusRingType:NSFocusRingTypeNone];
+    [self setBgLightDark];
 }
-
 
 - (void)windowDidBecomeKey:(NSNotification *)notification {
     __weak id _self = self;
@@ -476,7 +482,16 @@
     }
 }
 
+- (void)setBgLightDark {
+    NSString *interfaceStyle = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+    BOOL isDark = (interfaceStyle && [[interfaceStyle lowercaseString] isEqualToString:@"dark"]);
+
+    NSAppearance *appearance = isDark ? [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark] : [NSAppearance appearanceNamed:NSAppearanceNameVibrantLight];
+    self.window.appearance = appearance;
+}
+
 - (void)setBgLightDark:(BOOL)isDark {
+    [[NSDistributedNotificationCenter defaultCenter] removeObserver:self name:@"AppleInterfaceThemeChangedNotification" object:nil];
     NSAppearance *appearance = isDark ? [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark] : [NSAppearance appearanceNamed:NSAppearanceNameVibrantLight];
     self.window.appearance = appearance;
 }

--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -66,10 +66,6 @@
     return self;
 }
 
-- (void)dealloc {
-    self.isObservingThemeChanges = NO;
-}
-
 #pragma mark - Window related methods
 
 - (void)windowDidLoad {

--- a/extensions/chooser/internal.m
+++ b/extensions/chooser/internal.m
@@ -435,7 +435,7 @@ static int chooserSetSubTextColor(lua_State *L) {
 ///  * The text colors will not automatically change when you toggle the darkness of the chooser window, you should also set appropriate colors with `hs.chooser:fgColor()` and `hs.chooser:subTextColor()`
 static int chooserSetBgDark(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
-    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TNIL | LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK];
 
     chooser_userdata_t *userData = lua_touserdata(L, 1);
     HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
@@ -443,9 +443,14 @@ static int chooserSetBgDark(lua_State *L) {
     BOOL beDark;
 
     switch (lua_type(L, 2)) {
+        case LUA_TNIL:
+            [chooser setBgLightDark:nil];
+            lua_pushvalue(L, 1);
+            break;
+
         case LUA_TBOOLEAN:
             beDark = lua_toboolean(L, 2);
-            [chooser setBgLightDark:beDark];
+            [chooser setBgLightDark:[NSNumber numberWithBool:beDark]];
             lua_pushvalue(L, 1);
             break;
 

--- a/extensions/chooser/internal.m
+++ b/extensions/chooser/internal.m
@@ -649,6 +649,7 @@ static int userdata_gc(lua_State* L) {
         chooser.queryChangedCallbackRef = [skin luaUnref:refTable ref:chooser.queryChangedCallbackRef];
         chooser.completionCallbackRef = [skin luaUnref:refTable ref:chooser.completionCallbackRef];
         chooser.rightClickCallbackRef = [skin luaUnref:refTable ref:chooser.rightClickCallbackRef];
+        chooser.isObservingThemeChanges = NO;  // Stop observing for interface theme changes.
     }
     userData->chooser = nil;
     chooser = nil;


### PR DESCRIPTION
By default, the chooser now matches macOS preferences (and also changes its color on settings updates).
In case the user explicitly sets the color, it sticks to it, ignoring the preferences.

@cmsj, @asmagill: It's been a while since I last used Objective C, so advices/reviews/thoughts are welcome.