### PR TITLE
add `interface` to hsminweb and hsdoc

### DIFF
--- a/extensions/doc/hsdocs/init.lua
+++ b/extensions/doc/hsdocs/init.lua
@@ -372,6 +372,8 @@ end
 --- Notes:
 ---  * See `hs.httpserver.setInterface` for a description of valid values that can be specified as the `interface` argument to this function.
 ---  * A change to the interface can only occur when the documentation server is not running. If the server is currently active when you call this function with an argument, the server will be temporarily stopped and then restarted after the interface has been changed.
+---
+---  * Changes made with this function are saved with `hs.settings` with the label "_documentationServer.interface" and will persist through a reload or restart of Hammerspoon.
 module.interface = function(...)
     local args = table.pack(...)
     if args.n > 0 then
@@ -414,7 +416,7 @@ end
 --- Notes:
 ---  * The default port number is 12345.
 ---
----  * This value is stored in the Hammerspoon application defaults with the label "_documentationServer.serverPort".
+---  * Changes made with this function are saved with `hs.settings` with the label "_documentationServer.serverPort" and will persist through a reload or restart of Hammerspoon.
 module.port = function(...)
     local args = table.pack(...)
     local value = args[1]
@@ -438,8 +440,8 @@ end
 ---  * the table representing the `hs.doc.hsdocs` module
 ---
 --- Notes:
----  * This function is automatically called, if necessary, when `hs.doc.hsdocs.help` is invoked.
----  * The documentation web server can be viewed from a web browser by visiting "http://localhost:port" where `port` is the port the server is running on, 12345 by default -- see `hs.doc.hsdocs.port`.
+---  * This function is automatically called, if necessary, when [hs.doc.hsdocs.help](#help) is invoked.
+---  * The documentation web server can be viewed from a web browser by visiting "http://localhost:port" where `port` is the port the server is running on, 12345 by default -- see [hs.doc.hsdocs.port](#port).
 module.start = function()
     if module._server then
         error("documentation server already running")
@@ -530,10 +532,10 @@ end
 ---  * the current, possibly new, value
 ---
 --- Notes:
----  * If `hs.doc.hsdocs.trackBrowserFrame` is false or nil (the default), then you can use this function to specify the initial position of the documentation browser.
----  * If `hs.doc.hsdocs.trackBrowserFrame` is true, then this any value set with this function will be overwritten whenever the browser window is moved or resized.
+---  * If [hs.doc.hsdocs.trackBrowserFrame](#trackBrowserFrame) is false or nil (the default), then you can use this function to specify the initial position of the documentation browser.
+---  * If [hs.doc.hsdocs.trackBrowserFrame](#trackBrowserFrame) is true, then this any value set with this function will be overwritten whenever the browser window is moved or resized.
 ---
----  * This value is stored in the Hammerspoon application defaults with the label "_documentationServer.browserFrame".
+---  * Changes made with this function are saved with `hs.settings` with the label "_documentationServer.browserFrame" and will persist through a reload or restart of Hammerspoon.
 module.browserFrame = function(...)
     local args = table.pack(...)
     local value = args[1]
@@ -556,7 +558,7 @@ end
 ---  * the current, possibly new, value
 ---
 --- Notes:
----  * This value is stored in the Hammerspoon application defaults with the label "_documentationServer.trackBrowserFrameChanges".
+---  * Changes made with this function are saved with `hs.settings` with the label "_documentationServer.trackBrowserFrameChanges" and will persist through a reload or restart of Hammerspoon.
 module.trackBrowserFrame = function(...)
     local args = table.pack(...)
     if args.n == 1 and (type(args[1]) == "boolean" or type(args[1]) == "nil") then
@@ -582,7 +584,7 @@ end
 --- Notes:
 ---  * Inversion is applied through the use of CSS filtering, so while numeric values other than 0 (false) and 100 (true) are allowed, the result is generally not what is desired.
 ---
----  * This value is stored in the Hammerspoon application defaults with the label "_documentationServer.invertDocs".
+---  * Changes made with this function are saved with `hs.settings` with the label "_documentationServer.invertDocs" and will persist through a reload or restart of Hammerspoon.
 module.browserDarkMode = function(...)
     local args = table.pack(...)
     local value = args[1]
@@ -609,7 +611,7 @@ end
 ---
 ---  * This behavior is triggered automatically, regardless of this setting, if you are running with a version of OS X prior to 10.10, since `hs.webview` requires OS X 10.10 or later.
 ---
----  * This value is stored in the Hammerspoon application defaults with the label "_documentationServer.forceExternalBrowser".
+---  * Changes made with this function are saved with `hs.settings` with the label "_documentationServer.forceExternalBrowser" and will persist through a reload or restart of Hammerspoon.
 module.forceExternalBrowser = function(...)
     local args = table.pack(...)
     local value = args[1]

--- a/extensions/httpserver/hsminweb.lua
+++ b/extensions/httpserver/hsminweb.lua
@@ -1428,7 +1428,7 @@ end
 ---
 --- Notes:
 ---  * See `hs.httpserver.setInterface` for a description of valid values that can be specified as the `interface` argument to this method.
----  * the interface can only be specified before the hsminweb web server has been started.  If you wish to change the listening interface for a running web server, you must stop it with [hs.httpserver.hsminweb:stop()](#stop) before invoking this method and then restart it with [hs.httpserver.hsminweb:start](#start).
+---  * the interface can only be specified before the hsminweb web server has been started.  If you wish to change the listening interface for a running web server, you must stop it with [hs.httpserver.hsminweb:stop](#stop) before invoking this method and then restart it with [hs.httpserver.hsminweb:start](#start).
 objectMethods.interface = function(self, ...)
     local args = table.pack(...)
     if args.n == 0 then

--- a/extensions/httpserver/hsminweb.lua
+++ b/extensions/httpserver/hsminweb.lua
@@ -18,15 +18,10 @@
 --- `require("hs.doc.hsdocs").start()` and then visiting `http://localhost:12345/` with your web browser.
 
 --   [ ] Wiki docs
---   [ ] Add browser with hs.webview to hsdocs
 --   [ ] Add way to render template (and cgi?) to file
 --
 --   [ ] document headers._ support table for error functions
 --   [ ] document _allowRenderTranslations, _logBadTranslations, and _logPageErrorTranslations
---
--- Review to determine if basic support is sufficiently "correct"
---   [ ] additional response headers?
---   [ ] Additional errors to add?
 --
 -- May see how hard these would be... maybe only for Hammerspoon/Lua Template pages
 --   [ ] basic/digest auth via lua only?
@@ -1421,6 +1416,37 @@ objectMethods.accessList = function(self, ...)
     end
 end
 
+--- hs.httpserver.hsminweb:interface([interface]) -> hsminwebTable | current-value
+--- Method
+--- Get or set the network interface that the hsminweb web server will listen on
+---
+--- Paramaters:
+---  * interface - an optional string, or nil, specifying the network interface the web server will listen on.  An explicit nil specifies that the web server should listen on all active interfaces for the machine.  Defaults to nil.
+---
+--- Returns:
+---  * the hsminwebTable object if a parameter is provided, or the current value if no parameter is specified.
+---
+--- Notes:
+---  * See `hs.httpserver.setInterface` for a description of valid values that can be specified as the `interface` argument to this method.
+---  * the interface can only be specified before the hsminweb web server has been started.  If you wish to change the listening interface for a running web server, you must stop it with [hs.httpserver.hsminweb:stop()](#stop) before invoking this method and then restart it with [hs.httpserver.hsminweb:start](#start).
+objectMethods.interface = function(self, ...)
+    local args = table.pack(...)
+    if args.n == 0 then
+        return self._interface
+    else
+        if not self._server then
+            if args[1] == nil or type(args[1]) == "string" then
+                self._interface = args[1]
+            else
+                error("interface must be nil or a string", 2)
+            end
+        else
+            error("cannot set the interface on a running hsminweb web server", 2)
+        end
+        return self
+    end
+end
+
 --- hs.httpserver.hsminweb:start() -> hsminwebTable
 --- Method
 --- Start serving pages for the hsminweb web server.
@@ -1441,6 +1467,7 @@ objectMethods.start = function(self)
         if self._port                 then self._server:setPort(self._port) end
         if self._name                 then self._server:setName(self._name) end
         if self._maxBodySize          then self._server:maxBodySize(self._maxBodySize) end
+        if self._interface            then self._server:setInterface(self._interface) end
         if mt_table.__passwords[self] then self._server:setPassword(mt_table.__passwords[self]) end
 
         self._server:start()


### PR DESCRIPTION
further addresses #1293 

Note that this pull requires a build from the current (as of its submission) master -- the latest formal release does not support `hs.httpserver.setInterface` so this pull will not work for that even though the changes in this pull are only to lua files.

Adds

>hs.httpserver.hsminweb:interface([interface]) -> hsminwebTable | current-value
>Method
>Get or set the network interface that the hsminweb web server will listen on
>
>Paramaters:
> * interface - an optional string, or nil, specifying the network interface the web server will listen on.  An explicit nil specifies that the web server should listen on all active interfaces for the machine.  Defaults to nil.
>
>Returns:
> * the hsminwebTable object if a parameter is provided, or the current value if no parameter is specified.
>
>Notes:
> * See `hs.httpserver.setInterface` for a description of valid values that can be specified as the `interface` argument to this method.
> * the interface can only be specified before the hsminweb web server has been started.  If you wish to change the listening interface for a running web server, you must stop it with [hs.httpserver.hsminweb:stop()](#stop) before invoking this method and then restart it with [hs.httpserver.hsminweb:start](#start).

and

>hs.doc.hsdocs.interface([interface]) -> currentValue
>Function
>Get or set the network interface that the Hammerspoon documentation web server will be served on
>
>Paramaters:
> * interface - an optional string, or nil, specifying the network interface the Hammerspoon documentation web server will be served on.  An explicit nil specifies that the web server should listen on all active interfaces for the machine.  Defaults to "localhost".
>
>Returns:
> * the current, possibly new, value
>
>Notes:
> * See `hs.httpserver.setInterface` for a description of valid values that can be specified as the `interface` argument to this function.
> * A change to the interface can only occur when the documentation server is not running. If the server is currently active when you call this function with an argument, the server will be temporarily stopped and then restarted after the interface has been changed.

The difference in behavior between `hs.httpserver.hsminweb:interface` and `hs.doc.hsdocs.interface` when a server is active (i.e. already started) is intended -- `hsminweb` aims to give you complete control over a (mostly) standards compliant web server; the internal documentation is intended to be available to the newest of users and should be as easy to access and change as possible.

This can be altered if preferred.