### PR TITLE
Allow entries in hs.layout.apply to be functions

### DIFF
--- a/extensions/layout/init.lua
+++ b/extensions/layout/init.lua
@@ -75,9 +75,9 @@ layout.maximized = geometry.rect(0, 0, 1, 1)
 ---   * A string containing an application name, or an `hs.application` object, or nil
 ---   * A string containing a window title or nil
 ---   * A string containing a screen name, or an `hs.screen` object, or a function that accepts no parameters and returns an `hs.screen` object, or nil to select the first available screen
----   * A Unit rect (see `hs.window.moveToUnit()`)
----   * A Frame rect (see `hs.screen:frame()`)
----   * A Full-frame rect (see `hs.screen:fullFrame()`)
+---   * A Unit rect, or a function which is called for each window and returns a unit rect (see `hs.window.moveToUnit()`)
+---   * A Frame rect, or a function which is called for each window and returns a frame rect (see `hs.screen:frame()`)
+---   * A Full-frame rect, of a function which is called for each window and returns a full-frame rect (see `hs.screen:fullFrame()`)
 ---  * windowTitleComparator - (optional) Function to use for window title comparison. It is called with two string arguments (below) and its return value is evaluated as a boolean. If no comparator is provided, the '==' operator is used
 ---   * windowTitle: The `:title()` of the window object being examined
 ---   * layoutWindowTitle: The window title string (second field) specified in each element of the layout table
@@ -202,12 +202,24 @@ function layout.apply(layout, windowTitleComparator)
 
                 -- Apply supplied position, if any
                 if unit then
-                    _win:moveToUnit(unit)
+                    local realizedunit = unit
+                    if type(realizedunit) == "function" then
+                      realizedunit = realizedunit(_win)
+                    end
+                    _win:moveToUnit(realizedunit)
                 elseif frame then
-                    winframe = frame
+                    local realizedframe = frame
+                    if type(realizedframe) == "function" then
+                      realizedframe = realizedframe(_win)
+                    end
+                    winframe = realizedframe
                     screenrect = _win:screen():frame()
                 elseif fullframe then
-                    winframe = fullframe
+                    local realizedfullframe = fullframe
+                    if type(realizedfullframe) == "function" then
+                      realizedfullframe = realizedfullframe(_win)
+                    end
+                    winframe = realizedfullframe
                     screenrect = _win:screen():fullFrame()
                 end
 


### PR DESCRIPTION
Allow unit, frame and full-frame to be functions that return unit, frame or full-frame respectively in hs.layout.apply

I wanted this so I could set a different `unit` parameter for each window belonging to an application, but without having to enumerate the window titles. I.e "Put my editor window in alternating left50, right50, left50 etc, but I don't care in which order, or want to have to enumerate which filenames are in the title string". By defining a function that just returns left50, right50 based on a persistent counter and using that as `unit` you can have this alternating behavior.