### PR TITLE
Improve pasteboard management

### DIFF
--- a/extensions/pasteboard/init.lua
+++ b/extensions/pasteboard/init.lua
@@ -12,4 +12,49 @@ require("hs.sound")
 require("hs.styledtext")
 require("hs.drawing.color")
 
+-- Public interface ------------------------------------------------------
+
+--- hs.pasteboard.readAllData([name]) -> table
+--- Function
+--- Returns all values in the first item on the pasteboard in a table that maps a UTI value to the raw data of the item
+---
+--- Parameters:
+---  * name - an optional string indicating the pasteboard name.  If nil or not present, defaults to the system pasteboard.
+---
+--- Returns:
+--   a mapping from a UTI value to the raw data
+module.readAllData = function (name)
+  local contents = {}
+  for _, uti in ipairs(module.contentTypes(name)) do
+    contents[uti] = module.readDataForUTI(name, uti)
+  end
+  return contents
+end
+
+--- hs.pasteboard.writeAllData([name], table) -> boolean
+--- Function
+--- Stores in the pasteboard a given table of UTI to data mapping all at once
+---
+--- Parameters:
+---  * name - an optional string indicating the pasteboard name.  If nil or not present, defaults to the system pasteboard.
+---  * a mapping from a UTI value to the raw data
+---
+--- Returns:
+--   * True if the operation succeeded, otherwise false (in which case only some of the data might have been stored)
+module.writeAllData = function (...)
+  local name, contents
+  if #{...} == 1 then
+    contents = ...
+  else
+    name, contents = ...
+  end
+
+  local ok = true
+  module.clearContents(name)
+  for uti, data in pairs(contents) do
+    ok = ok and module.writeDataForUTI(name, uti, data, true)
+  end
+  return ok
+end
+
 return module

--- a/extensions/pasteboard/init.lua
+++ b/extensions/pasteboard/init.lua
@@ -40,7 +40,7 @@ end
 ---  * a mapping from a UTI value to the raw data
 ---
 --- Returns:
---   * True if the operation succeeded, otherwise false (in which case only some of the data might have been stored)
+--   * True if the operation succeeded, otherwise false (which most likely means ownership of the pasteboard has changed)
 module.writeAllData = function (...)
   local name, contents
   if #{...} == 1 then

--- a/extensions/pasteboard/internal.m
+++ b/extensions/pasteboard/internal.m
@@ -458,7 +458,7 @@ static int readArchivedDataForType(lua_State *L) {
 ///  * add  - an optional boolean value specifying if data with other UTI values should retain.  This value must be strictly either true or false if given, to avoid ambiguity with preceding parameters.
 ///
 /// Returns:
-///  * True if the operation succeeded, otherwise false
+///  * True if the operation succeeded, otherwise false (which most likely means ownership of the pasteboard has changed)
 ///
 /// Notes:
 ///  * NSKeyedArchiver specifies an architecture-independent format that is often used in OS X applications to store and transmit objects between applications and when storing data to a file. It works by recording information about the object types and key-value pairs which make up the objects being stored.
@@ -522,7 +522,7 @@ static int writeArchivedDataForType(lua_State *L) {
 ///  * add  - an optional boolean value specifying if data with other UTI values should retain.  This value must be strictly either true or false if given, to avoid ambiguity with preceding parameters.
 ///
 /// Returns:
-///  * True if the operation succeeded, otherwise false
+///  * True if the operation succeeded, otherwise false (which most likely means ownership of the pasteboard has changed)
 ///
 /// Notes:
 ///  * The UTI's of the items on the pasteboard can be determined with the [hs.pasteboard.allContentTypes](#allContentTypes) and [hs.pasteboard.contentTypes](#contentTypes) functions.
@@ -581,7 +581,7 @@ static int writeItemForType(lua_State *L) {
 ///  * add  - an optional boolean value specifying if data with other UTI values should retain.  This value must be strictly either true or false if given, to avoid ambiguity with preceding parameters.
 ///
 /// Returns:
-///  * True if the operation succeeded, otherwise false
+///  * True if the operation succeeded, otherwise false (which most likely means ownership of the pasteboard has changed)
 ///
 /// Notes:
 ///  * The UTI's of the items on the pasteboard can be determined with the [hs.pasteboard.allContentTypes](#allContentTypes) and [hs.pasteboard.contentTypes](#contentTypes) functions.


### PR DESCRIPTION
Currently hs.pasteboard.writeDataForUTI() always clears the pasteboard before writing given data, so you cannot store multiple values with differnt UTIs.

This PR adds an optional flag `add` which allows you to optionally "add" a new value in addition to existing values with different UTIs.

New utility functions readAllData() and writeAllData() are also added so you can easily save and restore what's in the pasteboard.