### PR TITLE
Add a root .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.h]
+indent_style = space
+indent_size = 4
+
+[*.m]
+indent_style = space
+indent_size = 4
+
+[*.lua]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
To avoid trivial style inconsistency when creating a PR, what about adding a root .editorconfig?

As for some extensions whose source files have their own styles, the authors can add .editorconfig in their subdirectories.