### PR TITLE
Fix accessing nil hs.application:name

### DIFF
--- a/extensions/application/init.lua
+++ b/extensions/application/init.lua
@@ -148,8 +148,12 @@ function application.find(hint,exact)
   else for _,a in ipairs(apps) do local aname=a:name() if aname and aname:lower():find(hint:lower()) then r[#r+1]=a end end end
 
   if spotlightEnabled then
-      for i, v in ipairs(table.pack(realNameFor(hint, exact))) do
-          for _, a in ipairs(apps) do if v:lower() == a:name():lower() then r[#r+1]=a end end
+      for _, v in ipairs(table.pack(realNameFor(hint, exact))) do
+          for _, a in ipairs(apps) do
+              if a:name() ~= nil and v:lower() == a:name():lower() then
+                  r[#r+1]=a
+              end
+          end
       end
   elseif type(spotlightEnabled) == "nil" and not findSpotlightWarningGiven then
       findSpotlightWarningGiven = true


### PR DESCRIPTION
I noticed that after the `hs.spotlight` addition I was getting some tracebacks in the console related to `hs.application.find` and an attempt to address a nil variable (sorry, I recompiled HS and did not copy the logs).

After a bit of digging I found the culprit: `hs.application:name` seems to be nil in some cases, and this PR should fix the issue.

On a broader note: is `hs.application:name` allowed to be nil by definition? Is this an issue rooted elsewhere?
Pinging @asmagill for this one.