### PR TITLE
Make checking return value of hs.eventtap.event:getFlags() easier

### DIFF
--- a/extensions/eventtap/eventtap_event.h
+++ b/extensions/eventtap/eventtap_event.h
@@ -5,6 +5,7 @@
 #import <LuaSkin/LuaSkin.h>
 
 #define EVENT_USERDATA_TAG  "hs.eventtap.event"
+#define MODS_USERDATA_TAG   "hs.eventtap.event.modifiers"
 
 NSPoint hs_topoint(lua_State* L, int idx) {
     luaL_checktype(L, idx, LUA_TTABLE);

--- a/extensions/eventtap/internal.m
+++ b/extensions/eventtap/internal.m
@@ -231,7 +231,7 @@ static int eventtap_isEnabled(lua_State* L) {
 /// Returns a table containing the current key modifiers being pressed or in effect *at this instant* for the keyboard most recently used.
 ///
 /// Parameters:
-///  * raw - an optional boolean value which, if true, includes the _raw key contining the numeric representation of all of the keyboard/modifier flags.
+///  * raw - an optional boolean value which, if true, includes the _raw key containing the numeric representation of all of the keyboard/modifier flags.
 ///
 /// Returns:
 ///  * Returns a table containing boolean values indicating which keyboard modifiers were held down when the function was invoked; The possible keys are:


### PR DESCRIPTION
It hasn't been a very easy task to check return value of `hs.eventtap.event:getFlags()`, because it is a table of key-values which cannot be simply tested against another list of values in Lua, even if you use `hs.fnutils`.

For example, to tell if pressed modifiers are exactly "cmd" and "shift", you have to say something like this:
```lua
local flags = e:getFlags()
if flags.cmd and flags.shift and not flags.ctrl and not flags.alt and not flag.fn then
  -- Listing all of existing modifiers..
end
```
Which is way too far from optimal.

This PR adds two methods to return value of hs.eventtap.event:getFlags().

- contain(mods) -> boolean

  Returns true if the modifiers contain all of given modifiers

- containExactly(mods) -> boolean

  Returns true if the modifiers contain all of given modifiers exactly and nothing else

```lua
if e:getFlags():containExactly{"cmd", "shift"} then
  -- Easy, no variable assignment!
end
```

The names I propose here are just some random choices, but what do you guys think about the idea of making it easier to test for pressed modifiers?