### PR TITLE
Add methods to hs.chooser for user customization

### DIFF
--- a/extensions/chooser/HSChooser.h
+++ b/extensions/chooser/HSChooser.h
@@ -47,6 +47,7 @@
 @property(nonatomic, retain) NSArray *filteredChoices;
 
 // Lua callback references
+@property(nonatomic) int showCallbackRef;
 @property(nonatomic) int choicesCallbackRef;
 @property(nonatomic) int queryChangedCallbackRef;
 @property(nonatomic) int completionCallbackRef;

--- a/extensions/chooser/HSChooser.h
+++ b/extensions/chooser/HSChooser.h
@@ -82,6 +82,7 @@
 
 // Actions
 - (IBAction)queryDidPressEnter:(id)sender;
+- (IBAction)cancel:(id)sender;
 
 // Choice related methods
 - (void)updateChoices;

--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -199,13 +199,15 @@
 
     [self controlTextDidChange:[NSNotification notificationWithName:@"Unused" object:nil]];
 
-	LuaSkin *skin = [LuaSkin shared];
+    LuaSkin *skin = [LuaSkin shared];
 
-	[skin pushLuaRef:*(self.refTable) ref:self.showCallbackRef];
-	if (![skin protectedCallAndTraceback:0 nresults:0]) {
-		[skin logError:[NSString stringWithFormat:@"%s:showCallback error - %@", USERDATA_TAG, [skin toNSObjectAtIndex:-1]]] ;
-		lua_pop(skin.L, 1) ; // remove error message
-	}
+    if (self.showCallbackRef != LUA_NOREF && self.showCallbackRef != LUA_REFNIL) {
+        [skin pushLuaRef:*(self.refTable) ref:self.showCallbackRef];
+        if (![skin protectedCallAndTraceback:0 nresults:0]) {
+            [skin logError:[NSString stringWithFormat:@"%s:showCallback error - %@", USERDATA_TAG, [skin toNSObjectAtIndex:-1]]] ;
+            lua_pop(skin.L, 1) ; // remove error message
+        }
+    }
 }
 
 - (void)hide {

--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -38,6 +38,7 @@
         self.currentCallbackChoices = nil;
         self.filteredChoices = nil;
 
+        self.showCallbackRef = LUA_NOREF;
         self.choicesCallbackRef = LUA_NOREF;
         self.queryChangedCallbackRef = LUA_NOREF;
         self.rightClickCallbackRef = LUA_NOREF;
@@ -197,6 +198,14 @@
     }
 
     [self controlTextDidChange:[NSNotification notificationWithName:@"Unused" object:nil]];
+
+	LuaSkin *skin = [LuaSkin shared];
+
+	[skin pushLuaRef:*(self.refTable) ref:self.showCallbackRef];
+	if (![skin protectedCallAndTraceback:0 nresults:0]) {
+		[skin logError:[NSString stringWithFormat:@"%s:showCallback error - %@", USERDATA_TAG, [skin toNSObjectAtIndex:-1]]] ;
+		lua_pop(skin.L, 1) ; // remove error message
+	}
 }
 
 - (void)hide {

--- a/extensions/chooser/internal.m
+++ b/extensions/chooser/internal.m
@@ -192,6 +192,32 @@ static int chooserSetChoices(lua_State *L) {
     return 1;
 }
 
+/// hs.chooser:showCallback([fn]) -> hs.chooser object
+/// Method
+/// Sets/clears a callback for when the chooser window is shown
+///
+/// Parameters:
+///  * fn - An optional function that will be called when the chooser window is shown. If this parameter is omitted, the existing callback will be removed.
+///
+/// Returns:
+///  * The hs.chooser object
+static int chooserShowCallback(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION|LS_TOPTIONAL, LS_TBREAK];
+
+    chooser_userdata_t *userData = lua_touserdata(L, 1);
+    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+
+    chooser.showCallbackRef = [skin luaUnref:refTable ref:chooser.showCallbackRef];
+
+    if (lua_type(L, 2) == LUA_TFUNCTION) {
+        chooser.showCallbackRef = [skin luaRef:refTable atIndex:2];
+    }
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
 /// hs.chooser:refreshChoicesCallback() -> hs.chooser object
 /// Method
 /// Refreshes the choices data from a callback
@@ -645,6 +671,7 @@ static int userdata_gc(lua_State* L) {
     HSChooser *chooser = (__bridge_transfer HSChooser *)userData->chooser;
     if (chooser) {
         LuaSkin *skin = [LuaSkin shared] ;
+        chooser.showCallbackRef = [skin luaUnref:refTable ref:chooser.showCallbackRef];
         chooser.choicesCallbackRef = [skin luaUnref:refTable ref:chooser.choicesCallbackRef];
         chooser.queryChangedCallbackRef = [skin luaUnref:refTable ref:chooser.queryChangedCallbackRef];
         chooser.completionCallbackRef = [skin luaUnref:refTable ref:chooser.completionCallbackRef];
@@ -673,6 +700,7 @@ static const luaL_Reg userdataLib[] = {
     {"hide", chooserHide},
     {"isVisible", chooserIsVisible},
     {"choices", chooserSetChoices},
+    {"showCallback", chooserShowCallback},
     {"queryChangedCallback", chooserQueryCallback},
     {"query", chooserSetQuery},
     {"delete", chooserDelete},

--- a/extensions/chooser/internal.m
+++ b/extensions/chooser/internal.m
@@ -657,6 +657,47 @@ static int chooserSelectedRowContents(lua_State *L) {
     return 1 ;
 }
 
+/// hs.chooser:select([row]) -> hs.chooser object
+/// Method
+/// Closes the chooser by selecting the specified row, or the currently selected row if not given
+///
+/// Parameters:
+///  * `row` - an optional integer specifying the row to select.
+///
+/// Returns:
+///  * The `hs.chooser` object
+static int chooserSelect(lua_State *L) {
+    chooser_userdata_t *userData = lua_touserdata(L, 1);
+    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+
+    chooserSelectedRow(L);
+    lua_pop(L, 1);
+
+    [chooser queryDidPressEnter:nil];
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
+/// hs.chooser:cancel() -> hs.chooser object
+/// Method
+/// Cancels the chooser
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * The `hs.chooser` object
+static int chooserCancel(lua_State *L) {
+    chooser_userdata_t *userData = lua_touserdata(L, 1);
+    HSChooser *chooser = (__bridge HSChooser *)userData->chooser;
+
+    [chooser cancel:nil];
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
 #pragma mark - Hammerspoon Infrastructure
 
 static int userdata_tostring(lua_State* L) {
@@ -708,6 +749,8 @@ static const luaL_Reg userdataLib[] = {
     {"rightClickCallback", chooserRightClickCallback},
     {"selectedRow", chooserSelectedRow},
     {"selectedRowContents", chooserSelectedRowContents},
+    {"select", chooserSelect},
+    {"cancel", chooserCancel},
     {"fgColor", chooserSetFgColor},
     {"subTextColor", chooserSetSubTextColor},
     {"bgDark", chooserSetBgDark},

--- a/extensions/chooser/internal.m
+++ b/extensions/chooser/internal.m
@@ -601,6 +601,7 @@ static int chooserSelectedRow(lua_State *L) {
         NSInteger newRow = lua_tointeger(L, 2) - 1 ;
         newRow = (newRow < 0) ? 0 : ((newRow > maxRow) ? maxRow : newRow) ;
         [chooser.choicesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:newRow] byExtendingSelection:NO] ;
+        [chooser.choicesTableView scrollRowToVisible:newRow];
         lua_pushvalue(L, 1) ;
     }
     return 1;


### PR DESCRIPTION
This adds some methods to hs.chooser for user customization as suggested in #1249.

- `hs.chooser:showCallback([fn])`: Called when show() is called, and can be used as a hook where user can add custom hotkeys.
- `hs.chooser:select([row])`: Closes the chooser by selecting a row.
- `hs.chooser:cancel()`: Cancels the chooser.

This also includes a fix for a bug where `hs.chooser:selectedRow(row)` does not update the scroll position.