### PR TITLE
Fix double margin between windows when using grid

### DIFF
--- a/extensions/grid/init.lua
+++ b/extensions/grid/init.lua
@@ -319,6 +319,30 @@ function grid.set(win, cell, scr)
     w = cell.w * cellw - (margins.w * 2),
     h = cell.h * cellh - (margins.h * 2),
   }
+
+  -- ensure windows are not spaced by a double margin
+  if cell.h < screengrid.h and cell.h % 1 == 0 then
+    if cell.y ~= 0 then
+      newframe.h = newframe.h + margins.h / 2
+      newframe.y = newframe.y - margins.h / 2
+    end
+
+    if cell.y + cell.h ~= screengrid.h then
+      newframe.h = newframe.h + margins.h / 2
+    end
+  end
+
+  if cell.w < screengrid.w and cell.w % 1 == 0 then
+    if cell.x ~= 0 then
+      newframe.w = newframe.w + margins.w / 2
+      newframe.x = newframe.x - margins.w / 2
+    end
+
+    if cell.x + cell.w ~= screengrid.w then
+      newframe.w = newframe.w + margins.w / 2
+    end
+  end
+
   win:setFrameInScreenBounds(newframe) --TODO check this (against screen bottom stickiness)
   return grid
 end


### PR DESCRIPTION
Currently the grid margin value applies in all directions. Which means get twice as much space inbetween windows, as you get between windows and the screen edge. This change ensures that if you set the margin to `{ w = 10, h = 10}` you get a 10 pixel gap between windows and screen edges, and also between different windows.

Before:

![menubar_and_untitled_3_and_untitled_2](https://user-images.githubusercontent.com/39563/28995690-03f4bba6-79e8-11e7-8b39-5666f9c94346.png)

After:

![menubar_and_untitled_3_and_untitled_2 2](https://user-images.githubusercontent.com/39563/28995693-0b675ff6-79e8-11e7-8993-3c39769914f4.png)

Apologies for not adding any tests for this change, the grid extension currently has no tests, and I'm brand new to Lua, so I don't really know where to start.

If lack of tests is a showstopper for getting this merged in, please point me in the right direction to get started with putting together some tests :)