### PR TITLE
console is now fully themeable

### DIFF
--- a/Hammerspoon/MJConsoleWindowController.h
+++ b/Hammerspoon/MJConsoleWindowController.h
@@ -3,8 +3,15 @@
 
 @interface MJConsoleWindowController : NSWindowController
 
+@property NSColor *MJColorForStdout ;
+@property NSColor *MJColorForCommand ;
+@property NSColor *MJColorForResult ;
+@property NSFont  *consoleFont ;
+
 + (instancetype) singleton;
 - (void) setup;
+
+- (void)initializeConsoleColorsAndFont ;
 
 BOOL MJConsoleWindowAlwaysOnTop(void);
 void MJConsoleWindowSetAlwaysOnTop(BOOL alwaysOnTop);

--- a/Hammerspoon/MJConsoleWindowController.m
+++ b/Hammerspoon/MJConsoleWindowController.m
@@ -2,10 +2,6 @@
 #import "MJLua.h"
 #import "variables.h"
 
-#define MJColorForStdout [NSColor colorWithCalibratedHue:0.88 saturation:1.0 brightness:0.6 alpha:1.0]
-#define MJColorForCommand [NSColor blackColor]
-#define MJColorForResult [NSColor colorWithCalibratedHue:0.54 saturation:1.0 brightness:0.7 alpha:1.0]
-
 @interface MJConsoleWindowController ()
 
 @property NSMutableArray* history;
@@ -30,8 +26,17 @@ typedef NS_ENUM(NSUInteger, MJReplLineType) {
     if (self) {
         self.dateFormatter = [[NSDateFormatter alloc] init];
         [self.dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
+
+        [self initializeConsoleColorsAndFont] ;
     }
     return self;
+}
+
+- (void)initializeConsoleColorsAndFont {
+    self.MJColorForStdout  = [NSColor colorWithCalibratedHue:0.88 saturation:1.0 brightness:0.6 alpha:1.0] ;
+    self.MJColorForCommand = [NSColor blackColor] ;
+    self.MJColorForResult  = [NSColor colorWithCalibratedHue:0.54 saturation:1.0 brightness:0.7 alpha:1.0] ;
+    self.consoleFont       = [NSFont fontWithName:@"Menlo" size:12.0] ;
 }
 
 - (NSString*) windowNibName {
@@ -89,18 +94,18 @@ typedef NS_ENUM(NSUInteger, MJReplLineType) {
 - (void) appendString:(NSString*)str type:(MJReplLineType)type {
     NSColor* color = nil;
     switch (type) {
-        case MJReplLineTypeStdout:  color = MJColorForStdout; break;
-        case MJReplLineTypeCommand: color = MJColorForCommand; break;
-        case MJReplLineTypeResult:  color = MJColorForResult; break;
+        case MJReplLineTypeStdout:  color = self.MJColorForStdout; break;
+        case MJReplLineTypeCommand: color = self.MJColorForCommand; break;
+        case MJReplLineTypeResult:  color = self.MJColorForResult; break;
     }
 
     if (type == MJReplLineTypeStdout) {
         str = [NSString stringWithFormat:@"%@: %@", [self.dateFormatter stringFromDate:[NSDate date]], str];
     }
 
-    NSDictionary* attrs = @{NSFontAttributeName: [NSFont fontWithName:@"Menlo" size:12.0], NSForegroundColorAttributeName: color};
+    NSDictionary* attrs = @{NSFontAttributeName: self.consoleFont, NSForegroundColorAttributeName: color};
     NSAttributedString* attrstr = [[NSAttributedString alloc] initWithString:str attributes:attrs];
-    [[self.outputView textStorage] performSelectorOnMainThread:@selector(appendAttributedString:) 
+    [[self.outputView textStorage] performSelectorOnMainThread:@selector(appendAttributedString:)
                                        withObject:attrstr
                                     waitUntilDone:YES];
 }
@@ -118,7 +123,7 @@ typedef NS_ENUM(NSUInteger, MJReplLineType) {
 
     [sender setStringValue:@""];
     [(HSGrowingTextField *)sender resetGrowth];
-    
+
     [self saveToHistory:command];
     [self.outputView scrollToEndOfDocument:self];
 }

--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -551,6 +551,8 @@ void MJLuaDestroy(void) {
 void MJLuaReplace(void) {
     MJLuaDeinit();
     MJLuaDealloc();
+    [[MJConsoleWindowController singleton] initializeConsoleColorsAndFont] ;
+
     MJLuaAlloc();
     MJLuaInit();
 }
@@ -671,10 +673,10 @@ void fileDroppedToDockIcon(NSString *filePath) {
 void callDockIconCallback(void) {
     LuaSkin *skin = MJLuaState;
     lua_State *L = MJLuaState.L;
-    
+
     lua_getglobal(L, "hs");
     lua_getfield(L, -1, "dockIconClickCallback");
-    
+
     if (lua_type(L, -1) == LUA_TFUNCTION) {
         [skin protectedCallAndTraceback:0 nresults:0];
     }


### PR DESCRIPTION
Been meaning  to do this for a while.

Adds functions to `hs.console` to change console colors and font, e.g.:
<img width="1392" alt="screen shot 2017-04-24 at 5 01 31 pm" src="https://cloud.githubusercontent.com/assets/8139480/25361130/255e8dc0-2912-11e7-83f6-98fb6a3cb549.png">
