### PR TITLE
Match iTunes previous() method with expected behaviour.

### DIFF
--- a/extensions/itunes/init.lua
+++ b/extensions/itunes/init.lua
@@ -96,7 +96,7 @@ end
 --- Returns:
 ---  * None
 function itunes.previous()
-  tell('previous track')
+  tell('back track')
 end
 
 --- hs.itunes.displayCurrentTrack()


### PR DESCRIPTION
This change makes the previous() method match the behavior of the
spotify extension. Using 'back track' repositions the player to the
beginning of the current track or changes to the previous track if
already at the start of the current track. 'previous track' repositions
the player to the previous track on the playlist regardless of the
position in the current track.

Thoughts on this? I am currently using a `tell` in my scripts to get around this. I was close to making a separate function, but because the default behavior of other music players (Spotify) was identical to using `back track`, consolidating the behaviors IMO makes the most sense.