### PR TITLE
hs.noises use internal queue for internal callback

### DIFF
--- a/extensions/noises/internal.m
+++ b/extensions/noises/internal.m
@@ -103,7 +103,7 @@ void AudioInputCallback(void * inUserData,  // Custom audio metadata
   status = AudioQueueNewInput(&recordState.dataFormat,
                               AudioInputCallback,
                               (__bridge void *)self,
-                              CFRunLoopGetCurrent(),
+                              NULL, // seems more responsive than CFRunLoopGetCurrent(),
                               kCFRunLoopCommonModes,
                               0,
                               &recordState.queue);


### PR DESCRIPTION
Per docs for AudioQueueNewInput:

> inCallbackRunLoop	
> The event loop on which the callback function pointed to by the inCallbackProc parameter is to be called. If you specify NULL, the callback is called on one of the audio queue’s internal threads.

More reliable sound detection when Hammerspoon is under load.