### PR TITLE
adds in page search for hsdocs web pages for module details

### DIFF
--- a/extensions/doc/builder.lua
+++ b/extensions/doc/builder.lua
@@ -34,24 +34,27 @@ local sections = {
     Method      = 8,
 }
 
---- hs.doc.builder.genComments(path) -> table
+--- hs.doc.builder.genComments(path, [recurse]) -> table
 --- Function
 --- Generates a documentation table for Hammerspoon modules or Spoon bundles from the source files located in the path(s) provided.
 ---
 --- Parameters:
 ---  * where - a string specifying a single path, or a table containing multiple strings specifying paths where source files should be examined to generate the documentation table.
+---  * recurse - an optional boolean, default true, specifying whether or not files in sub-directories of the specified path should be examined for comment strings as well.
 ---
 --- Returns:
 ---  * table - a table containing the documentation broken out into the key-value pairs used to generate documentation displayed by `hs.doc` and `hs.doc.hsdocs`.
 ---
 --- Notes:
 ---  * Because Hammerspoon and all known currently available modules are coded in Objective-C and/or Lua, only files with the .m or .lua extension are examined in the provided path(s).  Please submit an issue (or pull request, if you modify this submodule yourself) at https://github.com/Hammerspoon if you need this to be changed for your addition.
-module.genComments = function(where)
+module.genComments = function(where, recurse)
     -- get the comments from the specified path(s)
     local text = {}
     if type(where) == "string" then where = { where } end
+    if type(recurse) == "nil" then recurse = true end
+    local maxDepth = recurse and " -maxdepth 1" or ""
     for _, path in ipairs(where) do
-        for _, file in ipairs(fnutils.split(hs.execute("find "..path.." -name \\*.lua -print -o -name \\*.m -print"), "[\r\n]")) do
+        for _, file in ipairs(fnutils.split(hs.execute("find "..path..maxDepth.." -name \\*.lua -print -o -name \\*.m -print"), "[\r\n]")) do
             if file ~= "" then
                 local comment, incomment = {}, false
                 for line in io.lines(file) do

--- a/extensions/doc/hsdocs/common.lp
+++ b/extensions/doc/hsdocs/common.lp
@@ -53,3 +53,8 @@
 
   addEvent(window, 'load', function() { setInvertLevel(<%= invertLevel %>); } );
 </script>
+
+<link rel="stylesheet" href="<%= cgilua.mkurlpath("docs.css") %>" type="text/css" media="screen" />
+<style type="text/css">
+  h1 { margin:0; }
+</style>

--- a/extensions/doc/hsdocs/index.lp
+++ b/extensions/doc/hsdocs/index.lp
@@ -69,6 +69,36 @@
     <link rel="stylesheet" href="<%= cgilua.mkurlpath("docs.css") %>" type="text/css" media="screen" />
     <style type="text/css">
       h1 { margin:0; }
+      div.searchbar {
+        display: none;
+        top: 0;
+        left: 0;
+        width: 100%;
+        text-align: right;
+        position: fixed;
+        padding: 5px;
+      }
+      span.searchcontrols {
+        background-color: #ccc;
+        padding: 10px;
+        border-radius: 10px;
+      }
+      span.searchcontrols a {
+        font-size: .8rem;
+        font-style: italic;
+      }
+      ::-webkit-input-placeholder {
+         font-style: italic;
+      }
+      :-moz-placeholder {
+         font-style: italic;
+      }
+      ::-moz-placeholder {
+         font-style: italic;
+      }
+      :-ms-input-placeholder {
+         font-style: italic;
+      }
     </style>
 
     <script type="text/javascript">
@@ -97,6 +127,13 @@
   </head>
 
   <body>
+    <div class="searchbar" id="searcher">
+        <span class="searchcontrols">
+            <a href="javascript:searchForText(1)">⌘⇧-G prev</a>
+            &nbsp;<input type="text" id="query" placeholder="enter search term"/>&nbsp;
+            <a href="javascript:searchForText(0)">⌘-G next</a>
+        </span>
+    </div>
     <header>
       <h1>Hammerspoon.app</h1>
     </header>
@@ -140,8 +177,37 @@
   </body>
 
   <script type="text/javascript">
-  // Get the element with id="defaultOpen" and click on it
-  document.getElementById("defaultOpen").click();
+    // Get the element with id="defaultOpen" and click on it
+    document.getElementById("defaultOpen").click();
+
+    function searchForText(direction) {
+        return window.find(document.getElementById('query').value, 0, direction, 1) ;
+    }
+
+    function KeyPressHappened(e) {
+//       console.log(e) ;
+      code = e.keyCode ;
+      if ((code == 102) && e.metaKey) { // Cmd-F
+          if (document.getElementById("searcher").style.display == "block") {
+              document.getElementById("searcher").style.display = "none" ;
+          } else {
+              document.getElementById("searcher").style.display = "block" ;
+              document.getElementById('query').focus()
+          }
+      } else if (document.getElementById("searcher").style.display == "block") {
+          if ((code == 13 || (code == 103 && e.metaKey)) && e.shiftKey) {         // Shift-enter or Cmd-Shift-G
+            searchForText(1) ;
+          } else if ((code == 13 || (code == 103 && e.metaKey)) && !e.shiftKey) { // enter or Cmd-G
+             searchForText(0) ;
+          } else {
+            return true ;
+          }
+      } else {
+          return true ;
+      }
+      return false ;
+    }
+    document.onkeypress = KeyPressHappened;
   </script>
 
 <%= "<","!--" %> -->

--- a/extensions/doc/hsdocs/index.lp
+++ b/extensions/doc/hsdocs/index.lp
@@ -66,40 +66,6 @@
       }
 
     </style>
-    <link rel="stylesheet" href="<%= cgilua.mkurlpath("docs.css") %>" type="text/css" media="screen" />
-    <style type="text/css">
-      h1 { margin:0; }
-      div.searchbar {
-        display: none;
-        top: 0;
-        left: 0;
-        width: 100%;
-        text-align: right;
-        position: fixed;
-        padding: 5px;
-      }
-      span.searchcontrols {
-        background-color: #ccc;
-        padding: 10px;
-        border-radius: 10px;
-      }
-      span.searchcontrols a {
-        font-size: .8rem;
-        font-style: italic;
-      }
-      ::-webkit-input-placeholder {
-         font-style: italic;
-      }
-      :-moz-placeholder {
-         font-style: italic;
-      }
-      ::-moz-placeholder {
-         font-style: italic;
-      }
-      :-ms-input-placeholder {
-         font-style: italic;
-      }
-    </style>
 
     <script type="text/javascript">
       function openTab(evt, cityName) {
@@ -127,13 +93,6 @@
   </head>
 
   <body>
-    <div class="searchbar" id="searcher">
-        <span class="searchcontrols">
-            <a href="javascript:searchForText(1)">⌘⇧-G prev</a>
-            &nbsp;<input type="text" id="query" placeholder="enter search term"/>&nbsp;
-            <a href="javascript:searchForText(0)">⌘-G next</a>
-        </span>
-    </div>
     <header>
       <h1>Hammerspoon.app</h1>
     </header>
@@ -173,41 +132,12 @@
         <% end %>
       </table>
     </div>
-
+  <% cgilua.lp.include("search.lp") %>
   </body>
 
   <script type="text/javascript">
     // Get the element with id="defaultOpen" and click on it
     document.getElementById("defaultOpen").click();
-
-    function searchForText(direction) {
-        return window.find(document.getElementById('query').value, 0, direction, 1) ;
-    }
-
-    function KeyPressHappened(e) {
-//       console.log(e) ;
-      code = e.keyCode ;
-      if ((code == 102) && e.metaKey) { // Cmd-F
-          if (document.getElementById("searcher").style.display == "block") {
-              document.getElementById("searcher").style.display = "none" ;
-          } else {
-              document.getElementById("searcher").style.display = "block" ;
-              document.getElementById('query').focus()
-          }
-      } else if (document.getElementById("searcher").style.display == "block") {
-          if ((code == 13 || (code == 103 && e.metaKey)) && e.shiftKey) {         // Shift-enter or Cmd-Shift-G
-            searchForText(1) ;
-          } else if ((code == 13 || (code == 103 && e.metaKey)) && !e.shiftKey) { // enter or Cmd-G
-             searchForText(0) ;
-          } else {
-            return true ;
-          }
-      } else {
-          return true ;
-      }
-      return false ;
-    }
-    document.onkeypress = KeyPressHappened;
   </script>
 
 <%= "<","!--" %> -->

--- a/extensions/doc/hsdocs/init.lua
+++ b/extensions/doc/hsdocs/init.lua
@@ -200,21 +200,21 @@ local makeToolbar = function(browser)
         },
         {
             id = "prev",
-            tooltip = "Display previous page",
+            tooltip = "Display previously viewed page in history",
             image = toolbarImages.prevArrow,
             enable = false,
             allowedAlone = false,
         },
         {
             id = "next",
-            tooltip = "Display next page",
+            tooltip = "Display next viewed page in history",
             image = toolbarImages.nextArrow,
             enable = false,
             allowedAlone = false,
         },
         {
             id = "search",
-            tooltip = "Search for a HS function or method",
+            tooltip = "Search for a Hammerspoon function or method by name",
             searchfield = true,
             searchWidth = 250,
             searchPredefinedSearches = makeModuleListForMenu(),
@@ -227,7 +227,7 @@ local makeToolbar = function(browser)
         { id = "NSToolbarFlexibleSpaceItem" },
         {
             id = "mode",
-            tooltip = "Toggle display mode",
+            tooltip = "Toggle display mode between System/Dark/Light",
             image = toolbarImages.followMode,
         },
         {

--- a/extensions/doc/hsdocs/init.lua
+++ b/extensions/doc/hsdocs/init.lua
@@ -24,10 +24,12 @@ local webview   = require"hs.webview"
 local doc       = require"hs.doc"
 local watchable = require"hs.watchable"
 local timer     = require"hs.timer"
+local host      = require"hs.host"
+local hotkey    = require"hs.hotkey"
 
 local documentRoot = package.searchpath("hs.doc.hsdocs", package.path):match("^(/.*/).*%.lua$")
 
-local osVersion = require"hs.host".operatingSystemVersion()
+local osVersion = host.operatingSystemVersion()
 
 local toolbarImages = {
     prevArrow = image.imageFromASCII(".......\n" ..
@@ -143,6 +145,12 @@ local toolbarImages = {
 local frameTracker = function(cmd, wv, opt)
     if cmd == "frameChange" and settings.get("_documentationServer.trackBrowserFrameChanges") then
         settings.set("_documentationServer.browserFrame", opt)
+    elseif cmd == "focusChange" then
+        if module._modalKeys then
+            if opt then module._modalKeys:enter() else module._modalKeys:exit() end
+        end
+    elseif cmd == "close" then
+        if module._modalKeys then module._modalKeys:exit() end
     end
 end
 
@@ -270,7 +278,10 @@ local makeToolbar = function(browser)
                   -- shouldn't be possible, but...
                   module.browserDarkMode(nil)
               end
-              w:reload()
+--              w:reload()
+              local current = module.browserDarkMode()
+              if type(current) == "nil" then current = (host.interfaceStyle() == "Dark") end
+              w:evaluateJavaScript("setInvertLevel(" .. (current and "100" or "0") .. ")")
           elseif i == "track" then
               local track = module.trackBrowserFrame()
               if track then
@@ -285,6 +296,51 @@ local makeToolbar = function(browser)
 
     updateToolbarIcons(toolbar, browser)
     return toolbar
+end
+
+local defineHotkeys = function()
+    local hk = hotkey.modal.new()
+    hk:bind({"cmd"},          "f", nil, function() module._browser:evaluateJavaScript("toggleFind()") end)
+    hk:bind({"cmd"},          "l", nil, function()
+        if module._browser:attachedToolbar() then
+            module._browser:attachedToolbar():selectSearchField()
+        end
+    end)
+    hk:bind({"cmd"},          "r", nil, function() module._browser:evaluateJavaScript("window.location.reload(true)") end)
+
+    hk:bind({},          "escape", nil, function()
+        module._browser:evaluateJavaScript([[ document.getElementById("helpStuff").style.display == "block" ]], function(ans1)
+            if ans1 then module._browser:evaluateJavaScript("toggleHelp()") end
+            module._browser:evaluateJavaScript([[ document.getElementById("searcher").style.display == "block" ]], function(ans2)
+                if ans2 then module._browser:evaluateJavaScript("toggleFind()") end
+                if not ans1 and not ans2 then
+                    module._browser:hide()
+                    hk:exit()
+                end
+            end)
+        end)
+    end)
+
+    hk:bind({"cmd"},          "g", nil, function()
+        module._browser:evaluateJavaScript([[ document.getElementById("searcher").style.display == "block" ]], function(ans)
+            if ans then
+                module._browser:evaluateJavaScript("searchForText(0)")
+            end
+        end)
+    end)
+    hk:bind({"cmd", "shift"}, "g", nil, function()
+        module._browser:evaluateJavaScript([[ document.getElementById("searcher").style.display == "block" ]], function(ans)
+            if ans then
+                module._browser:evaluateJavaScript("searchForText(1)")
+            end
+        end)
+    end)
+
+-- because these would interfere with the search field, we let Javascript handle these, see search.lp
+--    hk:bind({},          "return", nil, function() end)
+--    hk:bind({"shift"},   "return", nil, function() end)
+
+    return hk
 end
 
 local makeBrowser = function()
@@ -310,24 +366,18 @@ local makeBrowser = function()
         options.applicationName = "Hammerspoon/" .. hs.processInfo.version
     end
 
-    local ucc = webview.usercontent.new("hsdocs"):setCallback(function(obj)
-        if obj.body == "enableCloseOnEscape" then
-            timer.doAfter(.1, function() module._browser:closeOnEscape(true) end)
-        elseif obj.body == "disableCloseOnEscape" then
-            module._browser:closeOnEscape(false)
-        elseif obj.body == "focusInSearchField" then
-            if module._browser:attachedToolbar() then
-                module._browser:attachedToolbar():selectSearchField()
-            end
-        else
-            print("~~ hsdocs unexpected ucc callback: ", require("hs.inspect")(obj))
-        end
-    end)
+-- not used anymore, but just in case, I'm leaving the skeleton here...
+--    local ucc = webview.usercontent.new("hsdocs"):setCallback(function(obj)
+----        if obj.body == "message" then
+----        else
+--            print("~~ hsdocs unexpected ucc callback: ", require("hs.inspect")(obj))
+----        end
+--    end)
 
-    local browser = webview.new(browserFrame, options, ucc):windowStyle(1+2+4+8)
+--    local browser = webview.new(browserFrame, options, ucc):windowStyle(1+2+4+8)
+    local browser = webview.new(browserFrame, options):windowStyle(1+2+4+8)
       :allowTextEntry(true)
       :allowGestures(true)
-      :closeOnEscape(true)
       :windowCallback(frameTracker)
       :navigationCallback(function(a, w, n, e)
           if e then
@@ -336,10 +386,10 @@ local makeBrowser = function()
           end
           if a == "didFinishNavigation" then
               updateToolbarIcons(w:attachedToolbar(), w)
-              w:closeOnEscape(true) -- in case find was open
           end
       end)
 
+    module._modalKeys = defineHotkeys()
     browser:attachedToolbar(makeToolbar(browser))
     return browser
 end

--- a/extensions/doc/hsdocs/module.lp
+++ b/extensions/doc/hsdocs/module.lp
@@ -150,6 +150,18 @@
         font-size: .8rem;
         font-style: italic;
       }
+      ::-webkit-input-placeholder {
+         font-style: italic;
+      }
+      :-moz-placeholder {
+         font-style: italic;
+      }
+      ::-moz-placeholder {
+         font-style: italic;
+      }
+      :-ms-input-placeholder {
+         font-style: italic;
+      }
     </style>
   </head>
 
@@ -157,7 +169,7 @@
     <div class="searchbar" id="searcher">
         <span class="searchcontrols">
             <a href="javascript:searchForText(1)">⌘⇧-G prev</a>
-            <input type="text" id="query">
+            &nbsp;<input type="text" id="query" placeholder="enter search term"/>&nbsp;
             <a href="javascript:searchForText(0)">⌘-G next</a>
         </span>
     </div>

--- a/extensions/doc/hsdocs/module.lp
+++ b/extensions/doc/hsdocs/module.lp
@@ -131,11 +131,37 @@
         width: 70vw;
       }
 <% end %>
-    </style>
 
+      div.searchbar {
+        display: none;
+        top: 0;
+        left: 0;
+        width: 100%;
+        text-align: right;
+        position: fixed;
+        padding: 5px;
+      }
+      span.searchcontrols {
+        background-color: #ccc;
+        padding: 10px;
+        border-radius: 10px;
+      }
+      span.searchcontrols a {
+        font-size: .8rem;
+        font-style: italic;
+      }
+    </style>
   </head>
 
   <body>
+    <div class="searchbar" id="searcher">
+        <span class="searchcontrols">
+            <a href="javascript:searchForText(1)">⌘⇧-G prev</a>
+            <input type="text" id="query">
+            <a href="javascript:searchForText(0)">⌘-G next</a>
+        </span>
+    </div>
+
     <header>
       <h1><a href="<%= cgilua.mkurlpath("index.lp") .. (isSpoon and "?q=Spoons" or "") %>"><%= (isSpoon and "spoon" or "docs") %></a> &raquo; <%= mod.name %></h1>
       <%= gfmConvert(mod.doc) %>
@@ -204,6 +230,37 @@
       end
     %>
   </body>
+
+  <script type="text/javascript">
+    function searchForText(direction) {
+        return window.find(document.getElementById('query').value, 0, direction, 1) ;
+    }
+
+    function KeyPressHappened(e) {
+//       console.log(e) ;
+      code = e.keyCode ;
+      if ((code == 102) && e.metaKey) { // Cmd-F
+          if (document.getElementById("searcher").style.display == "block") {
+              document.getElementById("searcher").style.display = "none" ;
+          } else {
+              document.getElementById("searcher").style.display = "block" ;
+              document.getElementById('query').focus()
+          }
+      } else if (document.getElementById("searcher").style.display == "block") {
+          if ((code == 13 || (code == 103 && e.metaKey)) && e.shiftKey) {         // Shift-enter or Cmd-Shift-G
+            searchForText(1) ;
+          } else if ((code == 13 || (code == 103 && e.metaKey)) && !e.shiftKey) { // enter or Cmd-G
+             searchForText(0) ;
+          } else {
+            return true ;
+          }
+      } else {
+          return true ;
+      }
+      return false ;
+    }
+    document.onkeypress = KeyPressHappened;
+  </script>
 
 <%= "<","!--" %> -->
 </html>

--- a/extensions/doc/hsdocs/module.lp
+++ b/extensions/doc/hsdocs/module.lp
@@ -94,6 +94,36 @@
 
     <style type="text/css">
       h1 { margin:0; }
+      div.searchbar {
+        display: none;
+        top: 0;
+        left: 0;
+        width: 100%;
+        text-align: right;
+        position: fixed;
+        padding: 5px;
+      }
+      span.searchcontrols {
+        background-color: #ccc;
+        padding: 10px;
+        border-radius: 10px;
+      }
+      span.searchcontrols a {
+        font-size: .8rem;
+        font-style: italic;
+      }
+      ::-webkit-input-placeholder {
+         font-style: italic;
+      }
+      :-moz-placeholder {
+         font-style: italic;
+      }
+      ::-moz-placeholder {
+         font-style: italic;
+      }
+      :-ms-input-placeholder {
+         font-style: italic;
+      }
 
 <% if settings.get("_documentationServer.entitiesInSidebar") then %>
 /* Inspired by https://openuserjs.org/scripts/krasnovpro/hammerspoon.org_Documentation/source */
@@ -131,37 +161,6 @@
         width: 70vw;
       }
 <% end %>
-
-      div.searchbar {
-        display: none;
-        top: 0;
-        left: 0;
-        width: 100%;
-        text-align: right;
-        position: fixed;
-        padding: 5px;
-      }
-      span.searchcontrols {
-        background-color: #ccc;
-        padding: 10px;
-        border-radius: 10px;
-      }
-      span.searchcontrols a {
-        font-size: .8rem;
-        font-style: italic;
-      }
-      ::-webkit-input-placeholder {
-         font-style: italic;
-      }
-      :-moz-placeholder {
-         font-style: italic;
-      }
-      ::-moz-placeholder {
-         font-style: italic;
-      }
-      :-ms-input-placeholder {
-         font-style: italic;
-      }
     </style>
   </head>
 

--- a/extensions/doc/hsdocs/module.lp
+++ b/extensions/doc/hsdocs/module.lp
@@ -4,6 +4,7 @@
 
   <%
       cgilua.lp.include("common.lp")
+
       local modNames = {}
       for i, v in ipairs(documentation) do
           modNames[v.name] = true
@@ -89,41 +90,6 @@
       td { width: 100%; background-color: #EEEEEE; vertical-align: top; padding: 3px; }
       table { width: 100% ; border: 1px solid #0; text-align: left; }
       section > table table td { width: 0; }
-    </style>
-    <link rel="stylesheet" href="<%= cgilua.mkurlpath("docs.css") %>" type="text/css" media="screen" />
-
-    <style type="text/css">
-      h1 { margin:0; }
-      div.searchbar {
-        display: none;
-        top: 0;
-        left: 0;
-        width: 100%;
-        text-align: right;
-        position: fixed;
-        padding: 5px;
-      }
-      span.searchcontrols {
-        background-color: #ccc;
-        padding: 10px;
-        border-radius: 10px;
-      }
-      span.searchcontrols a {
-        font-size: .8rem;
-        font-style: italic;
-      }
-      ::-webkit-input-placeholder {
-         font-style: italic;
-      }
-      :-moz-placeholder {
-         font-style: italic;
-      }
-      ::-moz-placeholder {
-         font-style: italic;
-      }
-      :-ms-input-placeholder {
-         font-style: italic;
-      }
 
 <% if settings.get("_documentationServer.entitiesInSidebar") then %>
 /* Inspired by https://openuserjs.org/scripts/krasnovpro/hammerspoon.org_Documentation/source */
@@ -165,14 +131,6 @@
   </head>
 
   <body>
-    <div class="searchbar" id="searcher">
-        <span class="searchcontrols">
-            <a href="javascript:searchForText(1)">⌘⇧-G prev</a>
-            &nbsp;<input type="text" id="query" placeholder="enter search term"/>&nbsp;
-            <a href="javascript:searchForText(0)">⌘-G next</a>
-        </span>
-    </div>
-
     <header>
       <h1><a href="<%= cgilua.mkurlpath("index.lp") .. (isSpoon and "?q=Spoons" or "") %>"><%= (isSpoon and "spoon" or "docs") %></a> &raquo; <%= mod.name %></h1>
       <%= gfmConvert(mod.doc) %>
@@ -240,38 +198,8 @@
         <% end
       end
     %>
+  <% cgilua.lp.include("search.lp") %>
   </body>
-
-  <script type="text/javascript">
-    function searchForText(direction) {
-        return window.find(document.getElementById('query').value, 0, direction, 1) ;
-    }
-
-    function KeyPressHappened(e) {
-//       console.log(e) ;
-      code = e.keyCode ;
-      if ((code == 102) && e.metaKey) { // Cmd-F
-          if (document.getElementById("searcher").style.display == "block") {
-              document.getElementById("searcher").style.display = "none" ;
-          } else {
-              document.getElementById("searcher").style.display = "block" ;
-              document.getElementById('query').focus()
-          }
-      } else if (document.getElementById("searcher").style.display == "block") {
-          if ((code == 13 || (code == 103 && e.metaKey)) && e.shiftKey) {         // Shift-enter or Cmd-Shift-G
-            searchForText(1) ;
-          } else if ((code == 13 || (code == 103 && e.metaKey)) && !e.shiftKey) { // enter or Cmd-G
-             searchForText(0) ;
-          } else {
-            return true ;
-          }
-      } else {
-          return true ;
-      }
-      return false ;
-    }
-    document.onkeypress = KeyPressHappened;
-  </script>
 
 <%= "<","!--" %> -->
 </html>

--- a/extensions/doc/hsdocs/module.lp
+++ b/extensions/doc/hsdocs/module.lp
@@ -124,7 +124,7 @@
       }
       body {
         margin-left: 20vw;
-        width: 70vw;
+        width: 75vw;
       }
 <% end %>
     </style>
@@ -138,6 +138,23 @@
     <h3>API Overview</h3>
     <ul>
       <%
+        if mod.name ~= "hs" then
+            local submodules = {}
+            local relevantJson = isSpoon and spoonDocumentation or documentation
+            for _, v in ipairs(relevantJson) do
+                if v.name:match("^" .. mod.name .. "%.") then table.insert(submodules, v.name) end
+            end
+
+            if #submodules > 0 then %>
+                <li>Submodules</li>
+                <ul>
+                  <% for _, item in ipairs(submodules) do %>
+                      <li><a href="<%= cgilua.mkurlpath("module.lp/" .. (isSpoon and "spoon." or "") .. item) %>"><%= item %></a></li>
+                  <% end %>
+                </ul>
+          <% end
+        end
+
         local sectionorder = { "Deprecated", "Command", "Constant", "Variable", "Function", "Constructor", "Field", "Method" }
         local sectiondetails = {
           ["Deprecated"]  = "API features which will be removed in an upcoming release",

--- a/extensions/doc/hsdocs/search.lp
+++ b/extensions/doc/hsdocs/search.lp
@@ -63,7 +63,7 @@
 <div class="searchbar" id="searcher">
     <span class="searchcontrols">
         <a href="javascript:searchForText(1)">⌘⇧-G prev</a>
-        &nbsp;<input type="text" id="query" placeholder="enter search term"/>&nbsp;
+        &nbsp;<input type="text" id="query" placeholder="enter search term" onfocusin="editingSearcher = true;" onfocusout="editingSearcher = false;"/>&nbsp;
         <a href="javascript:searchForText(0)">⌘-G next</a>
     </span>
 </div>
@@ -96,10 +96,11 @@
   <section>
     <h5>Keyboard Shortcuts</h5>
     <table>
-      <tr><th>⌘-F</th><td>Toggle the "Find in page" search box.  Close by typing ⌘-F or typing the Escape key.</td></tr>
-      <tr><th>⌘⇧-G</th><td>When the "Find in page" search box is visible, will search for the previous occurrence of the search term in the current page. You may also use ⇧-Enter.</td></tr>
-      <tr><th>⌘-G</th><td>When the "Find in page" search box is visible, will search for the next occurrence of the search term in the current page. You may also use Enter.</td></tr>
-      <tr><th>⌘-L</th><td>Focus the search field at the top of the page so you can type in a module to jump to</td></tr>
+      <tr><th>⌘F</th><td>Toggle the "Find in page" search box.  Close by typing ⌘-F or typing the Escape key.</td></tr>
+      <tr><th>⌘⇧G</th><td>When the "Find in page" search box is visible, will search for the previous occurrence of the search term in the current page. You may also use ⇧-Enter.</td></tr>
+      <tr><th>⌘G</th><td>When the "Find in page" search box is visible, will search for the next occurrence of the search term in the current page. You may also use Enter.</td></tr>
+      <tr><th>⌘L</th><td>Focus the search field at the top of the page so you can type in a module to jump to</td></tr>
+      <tr><th>⌘R</th><td>Reload the current page.</tr>
       <tr><td colspan="2">When neither the "Find in page" search box or this help are visible, the Escape key will close this documentation viewer.</td></tr>
     </table>
   </section>
@@ -112,62 +113,64 @@
       }
       if (state) {
         document.getElementById("helpStuff").style.display = "block";
-        sendToHammerspoon("disableCloseOnEscape");
       } else {
         document.getElementById("helpStuff").style.display = "none";
-        sendToHammerspoon("enableCloseOnEscape");
       }
   }
 
   function searchForText(direction) {
-      return window.find(document.getElementById('query').value, 0, direction, 1) ;
+      var ele = document.getElementById('query') ;
+      var result = window.find(ele.value, 0, direction, 1) ;
+      editingSearcher = (ele.selectionEnd != 0) ;
+      return result ;
   }
 
-  function sendToHammerspoon(msg) {
-      try {
-          webkit.messageHandlers.hsdocs.postMessage(msg);
-      } catch(err) {
-          console.log('The controller does not exist yet');
+  function toggleFind(state) {
+      if (state == null) {
+          state = !(document.getElementById("searcher").style.display == "block");
+      }
+      if (state) {
+        document.getElementById("searcher").style.display = "block";
+        var ele = document.getElementById('query') ;
+        ele.focus();
+        ele.selectionStart = 0;
+        ele.selectionEnd = ele.value.length;
+        editingSearcher = true ;
+      } else {
+        if (editingSearcher) {
+          document.getElementById("searcher").style.display = "none";
+        } else {
+          var ele = document.getElementById('query') ;
+          ele.focus();
+          ele.selectionStart = 0;
+          ele.selectionEnd = ele.value.length;
+          editingSearcher = true ;
+        }
       }
   }
 
+// not used anymore, but just in case, I'm leaving the skeleton here...
+//   function sendToHammerspoon(msg) {
+//       try {
+//           webkit.messageHandlers.hsdocs.postMessage(msg);
+//       } catch(err) {
+//           console.log('The controller does not exist yet');
+//       }
+//   }
+
+// most keys are handled by Hammerspoon with hs.hotkey.modal; allowing enter to find next/prev there would
+// prevent its use elsewhere (i.e. search field in toolbar, forms if we ever add them, etc.
+
   function KeyPressHappened(e) {
 //     console.log(e) ;
-    code = e.keyCode ;
-    if ((code == 102) && e.metaKey && !e.shiftKey) { // Cmd-F
-        if (document.getElementById("searcher").style.display == "block") {
-            document.getElementById("searcher").style.display = "none" ;
-            sendToHammerspoon("enableCloseOnEscape");
-        } else {
-            document.getElementById("searcher").style.display = "block" ;
-            sendToHammerspoon("disableCloseOnEscape");
-            document.getElementById('query').focus()
-        }
-    } else if (code == 108 && e.metaKey && !e.shiftKey) { // Cmd-L
-        sendToHammerspoon("focusInSearchField");
-    } else if (code == 114 && e.metaKey && !e.shiftKey) { // Cmd-R; also causes console to appear... must ponder
-        window.location.reload(true);
-    } else if (document.getElementById("helpStuff").style.display == "block") {
-        if (code == 27) { // Esc
-            toggleHelp();
-        } else {
-            return true;
-        }
-    } else if (document.getElementById("searcher").style.display == "block") {
-        if (code == 27) { // Esc
-            document.getElementById("searcher").style.display = "none" ;
-            sendToHammerspoon("enableCloseOnEscape");
-        } else if ((code == 13 || (code == 103 && e.metaKey)) && e.shiftKey) { // Shift-enter or Cmd-Shift-G
-          searchForText(1) ;
-        } else if ((code == 13 || (code == 103 && e.metaKey)) && !e.shiftKey) { // enter or Cmd-G
-           searchForText(0) ;
-        } else {
-          return true ;
-        }
-    } else {
-        return true ;
+    if (document.getElementById("searcher").style.display == "block") {
+      if (e.keyCode == 13 && !e.altKey && !e.ctrlKey) { // allow [shift] enter to find prev/next
+        searchForText(e.shiftKey ? 1 : 0) ;
+        return false ;
+      }
+      return true ;
     }
-    return false ;
+    return true ;
   }
 
   // see common.lp for "good enough" version of addEvent

--- a/extensions/doc/hsdocs/search.lp
+++ b/extensions/doc/hsdocs/search.lp
@@ -1,0 +1,73 @@
+<style type="text/css">
+  div.searchbar {
+    display: none;
+    top: 0;
+    left: 0;
+    width: 100%;
+    text-align: right;
+    position: fixed;
+    padding: 5px;
+  }
+  span.searchcontrols {
+    background-color: #ccc;
+    padding: 10px;
+    border-radius: 10px;
+  }
+  span.searchcontrols a {
+    font-size: .8rem;
+    font-style: italic;
+  }
+  ::-webkit-input-placeholder {
+     font-style: italic;
+  }
+  :-moz-placeholder {
+     font-style: italic;
+  }
+  ::-moz-placeholder {
+     font-style: italic;
+  }
+  :-ms-input-placeholder {
+     font-style: italic;
+  }
+</style>
+
+<div class="searchbar" id="searcher">
+    <span class="searchcontrols">
+        <a href="javascript:searchForText(1)">⌘⇧-G prev</a>
+        &nbsp;<input type="text" id="query" placeholder="enter search term"/>&nbsp;
+        <a href="javascript:searchForText(0)">⌘-G next</a>
+    </span>
+</div>
+
+<script type="text/javascript">
+  function searchForText(direction) {
+      return window.find(document.getElementById('query').value, 0, direction, 1) ;
+  }
+
+  function KeyPressHappened(e) {
+//       console.log(e) ;
+    code = e.keyCode ;
+    if ((code == 102) && e.metaKey) { // Cmd-F
+        if (document.getElementById("searcher").style.display == "block") {
+            document.getElementById("searcher").style.display = "none" ;
+        } else {
+            document.getElementById("searcher").style.display = "block" ;
+            document.getElementById('query').focus()
+        }
+    } else if (document.getElementById("searcher").style.display == "block") {
+        if ((code == 13 || (code == 103 && e.metaKey)) && e.shiftKey) {         // Shift-enter or Cmd-Shift-G
+          searchForText(1) ;
+        } else if ((code == 13 || (code == 103 && e.metaKey)) && !e.shiftKey) { // enter or Cmd-G
+           searchForText(0) ;
+        } else {
+          return true ;
+        }
+    } else {
+        return true ;
+    }
+    return false ;
+  }
+
+  // see common.lp for "good enough" version of addEvent
+  addEvent(document, "keypress", KeyPressHappened);
+</script>

--- a/extensions/doc/hsdocs/search.lp
+++ b/extensions/doc/hsdocs/search.lp
@@ -1,3 +1,8 @@
+
+<!-- ok, misnamed... everything for the built-in browser only goes here -->
+
+<% if hsminweb.request.headers["User-Agent"]:match("Hammerspoon/[%d%.]+$") then %>
+
 <style type="text/css">
   div.searchbar {
     display: none;
@@ -29,6 +34,23 @@
   :-ms-input-placeholder {
      font-style: italic;
   }
+
+  div.helpScreen {
+    display: none;
+    position: fixed;
+    top: 50%;
+    -webkit-transform: translateY(-50%);
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+    margin-left: auto ;
+    margin-right: auto ;
+    width: 80%;
+    padding: 20px;
+    background-color: #ccc;
+    border-radius: 10px;
+    border-style: solid;
+    border-width: medium;
+  }
 </style>
 
 <div class="searchbar" id="searcher">
@@ -39,23 +61,96 @@
     </span>
 </div>
 
+<div class="helpScreen" id="helpStuff">
+  <h4 style="margin:0">Using the builtin Hammerspoon Documentation Browser<h4>
+  <section>
+    <h5>Toolbar Icons</h5>
+    <table>
+<%
+    local doc = require("hs.doc")
+    local tb  = doc.hsdocs._browser:attachedToolbar()
+    local tbitems = tb:items()
+    local tbimages = {}
+    for _, v in ipairs(tbitems) do
+      if not v:match("^NS") then
+        local tbdt = tb:itemDetails(v)
+        if v == "search" then %>
+          <tr><th><i>🔍 Search</i></th><td><%= tbdt.tooltip %></td></tr>
+        <% elseif v == "navigation" then %>
+          <tr><th><img height="20" width="20" src="<%= tbdt.subitems[1].image:size{ h = 20, w = 20 }:encodeAsURLString() %>">&nbsp;<img height="20" width="20" src="<%= tbdt.subitems[2].image:size{ h = 20, w = 20 }:encodeAsURLString() %>"></th><td><%= tbdt.subitems[1].tooltip .. "/" .. tbdt.subitems[2].tooltip %></td></tr>
+        <% else %>
+          <tr><th><img height="20" width="20" src="<%= tbdt.image:size{ h = 20, w = 20 }:encodeAsURLString() %>"></th><td><%= tbdt.tooltip %></td></tr>
+      <% end
+      end
+    end
+%>
+    </table>
+  </section>
+  <section>
+    <h5>Keyboard Shortcuts</h5>
+    <table>
+      <tr><th>⌘-F</th><td>Toggle the "Find in page" search box.  Close by typing ⌘-F or typing the Escape key.</td></tr>
+      <tr><th>⌘⇧-G</th><td>When the "Find in page" search box is visible, will search for the previous occurrence of the search term in the current page. You may also use ⇧-Enter.</td></tr>
+      <tr><th>⌘-G</th><td>When the "Find in page" search box is visible, will search for the next occurrence of the search term in the current page. You may also use Enter.</td></tr>
+      <tr><th>⌘-L</th><td>Focus the search field at the top of the page so you can type in a module to jump to</td></tr>
+      <tr><td colspan="2">When neither the "Find in page" search box or this help are visible, the Escape key will close this documentation viewer.</td></tr>
+    </table>
+  </section>
+</div>
+
 <script type="text/javascript">
+  function toggleHelp(state) {
+      if (state == null) {
+          state = !(document.getElementById("helpStuff").style.display == "block");
+      }
+      if (state) {
+        document.getElementById("helpStuff").style.display = "block";
+        sendToHammerspoon("disableCloseOnEscape");
+      } else {
+        document.getElementById("helpStuff").style.display = "none";
+        sendToHammerspoon("enableCloseOnEscape");
+      }
+  }
+
   function searchForText(direction) {
       return window.find(document.getElementById('query').value, 0, direction, 1) ;
   }
 
+  function sendToHammerspoon(msg) {
+      try {
+          webkit.messageHandlers.hsdocs.postMessage(msg);
+      } catch(err) {
+          console.log('The controller does not exist yet');
+      }
+  }
+
   function KeyPressHappened(e) {
-//       console.log(e) ;
+//     console.log(e) ;
     code = e.keyCode ;
-    if ((code == 102) && e.metaKey) { // Cmd-F
+    if ((code == 102) && e.metaKey && !e.shiftKey) { // Cmd-F
         if (document.getElementById("searcher").style.display == "block") {
             document.getElementById("searcher").style.display = "none" ;
+            sendToHammerspoon("enableCloseOnEscape");
         } else {
             document.getElementById("searcher").style.display = "block" ;
+            sendToHammerspoon("disableCloseOnEscape");
             document.getElementById('query').focus()
         }
+    } else if (code == 108 && e.metaKey && !e.shiftKey) { // Cmd-L
+        sendToHammerspoon("focusInSearchField");
+    } else if (code == 114 && e.metaKey && !e.shiftKey) { // Cmd-R; also causes console to appear... must ponder
+        window.location.reload(true);
+    } else if (document.getElementById("helpStuff").style.display == "block") {
+        if (code == 27) { // Esc
+            toggleHelp();
+        } else {
+            return true;
+        }
     } else if (document.getElementById("searcher").style.display == "block") {
-        if ((code == 13 || (code == 103 && e.metaKey)) && e.shiftKey) {         // Shift-enter or Cmd-Shift-G
+        if (code == 27) { // Esc
+            document.getElementById("searcher").style.display = "none" ;
+            sendToHammerspoon("enableCloseOnEscape");
+        } else if ((code == 13 || (code == 103 && e.metaKey)) && e.shiftKey) { // Shift-enter or Cmd-Shift-G
           searchForText(1) ;
         } else if ((code == 13 || (code == 103 && e.metaKey)) && !e.shiftKey) { // enter or Cmd-G
            searchForText(0) ;
@@ -71,3 +166,5 @@
   // see common.lp for "good enough" version of addEvent
   addEvent(document, "keypress", KeyPressHappened);
 </script>
+
+<% end %>

--- a/extensions/doc/hsdocs/search.lp
+++ b/extensions/doc/hsdocs/search.lp
@@ -35,13 +35,20 @@
      font-style: italic;
   }
 
+<%
+  local translation = "translateY(-50%)"
+  if settings.get("_documentationServer.entitiesInSidebar") and cgilua.script_file == "module.lp" then
+      translation = translation .. " translateX(-10vw)"
+  end
+%>
+
   div.helpScreen {
     display: none;
     position: fixed;
     top: 50%;
-    -webkit-transform: translateY(-50%);
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
+    -webkit-transform: <%= translation .. ";" %>
+    -ms-transform: <%= translation .. ";" %>
+    transform: <%= translation .. ";" %>
     margin-left: auto ;
     margin-right: auto ;
     width: 80%;
@@ -77,9 +84,9 @@
         if v == "search" then %>
           <tr><th><i>🔍 Search</i></th><td><%= tbdt.tooltip %></td></tr>
         <% elseif v == "navigation" then %>
-          <tr><th><img height="20" width="20" src="<%= tbdt.subitems[1].image:size{ h = 20, w = 20 }:encodeAsURLString() %>">&nbsp;<img height="20" width="20" src="<%= tbdt.subitems[2].image:size{ h = 20, w = 20 }:encodeAsURLString() %>"></th><td><%= tbdt.subitems[1].tooltip .. "/" .. tbdt.subitems[2].tooltip %></td></tr>
+          <tr><th><img height="20" width="20" src="<%= tbdt.subitems[1].image:setSize{ h = 20, w = 20 }:encodeAsURLString() %>">&nbsp;<img height="20" width="20" src="<%= tbdt.subitems[2].image:setSize{ h = 20, w = 20 }:encodeAsURLString() %>"></th><td><%= tbdt.subitems[1].tooltip .. "/" .. tbdt.subitems[2].tooltip %></td></tr>
         <% else %>
-          <tr><th><img height="20" width="20" src="<%= tbdt.image:size{ h = 20, w = 20 }:encodeAsURLString() %>"></th><td><%= tbdt.tooltip %></td></tr>
+          <tr><th><img height="20" width="20" src="<%= tbdt.image:setSize{ h = 20, w = 20 }:encodeAsURLString() %>"></th><td><%= tbdt.tooltip %></td></tr>
       <% end
       end
     end


### PR DESCRIPTION
When viewing the web pages displaying module details from `hs.doc.hsdocs`, Command-F will toggle a search field at the top-right.  You can enter a term to search for in the page and use Enter/Shift-Enter or Cmd-G/Cmd-Shift-G to search forwards or backwards within the page.

Works for both the `hs.webview` viewer and in Safari.
