### PR TITLE
Change how keycodes are mapped

### DIFF
--- a/extensions/keycodes/internal.m
+++ b/extensions/keycodes/internal.m
@@ -43,10 +43,10 @@ int keycodes_cachemap(lua_State* L) {
         for (int i = 0 ; i < (int)(sizeof(relocatableKeyCodes)/sizeof(relocatableKeyCodes[0])) ; i++) {
             UCKeyTranslate(keyboardLayout,
                            relocatableKeyCodes[i],
-                           kUCKeyActionDisplay,
+                           kUCKeyActionDown,
                            0,
                            LMGetKbdType(),
-                           kUCKeyTranslateNoDeadKeysBit,
+                           kUCKeyTranslateNoDeadKeysMask,
                            &keysDown,
                            sizeof(chars) / sizeof(chars[0]),
                            &realLength,


### PR DESCRIPTION
Using mask kUCKeyTranslateNoDeadKeysMask  instead of flag
kUCKeyTranslateNoDeadKeysBit

https://developer.apple.com/reference/coreservices/1390568-key_translati
on_options_mask?language=objc

Also using kUCKeyActionDown instead of kUCKeyActionDisplay which is
said to be unreliable
http://stackoverflow.com/questions/27735217/how-to-use-uckeytranslate

Fixes #1169