### PR TITLE
Adopt new Vox Applescript dictionary (fixes #1250)

### DIFF
--- a/extensions/vox/init.lua
+++ b/extensions/vox/init.lua
@@ -293,7 +293,7 @@ end
 ---  * 0 for paused
 ---  * 1 for playing
 function vox.getPlayerState()
-  return tell('playerState')
+  return tell('player state')
 end
 
 --- hs.vox.isRunning()


### PR DESCRIPTION
This breaks backwards compatibility with previous versions of Vox.
If it is worth it we can manage to check for Vox's version and then use the correct Applescript dictionary string.