### PR TITLE
base64.encode triggers tostring for non-string input

### DIFF
--- a/extensions/base64/init.lua
+++ b/extensions/base64/init.lua
@@ -47,7 +47,7 @@ end
 --- Returns:
 ---  * A string containing the decoded data
 module.decode = function(data)
-    return module._decode(data:gsub("[\r\n]+",""))
+    return module._decode((data:gsub("[\r\n]+","")))
 end
 
 -- Return Module Object --------------------------------------------------

--- a/extensions/base64/internal.m
+++ b/extensions/base64/internal.m
@@ -24,6 +24,7 @@ NSData *TransformDataWithFunction(NSData *inputData, SecTransformRef (*function)
 // Function
 // Returns the base64 encoding of the string provided.
 static int base64_encode(lua_State* L) {
+    [[LuaSkin shared] checkArgs:LS_TNUMBER | LS_TSTRING, LS_TBREAK] ;
     NSUInteger sz ;
     const char* data = luaL_tolstring(L, 1, &sz) ;
     NSData* decodedStr = [[NSData alloc] initWithBytes:data length:sz] ;
@@ -37,8 +38,9 @@ static int base64_encode(lua_State* L) {
 // Function
 // Returns a Lua string representing the given base64 string.
 static int base64_decode(lua_State* L) {
-    const char* data = lua_tostring(L,1) ;
-    NSUInteger sz = lua_rawlen(L, 1) ;
+    [[LuaSkin shared] checkArgs:LS_TNUMBER | LS_TSTRING, LS_TBREAK] ;
+    NSUInteger sz ;
+    const char* data = luaL_tolstring(L, 1, &sz) ;
     NSData* encodedStr = [[NSData alloc] initWithBytes:data length:sz] ;
 
     NSData* decodedStr = TransformDataWithFunction(encodedStr, SecDecodeTransformCreate);

--- a/extensions/base64/internal.m
+++ b/extensions/base64/internal.m
@@ -24,8 +24,8 @@ NSData *TransformDataWithFunction(NSData *inputData, SecTransformRef (*function)
 // Function
 // Returns the base64 encoding of the string provided.
 static int base64_encode(lua_State* L) {
-    const char* data = lua_tostring(L,1) ;
-    NSUInteger sz = lua_rawlen(L, 1) ;
+    NSUInteger sz ;
+    const char* data = luaL_tolstring(L, 1, &sz) ;
     NSData* decodedStr = [[NSData alloc] initWithBytes:data length:sz] ;
 
     NSData* encodedStr = TransformDataWithFunction(decodedStr, SecEncodeTransformCreate);


### PR DESCRIPTION
addresses #1466 

this fix invokes the "__tostring" metamethod on anything that isn't a string or number, so using an image like `hs.base64.encode(hs.image.imageFromName(hs.image.systemImageNames.ActionTemplate))` actually encodes the string "hs.image: NSActionTemplate (0x6000010542a8)" (the address will differ).

Is this sufficient or should it generate an error instead?