### PR TITLE
Allows an hs.canvas to accept drag-and-drops

### DIFF
--- a/extensions/canvas/Canvas.h
+++ b/extensions/canvas/Canvas.h
@@ -5,10 +5,11 @@
 @property NSString            *subroleOverride ;
 @end
 
-@interface HSCanvasView : NSView
+@interface HSCanvasView : NSView <NSDraggingDestination>
 @property int                 selfRef ;
 @property HSCanvasWindow     *wrapperWindow ;
 @property int                 mouseCallbackRef ;
+@property int                 draggingCallbackRef ;
 @property BOOL                mouseTracking ;
 @property BOOL                canvasMouseDown ;
 @property BOOL                canvasMouseUp ;

--- a/extensions/canvas/internal.m
+++ b/extensions/canvas/internal.m
@@ -968,6 +968,7 @@ static int userdata_gc(lua_State* L) ;
         _wrapperWindow         = nil ;
 
         _mouseCallbackRef      = LUA_NOREF;
+        _draggingCallbackRef   = LUA_NOREF;
         _canvasDefaults        = [[NSMutableDictionary alloc] init] ;
         _elementList           = [[NSMutableArray alloc] init] ;
         _elementBounds         = [[NSMutableArray alloc] init] ;
@@ -2176,6 +2177,87 @@ static int userdata_gc(lua_State* L) ;
     [NSAnimationContext endGrouping];
 }
 
+#pragma mark - NSDraggingDestination protocol methods
+
+- (BOOL)draggingCallback:(NSString *)message with:(id<NSDraggingInfo>)sender {
+    BOOL isAllGood = NO ;
+    if (_draggingCallbackRef != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared] ;
+        lua_State *L = skin.L ;
+        int argCount = 2 ;
+        [skin pushLuaRef:refTable ref:_draggingCallbackRef] ;
+        [skin pushNSObject:self] ;
+        [skin pushNSObject:message] ;
+        if (sender) {
+            lua_newtable(L) ;
+            NSPasteboard *pasteboard = [sender draggingPasteboard] ;
+            if (pasteboard) {
+                [skin pushNSObject:pasteboard.name] ; lua_setfield(L, -2, "pasteboard") ;
+            }
+            lua_pushinteger(L, [sender draggingSequenceNumber]) ; lua_setfield(L, -2, "sequence") ;
+            [skin pushNSPoint:[sender draggingLocation]] ; lua_setfield(L, -2, "mouse") ;
+            NSDragOperation operation = [sender draggingSourceOperationMask] ;
+            lua_newtable(L) ;
+            if (operation == NSDragOperationNone) {
+                lua_pushstring(L, "none") ; lua_rawseti(L, -2, luaL_len(L, -2) + 1)  ;
+            } else {
+                if ((operation & NSDragOperationCopy) == NSDragOperationCopy) {
+                    lua_pushstring(L, "copy") ; lua_rawseti(L, -2, luaL_len(L, -2) + 1)  ;
+                }
+                if ((operation & NSDragOperationLink) == NSDragOperationLink) {
+                    lua_pushstring(L, "link") ; lua_rawseti(L, -2, luaL_len(L, -2) + 1)  ;
+                }
+                if ((operation & NSDragOperationGeneric) == NSDragOperationGeneric) {
+                    lua_pushstring(L, "generic") ; lua_rawseti(L, -2, luaL_len(L, -2) + 1)  ;
+                }
+                if ((operation & NSDragOperationPrivate) == NSDragOperationPrivate) {
+                    lua_pushstring(L, "private") ; lua_rawseti(L, -2, luaL_len(L, -2) + 1)  ;
+                }
+                if ((operation & NSDragOperationMove) == NSDragOperationMove) {
+                    lua_pushstring(L, "move") ; lua_rawseti(L, -2, luaL_len(L, -2) + 1)  ;
+                }
+                if ((operation & NSDragOperationDelete) == NSDragOperationDelete) {
+                    lua_pushstring(L, "delete") ; lua_rawseti(L, -2, luaL_len(L, -2) + 1)  ;
+                }
+            }
+            lua_setfield(L, -2, "operation") ;
+            argCount += 1 ;
+        }
+        if ([skin protectedCallAndTraceback:argCount nresults:1]) {
+            isAllGood = lua_isnoneornil(L, -1) ? YES : (BOOL)lua_toboolean(skin.L, -1) ;
+        } else {
+            [skin logError:[NSString stringWithFormat:@"%s:draggingCallback error: %@", USERDATA_TAG, [skin toNSObjectAtIndex:-1]]] ;
+        }
+        lua_pop(L, 1) ;
+    }
+    return isAllGood ;
+}
+
+- (BOOL)wantsPeriodicDraggingUpdates {
+    return NO ;
+}
+
+- (BOOL)prepareForDragOperation:(__unused id<NSDraggingInfo>)sender {
+    return YES ;
+}
+
+- (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender {
+    return [self draggingCallback:@"enter" with:sender] ? NSDragOperationGeneric : NSDragOperationNone ;
+}
+
+- (void)draggingExited:(id<NSDraggingInfo>)sender {
+    [self draggingCallback:@"exit" with:sender] ;
+}
+
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender {
+    return [self draggingCallback:@"receive" with:sender] ;
+}
+
+// - (NSDragOperation)draggingUpdated:(id<NSDraggingInfo>)sender ;
+// - (void)concludeDragOperation:(id<NSDraggingInfo>)sender ;
+// - (void)draggingEnded:(id<NSDraggingInfo>)sender ;
+// - (void)updateDraggingItemsForDrag:(id<NSDraggingInfo>)sender
+
 @end
 
 #pragma mark - Module Functions
@@ -2306,6 +2388,52 @@ static int default_textAttributes(lua_State *L) {
 }
 
 #pragma mark - Module Methods
+
+/// hs.canvas:draggingCallback(fn | nil) -> canvasObject
+/// Method
+/// Sets or remove a callback for accepting dragging and dropping items onto the canvas.
+///
+/// Parameters:
+///  * `fn`   - A function, can be nil, that will be called when an item is dragged onto the canvas.  An explicit nil, the default, disables drag-and-drop for this canvas.
+///
+/// Returns:
+///  * The canvas object
+///
+/// Notes:
+///  * The callback function should expect 3 arguments and optionally return 1: the canvas object itself, a message specifying the type of dragging event, and a table containing details about the item(s) being dragged.  The key-value pairs of the details table will be the following:
+///    * `pasteboard` - the name of the pasteboard that contains the items being dragged
+///    * `sequence`   - an integer that uniquely identifies the dragging session.
+///    * `mouse`      - a point table containing the location of the mouse pointer within the canvas corresponding to when the callback occurred.
+///    * `operation`  - a table containing string descriptions of the type of dragging the source application supports. Potentially useful for determining if your callback function should accept the dragged item or not.
+///
+/// * The possible messages the callback function may receive are as follows:
+///    * "enter"   - the user has dragged an item into the canvas.  When your callback receives this message, you can optionally return false to indicate that you do not wish to accept the item being dragged.
+///    * "exit"    - the user has moved the item out of the canvas; if the previous "enter" callback returned false, this message will also occur when the user finally releases the items being dragged.
+///    * "receive" - indicates that the user has released the dragged object while it is still within the canvas frame.  When your callback receives this message, you can optionally return false to indicate to the sending application that you do not want to accept the dragged item -- this may affect the animations provided by the sending application.
+///
+///  * You can use the sequence number in the details table to match up an "enter" with an "exit" or "receive" message.
+///
+///  * You should capture the details you require from the drag-and-drop operation during the callback for "receive" by using the pasteboard field of the details table and the `hs.pasteboard` module.  Because of the nature of "promised items", it is not guaranteed that the items will still be on the pasteboard after your callback completes handling this message.
+///
+///  * A canvas object can only accept drag-and-drop items when its window level is at [hs.canvas.windowLevels.dragging](#windowLevels) or lower.
+///  * a canvas object can only accept drag-and-drop items when it accepts mouse events.  You must define a [hs.canvas:mouseCallback](#mouseCallback) function, even if it is only a placeholder, e.g. `hs.canvas:mouseCallback(function() end)`
+static int canvas_draggingCallback(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION | LS_TNIL, LS_TBREAK] ;
+    HSCanvasView   *canvasView   = [skin luaObjectAtIndex:1 toClass:"HSCanvasView"] ;
+
+    // We're either removing callback(s), or setting new one(s). Either way, remove existing.
+    canvasView.draggingCallbackRef = [skin luaUnref:refTable ref:canvasView.mouseCallbackRef];
+    [canvasView unregisterDraggedTypes] ;
+    if ([skin luaTypeAtIndex:2] == LUA_TFUNCTION) {
+        lua_pushvalue(L, 2);
+        canvasView.draggingCallbackRef = [skin luaRef:refTable] ;
+        [canvasView registerForDraggedTypes:@[ (__bridge NSString *)kUTTypeItem ]] ;
+    }
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
 
 static int canvas_accessibilitySubrole(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared] ;
@@ -3792,6 +3920,8 @@ static const luaL_Reg userdata_metaLib[] = {
     {"topLeft",               canvas_topLeft},
     {"transformation",        canvas_canvasTransformation},
     {"wantsLayer",            canvas_wantsLayer},
+    {"draggingCallback",      canvas_draggingCallback},
+
     {"_accessibilitySubrole", canvas_accessibilitySubrole},
 
     {"__tostring",            userdata_tostring},

--- a/extensions/doc/hsdocs/module.lp
+++ b/extensions/doc/hsdocs/module.lp
@@ -151,7 +151,7 @@
           ["Variable"]    = "Configurable values",
           ["Function"]    = "API calls offered directly by the extension",
           ["Constructor"] = "API calls which return an object, typically one that offers API methods",
-          ["Field"]       = "Variables which can only be access from an object returned by a constructor",
+          ["Field"]       = "Variables which can only be accessed from an object returned by a constructor",
           ["Method"]      = "API calls which can only be made on an object returned by a constructor",
         }
 

--- a/extensions/pasteboard/init.lua
+++ b/extensions/pasteboard/init.lua
@@ -11,6 +11,7 @@ require("hs.image")
 require("hs.sound")
 require("hs.styledtext")
 require("hs.drawing.color")
+require("hs.sharing")
 
 -- Public interface ------------------------------------------------------
 

--- a/extensions/sharing/internal.m
+++ b/extensions/sharing/internal.m
@@ -163,6 +163,7 @@ static int sharing_servicesForItems(lua_State *L) {
 ///  * Because macOS requires URLs to be represented as a specific object type which has no exact equivalent in Lua, Hammerspoon uses a table with specific keys to allow proper identification of a URL when included as an argument or result type.  Use this function or the [hs.sharing.fileURL](#fileURL) wrapper function when specifying a URL to ensure that the proper keys are defined.
 ///  * At present, the following keys are defined for a URL table (additional keys may be added in the future if future Hammerspoon modules require them to more completely utilize the macOS NSURL class, but these will not change):
 ///    * url           - a string containing the URL with a proper schema and resource locator
+///    * filePath      = a string specifying the actual path to the file in case the url is a file reference URL.  Note that setting this field with this method will be silently ignored; the field is automatically inserted if appropriate when returning an NSURL object to lua.
 ///    * __luaSkinType - a string specifying the macOS type this table represents when converted into an Objective-C type
 static int sharing_makeURL(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared] ;
@@ -562,6 +563,10 @@ static int pushNSURL(lua_State *L, id obj) {
     lua_newtable(L) ;
     [skin pushNSObject:[url absoluteString]] ;
     lua_setfield(L, -2, "url") ;
+    if (url.fileURL) {
+        [skin pushNSObject:[url path]] ;
+        lua_setfield(L, -2, "filePath") ;
+    }
     lua_pushstring(L, "NSURL") ; lua_setfield(L, -2, "__luaSkinType") ;
     return 1 ;
 }


### PR DESCRIPTION
Adds `hs.canvas:draggingCallback` which can accept items (text, files, etc.) from drag-and-drop operations.

An example showing its use can be found at https://github.com/asmagill/hammerspoon-config/blob/master/_scratch/dragging.lua
