### PR TITLE
Logging updates to LuaSkin

### DIFF
--- a/LuaSkin/LuaSkin/Skin.h
+++ b/LuaSkin/LuaSkin/Skin.h
@@ -757,18 +757,5 @@ NSString *specMaskToString(int spec);
  */
 - (NSString *)tracebackWithTag:(NSString *)theTag fromStackPos:(int)level ;
 
-/*!
- @abstract Log the specified message with at the specified level with the traceback position prepended.
-
- @discussion Logs the specified message, prepended with the lua chunk name and line number at the specified traceback level, for the specified level.  The log level and combined message is logged with @link logAtLevel:withMessage: @/link.
-
- @warning This method is primarily for testing and may be removed in a future release.
-
- @param level The message log level as an integer.  Predefined levels are defined and used within LuaSkin itself as (in decreasing level of severity) @link LS_LOG_ERROR @/link, @link LS_LOG_WARN @/link, @link LS_LOG_INFO @/link, @link LS_LOG_DEBUG @/link, and @link LS_LOG_VERBOSE @/link.
- @param theMessage the message to log
- @param pos the lua traceback level to attempt to retrieve the chunk name and line number from
- */
-- (void)logAtLevel:(int)level withMessage:(NSString *)theMessage fromStackPos:(int)pos ;
-
 @end
 

--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -490,8 +490,7 @@ nextarg:
             [self logAtLevel:LS_LOG_WARN
                  withMessage:[NSString stringWithFormat:@"registerPushNSHelper:forClass:%s already defined at %@",
                                                         className,
-                                                        self.registeredNSHelperLocations[@(className)]]
-                fromStackPos:level] ;
+                                                        self.registeredNSHelperLocations[@(className)]]] ;
         } else {
             luaL_where(self.L, level) ;
             NSString *locationString = @(lua_tostring(self.L, -1)) ;
@@ -502,8 +501,7 @@ nextarg:
         }
     } else {
         [self logAtLevel:LS_LOG_WARN
-             withMessage:@"registerPushNSHelper:forClass: requires both helperFN and className"
-             fromStackPos:level] ;
+             withMessage:@"registerPushNSHelper:forClass: requires both helperFN and className"] ;
     }
     return allGood ;
 }
@@ -572,8 +570,7 @@ nextarg:
             [self logAtLevel:LS_LOG_WARN
                  withMessage:[NSString stringWithFormat:@"registerLuaObjectHelper:forClass:%s already defined at %@",
                                                         className,
-                                                        self.registeredLuaObjectHelperFunctions[@(className)]]
-                fromStackPos:level] ;
+                                                        self.registeredLuaObjectHelperFunctions[@(className)]]] ;
         } else {
             luaL_where(self.L, level) ;
             NSString *locationString = @(lua_tostring(self.L, -1)) ;
@@ -584,8 +581,7 @@ nextarg:
         }
     } else {
         [self logAtLevel:LS_LOG_WARN
-             withMessage:@"registerLuaObjectHelper:forClass: requires both helperFN and className"
-            fromStackPos:level] ;
+             withMessage:@"registerLuaObjectHelper:forClass: requires both helperFN and className"] ;
     }
     return allGood ;
 }
@@ -624,8 +620,7 @@ nextarg:
         return  NSMakeRect(x, y, w, h) ;
     } else {
         [self logAtLevel:LS_LOG_WARN
-             withMessage:[NSString stringWithFormat:@"returning NSZeroRect: can't make NSRect from %s.", lua_typename(self.L, lua_type(self.L, idx))]
-            fromStackPos:1] ;
+             withMessage:[NSString stringWithFormat:@"returning NSZeroRect: can't make NSRect from %s.", lua_typename(self.L, lua_type(self.L, idx))]] ;
         return NSZeroRect ;
     }
 }
@@ -639,8 +634,7 @@ nextarg:
         return NSMakePoint(x, y);
     } else {
         [self logAtLevel:LS_LOG_WARN
-             withMessage:[NSString stringWithFormat:@"returning NSZeroPoint: can't make NSPoint from %s.", lua_typename(self.L, lua_type(self.L, idx))]
-            fromStackPos:1] ;
+             withMessage:[NSString stringWithFormat:@"returning NSZeroPoint: can't make NSPoint from %s.", lua_typename(self.L, lua_type(self.L, idx))]] ;
         return NSZeroPoint ;
     }
 }
@@ -654,8 +648,7 @@ nextarg:
         return NSMakeSize(w, h);
     } else {
         [self logAtLevel:LS_LOG_WARN
-             withMessage:[NSString stringWithFormat:@"returning NSZeroSize: can't make NSSize from %s.", lua_typename(self.L, lua_type(self.L, idx))]
-            fromStackPos:1] ;
+             withMessage:[NSString stringWithFormat:@"returning NSZeroSize: can't make NSSize from %s.", lua_typename(self.L, lua_type(self.L, idx))]] ;
         return NSZeroSize ;
     }
 }
@@ -677,8 +670,7 @@ nextarg:
         }
     } else {
         [self logAtLevel:LS_LOG_ERROR
-             withMessage:[NSString stringWithFormat:@"table expected (found %s)", lua_typename(self.L, lua_type(self.L, idx))]
-            fromStackPos:0] ;
+             withMessage:[NSString stringWithFormat:@"table expected (found %s)", lua_typename(self.L, lua_type(self.L, idx))]] ;
     }
     return max ;
 }
@@ -695,8 +687,7 @@ nextarg:
         }
     } else {
         [self logAtLevel:LS_LOG_ERROR
-             withMessage:[NSString stringWithFormat:@"table expected (found %s)", lua_typename(self.L, lua_type(self.L, idx))]
-            fromStackPos:0] ;
+             withMessage:[NSString stringWithFormat:@"table expected (found %s)", lua_typename(self.L, lua_type(self.L, idx))]] ;
     }
     return max ;
 }
@@ -1026,8 +1017,7 @@ nextarg:
     if (seenObject) {
         if ([[seenObject lastObject] isEqualToNumber:@(NO)] && ((options & LS_NSAllowsSelfReference) != LS_NSAllowsSelfReference)) {
             [self logAtLevel:LS_LOG_WARN
-                 withMessage:@"lua table cannot contain self-references"
-                fromStackPos:1] ;
+                 withMessage:@"lua table cannot contain self-references"] ;
 //             return [NSNull null] ;
             return nil ;
         } else {
@@ -1060,8 +1050,7 @@ nextarg:
                 } else {
                     if (stringOptions != LS_NSNone) {
                         [self logAtLevel:LS_LOG_DEBUG
-                             withMessage:@"only one of LS_NSPreserveLuaStringExactly or LS_NSLuaStringAsDataOnly can be specified: using default behavior"
-                            fromStackPos:0] ;
+                             withMessage:@"only one of LS_NSPreserveLuaStringExactly or LS_NSLuaStringAsDataOnly can be specified: using default behavior"] ;
                     }
                     return [self getValidUTF8AtIndex:idx] ;
                 }
@@ -1190,8 +1179,7 @@ nextarg:
                 } else {
                     [self logAtLevel:LS_LOG_ERROR
                          withMessage:[NSString stringWithFormat:@"array element (%s) cannot be converted into a proper NSObject",
-                                                                 luaL_tolstring(self.L, -1, NULL)]
-                        fromStackPos:1] ;
+                                                                 luaL_tolstring(self.L, -1, NULL)]] ;
                     result = nil ;
                     lua_pop(self.L, 2) ; // luaL_tolstring result and lua_geti result
                     return nil ;
@@ -1209,8 +1197,7 @@ nextarg:
                     [self logAtLevel:LS_LOG_ERROR
                          withMessage:[NSString stringWithFormat:@"dictionary %@ (%s) cannot be converted into a proper NSObject",
                                                                  (key) ? @"key" : @"value",
-                                                                 luaL_tolstring(self.L, (key) ? -2 : lua_gettop(self.L), NULL)]
-                        fromStackPos:1] ;
+                                                                 luaL_tolstring(self.L, (key) ? -2 : lua_gettop(self.L), NULL)]] ;
                     result = nil ;
                     lua_pop(self.L, 3) ; // luaL_tolstring result, lua_next value, and lua_next key
                     return nil ;
@@ -1234,17 +1221,6 @@ nextarg:
     } else {
         HSNSLOG(@"(missing delegate):log level %d: %@", level, theMessage) ;
     }
-}
-
-// Testing for: chunkname:currentline:theMessage
-- (void) logAtLevel:(int)level withMessage:(NSString *)theMessage fromStackPos:(int)pos {
-    luaL_where(self.L, pos) ;
-    NSString *locationInfo = @(lua_tostring(self.L, -1)) ;
-    lua_pop(self.L, 1) ;
-    if (!locationInfo || [locationInfo isEqualToString:@""])
-        locationInfo = [NSString stringWithFormat:@"(no lua location info at depth %d)", pos] ;
-
-    [self logAtLevel:level withMessage:[NSString stringWithFormat:@"%@:%@", locationInfo, theMessage]] ;
 }
 
 // shorthand

--- a/extensions/application/internal.m
+++ b/extensions/application/internal.m
@@ -1169,9 +1169,7 @@ static int nsrunningapplication_tolua(lua_State *L, id obj) {
 
     if (!new_application(L, [app processIdentifier])) {
         lua_pop(L, 1) ; // removed aborted userdata
-        [[LuaSkin shared] logAtLevel:LS_LOG_WARN
-                         withMessage:[NSString stringWithFormat:@"No Process ID for %@", obj]
-                        fromStackPos:1] ;
+        [[LuaSkin shared] logWarn:[NSString stringWithFormat:@"No Process ID for %@", obj]] ;
         lua_pushnil(L) ;
     }
     return 1 ;

--- a/extensions/socket/internal.m
+++ b/extensions/socket/internal.m
@@ -79,14 +79,14 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(UInt16)port {
-    [LuaSkin logInfo:@"TCP socket connected"];
+    [LuaSkin logDebug:@"TCP socket connected"];
     self.userData = DEFAULT;
     if (self.connectCallback != LUA_NOREF)
         connectCallback(self);
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didConnectToUrl:(NSURL *)url {
-    [LuaSkin logInfo:@"TCP Unix domain socket connected"];
+    [LuaSkin logDebug:@"TCP Unix domain socket connected"];
     self.userData = DEFAULT;
     self.unixSocketPath = [url path];
     if (self.connectCallback != LUA_NOREF)
@@ -94,7 +94,7 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didAcceptNewSocket:(GCDAsyncSocket *)newSocket {
-    [LuaSkin logInfo:@"TCP client connected"];
+    [LuaSkin logDebug:@"TCP client connected"];
     newSocket.userData = CLIENT;
 
     @synchronized(self.connectedSockets) {
@@ -104,12 +104,12 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
 
 - (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err {
     if (sock.userData == CLIENT) {
-        [LuaSkin logInfo:[NSString stringWithFormat:@"TCP client disconnected: %@", [err localizedDescription]]];
+        [LuaSkin logDebug:[NSString stringWithFormat:@"TCP client disconnected: %@", [err localizedDescription]]];
         @synchronized(self.connectedSockets) {
             [self.connectedSockets removeObject:sock];
         }
     } else if (sock.userData == SERVER) {
-        [LuaSkin logInfo:[NSString stringWithFormat:@"TCP server disconnected: %@", [err localizedDescription]]];
+        [LuaSkin logDebug:[NSString stringWithFormat:@"TCP server disconnected: %@", [err localizedDescription]]];
         @synchronized(self.connectedSockets) {
             for (HSAsyncTcpSocket *client in self.connectedSockets)
                 [client disconnect];
@@ -123,19 +123,19 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
             self.unixSocketPath = nil;
         }
     } else
-        [LuaSkin logInfo:[NSString stringWithFormat:@"TCP socket disconnected: %@", [err localizedDescription]]];
+        [LuaSkin logDebug:[NSString stringWithFormat:@"TCP socket disconnected: %@", [err localizedDescription]]];
 
     sock.userData = nil;
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didWriteDataWithTag:(long)tag {
-    [LuaSkin logInfo:@"Data written to TCP socket"];
+    [LuaSkin logDebug:@"Data written to TCP socket"];
     if (self.writeCallback != LUA_NOREF)
         writeCallback(self, tag);
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag  {
-    [LuaSkin logInfo:@"Data read from TCP socket"];
+    [LuaSkin logDebug:@"Data read from TCP socket"];
     if (self.readCallback != LUA_NOREF)
         readCallback(self, data, tag);
 }
@@ -148,7 +148,7 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
 }
 
 - (void)socketDidSecure:(GCDAsyncSocket *)sock {
-    [LuaSkin logInfo:@"TCP socket secured"];
+    [LuaSkin logDebug:@"TCP socket secured"];
 }
 
 @end

--- a/extensions/socket/udp.m
+++ b/extensions/socket/udp.m
@@ -75,7 +75,7 @@ static void readCallback(HSAsyncUdpSocket *asyncUdpSocket, NSData *data, NSData 
 }
 
 - (void)udpSocket:(GCDAsyncUdpSocket *)sock didConnectToAddress:(NSData *)address {
-    [LuaSkin logInfo:@"UDP socket connected"];
+    [LuaSkin logDebug:@"UDP socket connected"];
     self.userData = DEFAULT;
     if (self.connectCallback != LUA_NOREF)
         connectCallback(self);
@@ -87,12 +87,12 @@ static void readCallback(HSAsyncUdpSocket *asyncUdpSocket, NSData *data, NSData 
 }
 
 - (void)udpSocketDidClose:(GCDAsyncUdpSocket *)sock withError:(NSError *)error {
-    [LuaSkin logInfo:[NSString stringWithFormat:@"UDP socket closed: %@", [error localizedDescription]]];
+    [LuaSkin logDebug:[NSString stringWithFormat:@"UDP socket closed: %@", [error localizedDescription]]];
     sock.userData = nil;
 }
 
 - (void)udpSocket:(GCDAsyncUdpSocket *)sock didSendDataWithTag:(long)tag {
-    [LuaSkin logInfo:@"Data written to UDP socket"];
+    [LuaSkin logDebug:@"Data written to UDP socket"];
     if (self.writeCallback != LUA_NOREF)
         writeCallback(self, tag);
 }
@@ -103,7 +103,7 @@ static void readCallback(HSAsyncUdpSocket *asyncUdpSocket, NSData *data, NSData 
 }
 
 - (void)udpSocket:(GCDAsyncUdpSocket *)sock didReceiveData:(NSData *)data fromAddress:(NSData *)address withFilterContext:(id)filterContext {
-    [LuaSkin logInfo:@"Data read from UDP socket"];
+    [LuaSkin logDebug:@"Data read from UDP socket"];
     if (self.readCallback != LUA_NOREF)
         readCallback(self, data, address);
 }

--- a/extensions/styledtext/internal.m
+++ b/extensions/styledtext/internal.m
@@ -1373,18 +1373,11 @@ static id lua_toNSAttributedString(lua_State *L, int idx) {
                                        range:NSMakeRange(loc, len)];
                 }
                 @catch (NSException *theException) {
-                    [skin logAtLevel:LS_LOG_ERROR
-                         withMessage:[NSString stringWithFormat:@"error creating NSAttributedString from table: %@", [theException name]]
-                        fromStackPos:1] ;
+                    [skin logError:[NSString stringWithFormat:@"error creating NSAttributedString from table: %@", [theException name]]] ;
                     return [[NSAttributedString alloc] initWithString:@""];
                 }
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:[NSString stringWithFormat:@"skipping style specification %lld: expected table, found %s.",
-                                                            (locInTable - 1),
-                                                            lua_typename(L, lua_type(L, -1))]
-
-                    fromStackPos:1] ;
+                [skin logWarn:[NSString stringWithFormat:@"skipping style specification %lld: expected table, found %s.", (locInTable - 1), lua_typename(L, lua_type(L, -1))]] ;
             }
             locInTable++;
             lua_pop(L, 1);
@@ -1483,10 +1476,7 @@ static id table_toAttributesDictionary(lua_State *L, int idx) {
         lua_pop(L, 1);
     } else {
         // since we use this internally only, "tableness" should already be validated, so this shouldn't happen...
-        [skin logAtLevel:LS_LOG_ERROR
-             withMessage:[NSString stringWithFormat:@"invalid attributes dictionary: expected table, found %s",
-                                                    lua_typename(L, lua_type(L, idx))]
-            fromStackPos:0] ;
+        [skin logError:[NSString stringWithFormat:@"invalid attributes dictionary: expected table, found %s", lua_typename(L, lua_type(L, idx))]] ;
     }
 
     return theAttributes;
@@ -1558,19 +1548,14 @@ static id table_toNSFont(lua_State *L, int idx) {
         }
         lua_pop(L, 1);
     } else {
-        [skin logAtLevel:LS_LOG_WARN
-             withMessage:[NSString stringWithFormat:@"invalid font: expected table or string, found %s",
-                                                    lua_typename(L, lua_type(L, idx))]
-            fromStackPos:1] ;
+        [skin logWarn:[NSString stringWithFormat:@"invalid font: expected table or string, found %s", lua_typename(L, lua_type(L, idx))]] ;
     }
 
     NSFont *theFont = [NSFont fontWithName:theName size:theSize];
     if (theFont) {
         return theFont;
     } else {
-        [skin logAtLevel:LS_LOG_WARN
-             withMessage:[NSString stringWithFormat:@"invalid font specified: %@", theName]
-            fromStackPos:1] ;
+        [skin logWarn:[NSString stringWithFormat:@"invalid font specified: %@", theName]] ;
 
         return [NSFont systemFontOfSize:0] ;
     }
@@ -1634,9 +1619,7 @@ static id table_toNSShadow(lua_State *L, int idx) {
         }
         lua_pop(L, 1);
     } else {
-        [skin logAtLevel:LS_LOG_WARN
-             withMessage:[NSString stringWithFormat:@"invalid shadow object: expected table, found %s", lua_typename(L, lua_type(L, idx))]
-            fromStackPos:1] ;
+        [skin logWarn:[NSString stringWithFormat:@"invalid shadow object: expected table, found %s", lua_typename(L, lua_type(L, idx))]] ;
     }
     return theShadow;
 }
@@ -1817,9 +1800,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             } else if ([theString isEqualToString:@"natural"]) {
                 thePS.alignment = NSNaturalTextAlignment;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:[NSString stringWithFormat:@"invalid alignment specified: %@", theString]
-                    fromStackPos:1] ;
+                [skin logWarn:[NSString stringWithFormat:@"invalid alignment specified: %@", theString]] ;
             }
         }
         lua_pop(L, 1);
@@ -1838,9 +1819,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             } else if ([theString isEqualToString:@"wordWrap"]) {
                 thePS.lineBreakMode = NSLineBreakByWordWrapping;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:[NSString stringWithFormat:@"invalid lineBreakMode: %@", theString]
-                    fromStackPos:1] ;
+                [skin logWarn:[NSString stringWithFormat:@"invalid lineBreakMode: %@", theString]] ;
             }
         }
         lua_pop(L, 1);
@@ -1853,9 +1832,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             } else if ([theString isEqualToString:@"natural"]) {
                 thePS.baseWritingDirection = NSWritingDirectionNatural;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:[NSString stringWithFormat:@"invalid baseWritingDirection: %@", theString]
-                    fromStackPos:1] ;
+                [skin logWarn:[NSString stringWithFormat:@"invalid baseWritingDirection: %@", theString]] ;
             }
         }
         lua_pop(L, 1);
@@ -1864,9 +1841,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0) {
                 thePS.defaultTabInterval = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"defaultTabInterval must be non-negative"
-                    fromStackPos:1] ;
+                [skin logWarn:@"defaultTabInterval must be non-negative"] ;
             }
         }
         lua_pop(L, 1);
@@ -1875,9 +1850,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0) {
                 thePS.firstLineHeadIndent = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"firstLineHeadIndent must be non-negative"
-                    fromStackPos:1] ;
+                [skin logWarn:@"firstLineHeadIndent must be non-negative"] ;
             }
         }
         lua_pop(L, 1);
@@ -1887,9 +1860,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0) {
                 thePS.headIndent = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"headIndent must be non-negative"
-                    fromStackPos:1] ;
+                [skin logWarn:@"headIndent must be non-negative"] ;
             }
         }
         lua_pop(L, 1);
@@ -1902,9 +1873,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0) {
                 thePS.maximumLineHeight = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"maximumLineHeight must be non-negative"
-                    fromStackPos:1] ;
+                [skin logWarn:@"maximumLineHeight must be non-negative"] ;
             }
         }
         lua_pop(L, 1);
@@ -1913,9 +1882,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0) {
                 thePS.minimumLineHeight = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"minimumLineHeight must be non-negative"
-                    fromStackPos:1] ;
+                [skin logWarn:@"minimumLineHeight must be non-negative"] ;
             }
         }
         lua_pop(L, 1);
@@ -1924,9 +1891,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0) {
                 thePS.lineSpacing = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"lineSpacing must be non-negative"
-                    fromStackPos:1] ;
+                [skin logWarn:@"lineSpacing must be non-negative"] ;
             }
         }
         lua_pop(L, 1);
@@ -1935,9 +1900,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0) {
                 thePS.paragraphSpacing = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"paragraphSpacing must be non-negative"
-                    fromStackPos:1] ;
+                [skin logWarn:@"paragraphSpacing must be non-negative"] ;
             }
         }
         lua_pop(L, 1);
@@ -1946,9 +1909,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0) {
                 thePS.paragraphSpacingBefore = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"paragraphSpacingBefore must be non-negative"
-                    fromStackPos:1] ;
+                [skin logWarn:@"paragraphSpacingBefore must be non-negative"] ;
             }
         }
         lua_pop(L, 1);
@@ -1957,9 +1918,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0) {
                 thePS.lineHeightMultiple = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"lineHeightMultiple must be non-negative"
-                    fromStackPos:1] ;
+                [skin logWarn:@"lineHeightMultiple must be non-negative"] ;
             }
         }
         lua_pop(L, 1);
@@ -1968,9 +1927,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0.0 && theNumber <= 1.0) {
                 thePS.hyphenationFactor = (float)theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"hyphenationFactor must be between 0.0 and 1.0 inclusive"
-                    fromStackPos:1] ;
+                [skin logWarn:@"hyphenationFactor must be between 0.0 and 1.0 inclusive"] ;
             }
         }
         lua_pop(L, 1);
@@ -1991,9 +1948,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
             if (theNumber >= 0 && theNumber <= 6) {
                 thePS.headerLevel = theNumber;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:@"headerNumber must be between 0 and 6 inclusive"
-                    fromStackPos:1] ;
+                [skin logWarn:@"headerNumber must be between 0 and 6 inclusive"] ;
             }
         }
         lua_pop(L, 1);
@@ -2007,9 +1962,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
                     [theTabStops addObject:[skin luaObjectAtIndex:-1 toClass:"NSTextTab"]];
                     lua_pop(L, 1); // the tabStop table we just looked at
                 } else {
-                    [skin logAtLevel:LS_LOG_WARN
-                         withMessage:[NSString stringWithFormat:@"invalid tapStop at position %lld: expected table, found %s", pos, lua_typename(L, lua_type(L, -1))]
-                        fromStackPos:1] ;
+                    [skin logWarn:[NSString stringWithFormat:@"invalid tapStop at position %lld: expected table, found %s", pos, lua_typename(L, lua_type(L, -1))]] ;
                 }
                 pos++;
             }
@@ -2018,9 +1971,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
         }
         lua_pop(L, 1);
     } else {
-        [skin logAtLevel:LS_LOG_WARN
-             withMessage:[NSString stringWithFormat:@"invalid paragraphStyle: expected table, found %s", lua_typename(L, lua_type(L, idx))]
-            fromStackPos:1] ;
+        [skin logWarn:[NSString stringWithFormat:@"invalid paragraphStyle: expected table, found %s", lua_typename(L, lua_type(L, idx))]] ;
     }
     return thePS;
 }
@@ -2154,9 +2105,7 @@ static id table_toNSTextTab(lua_State *L, int idx) {
             } else if ([theString isEqualToString:@"decimal"]) {
                 tabStopType = NSDecimalTabStopType;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:[NSString stringWithFormat:@"invalid tabStopType: %@", theString]
-                    fromStackPos:1] ;
+                [skin logWarn:[NSString stringWithFormat:@"invalid tabStopType: %@", theString]] ;
             }
         }
         lua_pop(L, 1);
@@ -2166,9 +2115,7 @@ static id table_toNSTextTab(lua_State *L, int idx) {
         lua_pop(L, 1);
     } else {
         // since this is only used internally, "tableness" should have already been checked...
-        [skin logAtLevel:LS_LOG_ERROR
-             withMessage:[NSString stringWithFormat:@"invalid type for tabStop: expected table, found %s", lua_typename(L, lua_type(L, idx))]
-            fromStackPos:0] ;
+        [skin logError:[NSString stringWithFormat:@"invalid type for tabStop: expected table, found %s", lua_typename(L, lua_type(L, idx))]] ;
     }
     return [[NSTextTab alloc] initWithType:tabStopType location:tabStopLocation];
 }

--- a/extensions/webview/usercontent.m
+++ b/extensions/webview/usercontent.m
@@ -235,9 +235,7 @@ static id table_toWKUserScript(lua_State* L, int idx) {
             lua_pop(L, 1) ;
         } else {
             lua_pop(L, 1) ;
-            [skin logAtLevel:LS_LOG_WARN
-                 withMessage:@"source is required and must be a string"
-                fromStackPos:1] ;
+            [skin logWarn:@"source is required and must be a string"] ;
             return nil ;
         }
 
@@ -246,9 +244,7 @@ static id table_toWKUserScript(lua_State* L, int idx) {
             if ([label isEqualToString:@"documentStart"])      { injectionTime = WKUserScriptInjectionTimeAtDocumentStart ;
             } else if ([label isEqualToString:@"documentEnd"]) { injectionTime = WKUserScriptInjectionTimeAtDocumentEnd ;
             } else {
-                [skin logAtLevel:LS_LOG_WARN
-                     withMessage:[NSString stringWithFormat:@"invalid injectionTime, %@, defaulting to `documentStart`", label]
-                    fromStackPos:1] ;
+                [skin logWarn:[NSString stringWithFormat:@"invalid injectionTime, %@, defaulting to `documentStart`", label]] ;
             }
         }
         lua_pop(L, 1) ;
@@ -258,11 +254,7 @@ static id table_toWKUserScript(lua_State* L, int idx) {
                                                    forMainFrameOnly:mainFrame] ;
         return script ;
     } else {
-        [skin logAtLevel:LS_LOG_WARN
-             withMessage:[NSString stringWithFormat:@"%s:invalid type for userscript, expected table, found %s",
-                                                      USERDATA_UCC_TAG,
-                                                      lua_typename(L, lua_type(L, idx))]
-            fromStackPos:1] ;
+        [skin logWarn:[NSString stringWithFormat:@"%s:invalid type for userscript, expected table, found %s", USERDATA_UCC_TAG, lua_typename(L, lua_type(L, idx))]] ;
         return nil ;
     }
 }


### PR DESCRIPTION
* makes run-of-the-mill logs from `hs.socket` less obtrusive
* remove –logAtLevel:withMessage:fromStackPos:

Basically prep work for #1426 and #1425; more to come, not ready for merge yet.