### PR TITLE
Blacklist Macafee reporter

### DIFF
--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -79,7 +79,7 @@ end
 local SKIP_APPS={
   ['com.apple.WebKit.WebContent']=true,['com.apple.qtserver']=true,['com.google.Chrome.helper']=true,
   ['org.pqrs.Karabiner-AXNotifier']=true,['com.adobe.PDApp.AAMUpdatesNotifier']=true,
-  ['com.adobe.csi.CS5.5ServiceManager']=true}
+  ['com.adobe.csi.CS5.5ServiceManager']=true,['com.mcafee.McAfeeReporter']=true}
 -- so apparently OSX enforces a 6s limit on apps to respond to AX queries;
 -- Karabiner's AXNotifier and Adobe Update Notifier fail in that fashion
 function window.allWindows()


### PR DESCRIPTION
This timed out at 6 seconds in timed window hinting. Blacklisting the reporter app instantly improved performance on my machine.