### PR TITLE
Fix the key name for kVK_ANSI_Quote in the kTISPropertyUnicodeKeyLayoutData fallback table

### DIFF
--- a/extensions/keycodes/internal.m
+++ b/extensions/keycodes/internal.m
@@ -100,7 +100,7 @@ int keycodes_cachemap(lua_State* L) {
         pushkeycode(L, kVK_ANSI_Minus, "-");
         pushkeycode(L, kVK_ANSI_RightBracket, "]");
         pushkeycode(L, kVK_ANSI_LeftBracket, "[");
-        pushkeycode(L, kVK_ANSI_Quote, "\"");
+        pushkeycode(L, kVK_ANSI_Quote, "'");
         pushkeycode(L, kVK_ANSI_Semicolon, ";");
         pushkeycode(L, kVK_ANSI_Backslash, "\\");
         pushkeycode(L, kVK_ANSI_Comma, ",");


### PR DESCRIPTION
It is for the single quote, not the double quote.  Because of this typo, you get the following results when you specify the quote key:

```
> hk = hs.hotkey.bind({"ctrl"}, "'", function () hs.eventtap.keyStroke({}, "`") end)
2017-04-14 18:57:57: 18:57:57 ** Warning:hs.keycode: key ''' not found in active keymap; using ANSI-standard US keyboard layout as fallback, returning '39'
2017-04-14 18:57:57:              hotkey: Enabled hotkey ⌃"
```

As you can see, the quote key only works thanks to the fallback to the ANSI/US layout, and the human representation for the key code 39 is incorrect.