### PR TITLE
adds hs.hotkey.assigned

### DIFF
--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -70,10 +70,13 @@ local function enable(self,force,isModal)
   local returnVal = self._hk:enable() --objc
   if returnVal ~= nil then
     log[isModal and 'df' or 'f']('Enabled hotkey %s%s',self.msg,isModal and ' (in modal)' or '')
-  end
     tinsert(hotkeys[idx],self) -- bring to the top of the stack
 --   return returnVal
     return self
+  else
+    self.enabled = false
+    return nil
+  end
 end
 
 --- hs.hotkey:disable() -> hs.hotkey object
@@ -178,7 +181,7 @@ end
 ---  * repeatfn - A function that will be called when a pressed hotkey is repeating, or nil
 ---
 --- Returns:
----  * A new `hs.hotkey` object
+---  * A new `hs.hotkey` object or nil if the hotkey could not be enabled
 ---
 --- Notes:
 ---  * You can create multiple `hs.hotkey` objects for the same keyboard combination, but only one can be active
@@ -219,7 +222,7 @@ function hotkey.new(mods, key, message, pressedfn, releasedfn, repeatfn)
   return hk
 end
 
---- hs.hotkey.assigned(mods, key) -> table | false
+--- hs.hotkey.systemAssigned(mods, key) -> table | false
 --- Function
 --- Examine whether a potential hotkey is in use by the macOS system such as the Screen Capture, Universal Access, and Keyboard Navigation keys.
 ---
@@ -240,12 +243,42 @@ end
 ---  * if the hotkey combination is not in use by the operating system, returns the boolean value `false`
 ---
 --- Notes:
----  * this is provided for informational purposes and does not provide a reliable test as to whether or not Hammerspoon can use the combination to create a custom hotkey -- some combinations which return a table can be over-ridden by Hammerspoon while others cannot.  At this time there is no known reliable test except to assign the hotkey with `hs.hotkey.enable` and see if it works.
-local originalAssigned = hotkey.assigned
-function hotkey.assigned(mods, key)
+---  * this is provided for informational purposes and does not provide a reliable test as to whether or not Hammerspoon can use the combination to create a custom hotkey -- some combinations which return a table can be over-ridden by Hammerspoon while others cannot.  See also [hs.hotkey.assignable](#assignable).
+local originalSystemAssigned = hotkey.systemAssigned
+function hotkey.systemAssigned(mods, key)
   local keycode = getKeycode(key)
   mods = getMods(mods)
-  return originalAssigned(mods, keycode)
+  return originalSystemAssigned(mods, keycode)
+end
+
+--- hs.hotkey.assignable(mods, key) -> boolean
+--- Function
+--- Determines whether the hotkey combination can be assigned a callback through Hammerspoon.
+---
+--- Parameters:
+---  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
+---    which should be zero or more of the following:
+---    * "cmd", "command" or "⌘"
+---    * "ctrl", "control" or "⌃"
+---    * "alt", "option" or "⌥"
+---    * "shift" or "⇧"
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
+---
+--- Returns:
+---  * a boolean value, true if the hotkey combination can be given an assignment by Hammerspoon or false if it cannot.
+---
+--- Notes:
+---  * The most common reason a hotkey combination cannot be given an assignment by Hammerspoon is because it is in use by the Mac operating system -- see the Shortcuts tab of Keyboard in the System Preferences application or [hs.hotkey.systemAssigned](#systemAssigned).
+function hotkey.assignable(mods, key)
+    local k = hotkey.new(mods, key, function() end)
+    local prevLevel = hs.luaSkinLog.level
+    -- supress luaSkinLog error if binding fails
+    hs.luaSkinLog.level = 0
+    local status = k._hk:enable()
+    if status then k._hk:disable() end
+    k.enabled = false
+    hs.luaSkinLog.level = prevLevel
+    return status and true or false
 end
 
 --- hs.hotkey.disableAll(mods, key)

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -219,6 +219,13 @@ function hotkey.new(mods, key, message, pressedfn, releasedfn, repeatfn)
   return hk
 end
 
+local originalAssigned = hotkey.assigned
+function hotkey.assigned(mods, key)
+  local keycode = getKeycode(key)
+  mods = getMods(mods)
+  return originalAssigned(mods, keycode)
+end
+
 --- hs.hotkey.disableAll(mods, key)
 --- Function
 --- Disables all previously set callbacks for a given keyboard combination

--- a/extensions/hotkey/init.lua
+++ b/extensions/hotkey/init.lua
@@ -219,6 +219,28 @@ function hotkey.new(mods, key, message, pressedfn, releasedfn, repeatfn)
   return hk
 end
 
+--- hs.hotkey.assigned(mods, key) -> table | false
+--- Function
+--- Examine whether a potential hotkey is in use by the macOS system such as the Screen Capture, Universal Access, and Keyboard Navigation keys.
+---
+--- Parameters:
+---  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
+---    which should be zero or more of the following:
+---    * "cmd", "command" or "⌘"
+---    * "ctrl", "control" or "⌃"
+---    * "alt", "option" or "⌥"
+---    * "shift" or "⇧"
+---  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
+---
+--- Returns:
+---  * if the hotkey combination is in use by a system function, returns a table containing the following keys:
+---    * keycode - the numberic keycode for the hotkey
+---    * mods    - a numeric representation of the modifier flags for the htokey
+---    * enabled - a boolean indicating whether or not the key is currently enabled
+---  * if the hotkey combination is not in use by the operating system, returns the boolean value `false`
+---
+--- Notes:
+---  * this is provided for informational purposes and does not provide a reliable test as to whether or not Hammerspoon can use the combination to create a custom hotkey -- some combinations which return a table can be over-ridden by Hammerspoon while others cannot.  At this time there is no known reliable test except to assign the hotkey with `hs.hotkey.enable` and see if it works.
 local originalAssigned = hotkey.assigned
 function hotkey.assigned(mods, key)
   local keycode = getKeycode(key)

--- a/extensions/hotkey/internal.m
+++ b/extensions/hotkey/internal.m
@@ -179,7 +179,7 @@ static int hotkey_new(lua_State* L) {
     return 1;
 }
 
-static int hotkey_assigned(lua_State* L) {
+static int hotkey_systemAssigned(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
 
     luaL_checktype(L, 1, LUA_TTABLE);
@@ -395,7 +395,7 @@ static int userdata_tostring(lua_State* L) {
 
 static const luaL_Reg hotkeylib[] = {
     {"_new", hotkey_new},
-    {"assigned", hotkey_assigned},
+    {"systemAssigned", hotkey_systemAssigned},
 
     {NULL, NULL}
 };

--- a/extensions/hotkey/internal.m
+++ b/extensions/hotkey/internal.m
@@ -179,6 +179,59 @@ static int hotkey_new(lua_State* L) {
     return 1;
 }
 
+static int hotkey_assigned(lua_State* L) {
+    LuaSkin *skin = [LuaSkin shared];
+
+    luaL_checktype(L, 1, LUA_TTABLE);
+    UInt32 keycode = (UInt32)luaL_checkinteger(L, 2);
+    UInt32 mods    = 0 ;
+
+    // save mods
+    lua_pushnil(L);
+    while (lua_next(L, 1) != 0) {
+        NSString* mod = [[NSString stringWithUTF8String:luaL_checkstring(L, -1)] lowercaseString];
+        if ([mod isEqualToString: @"cmd"] || [mod isEqualToString: @"⌘"])        mods |= cmdKey;
+        else if ([mod isEqualToString: @"ctrl"] || [mod isEqualToString: @"⌃"])  mods |= controlKey;
+        else if ([mod isEqualToString: @"alt"] || [mod isEqualToString: @"⌥"])   mods |= optionKey;
+        else if ([mod isEqualToString: @"shift"] || [mod isEqualToString: @"⇧"]) mods |= shiftKey;
+        lua_pop(L, 1);
+    }
+
+    BOOL assigned = NO ;
+    CFArrayRef registeredHotKeys = NULL ;
+    OSStatus status = CopySymbolicHotKeys(&registeredHotKeys) ;
+    if (status == noErr && registeredHotKeys) {
+
+        CFIndex count = CFArrayGetCount(registeredHotKeys);
+        for(CFIndex i = 0; i < count; i++)
+        {
+            CFDictionaryRef hotKeyInfo      = CFArrayGetValueAtIndex(registeredHotKeys, i);
+            CFNumberRef     hotKeyCode      = CFDictionaryGetValue(hotKeyInfo, kHISymbolicHotKeyCode);
+            CFNumberRef     hotKeyModifiers = CFDictionaryGetValue(hotKeyInfo, kHISymbolicHotKeyModifiers);
+            CFBooleanRef    hotKeyEnabled   = CFDictionaryGetValue(hotKeyInfo, kHISymbolicHotKeyEnabled);
+            // I *think* 1<< 17 represents the Fn key on laptops; at any rate, it's automatically added for
+            // some keys, notably Function keys, arrow keys, etc... since we can't actually set it, remove
+            // it from the dictionary if present.
+            UInt32 modifierFlags = [(__bridge NSNumber *)hotKeyModifiers unsignedIntValue] & ~(1 << 17) ;
+            if (([(__bridge NSNumber *)hotKeyCode unsignedIntValue] == keycode) && (modifierFlags == mods)) {
+                lua_newtable(L) ;
+                [skin pushNSObject:(__bridge NSNumber *)hotKeyCode]    ; lua_setfield(L, -2, "keycode") ;
+                lua_pushinteger(L, modifierFlags) ;                      lua_setfield(L, -2, "mods") ;
+                [skin pushNSObject:(__bridge NSNumber *)hotKeyEnabled] ; lua_setfield(L, -2, "enabled") ;
+                assigned = YES ;
+                break ;
+            }
+        }
+        CFRelease(registeredHotKeys) ;
+        if (!assigned) lua_pushboolean(L, false) ;
+    } else {
+        [skin logWarn:[NSString stringWithFormat:@"%s.assigned - unable to retrieve SymbolicHotKeys (%d)", USERDATA_TAG, status]] ;
+        lua_pushnil(L) ;
+    }
+
+    return 1;
+}
+
 static int hotkey_enable(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
@@ -342,6 +395,7 @@ static int userdata_tostring(lua_State* L) {
 
 static const luaL_Reg hotkeylib[] = {
     {"_new", hotkey_new},
+    {"assigned", hotkey_assigned},
 
     {NULL, NULL}
 };


### PR DESCRIPTION
sort of addresses #1391 

This isn't really a conclusive test (for example, both `Cmd-F5` and `Ctrl-1` are defined on my system and will return a table with this function; however, if I create a Hammerspoon hotkey for `Cmd-F5`, it works, while a Hammerspoon hotkey for`Ctrl-1` fails.)

What's the group consensus?  It's useful to see if you're trying to overwrite a system hotkey, but... it isn't a reliable way to tell if you *can* or not.

> Function: hs.hotkey.assigned(mods, key) -> table | false
>
> Examine whether a potential hotkey is in use by the macOS system such as the Screen Capture, Universal Access, and Keyboard Navigation keys.
>
> Parameters:
>  * mods - A table or a string containing (as elements, or as substrings with any separator) the keyboard modifiers required,
>    which should be zero or more of the following:
>    * "cmd", "command" or "⌘"
>    * "ctrl", "control" or "⌃"
>    * "alt", "option" or "⌥"
>    * "shift" or "⇧"
>  * key - A string containing the name of a keyboard key (as found in [hs.keycodes.map](hs.keycodes.html#map) ), or a raw keycode number
>
> Returns:
>  * if the hotkey combination is in use by a system function, returns a table containing the following keys:
>    * keycode - the numberic keycode for the hotkey
>    * mods    - a numeric representation of the modifier flags for the htokey
>    * enabled - a boolean indicating whether or not the key is currently enabled
>  * if the hotkey combination is not in use by the operating system, returns the boolean value `false`
>
> Notes:
>  * this is provided for informational purposes and does not provide a reliable test as to whether or not Hammerspoon can use the combination to create a custom hotkey -- some combinations which return a table can be over-ridden by Hammerspoon while others cannot.  At this time there is no known reliable test except to assign the hotkey with `hs.hotkey.enable` and see if it works.
