### PR TITLE
canvas: add percentage conversion fallback

### DIFF
--- a/extensions/canvas/internal.m
+++ b/extensions/canvas/internal.m
@@ -785,12 +785,22 @@ static attributeValidity isValueValidForAttribute(NSString *keyName, id keyValue
 static NSNumber *convertPercentageStringToNumber(NSString *stringValue) {
     NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
     formatter.locale = [NSLocale currentLocale] ;
-    formatter.numberStyle = NSNumberFormatterDecimalStyle ;
 
+    formatter.numberStyle = NSNumberFormatterDecimalStyle ;
     NSNumber *tmpValue = [formatter numberFromString:stringValue] ;
     if (!tmpValue) {
         formatter.numberStyle = NSNumberFormatterPercentStyle ;
         tmpValue = [formatter numberFromString:stringValue] ;
+    }
+    // just to be sure, let's also check with the en_US locale
+    if (!tmpValue) {
+        formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US"] ;
+        formatter.numberStyle = NSNumberFormatterDecimalStyle ;
+        tmpValue = [formatter numberFromString:stringValue] ;
+        if (!tmpValue) {
+            formatter.numberStyle = NSNumberFormatterPercentStyle ;
+            tmpValue = [formatter numberFromString:stringValue] ;
+        }
     }
     return tmpValue ;
 }


### PR DESCRIPTION
Fallback to en_US locale for percentage conversion if using the current locale fails.

Test case: set a locale that uses "," as the decimal separator (e.g. "fr-US"); if you set a percentage through lua division (e.g. `x = tostring(10/100)`), lua isn't locale aware and generates "0.10" which the current code fails on.

This fix adds a fallback to "en_US" if the current locale doesn't recognize the percentage string given.

Addresses #1458 