### PR TITLE
Add API for focusing OSX tabs

### DIFF
--- a/extensions/window/internal.m
+++ b/extensions/window/internal.m
@@ -168,6 +168,7 @@ static AXUIElementRef get_window_tabs(AXUIElementRef win) {
     return tabs;
 }
 
+// tabIndex is a 0-based index of the tab to select
 static BOOL window_presstab(AXUIElementRef win, CFIndex tabIndex) {
     BOOL worked = NO;
     CFArrayRef children = NULL;
@@ -467,7 +468,7 @@ static int window__close(lua_State* L) {
 /// Works with document tab groups and some app tabs, like Chrome and Safari.
 ///
 /// Parameters:
-///  * index - A number, a 0-based index of a tab to focus
+///  * index - A number, a 1-based index of a tab to focus
 ///
 /// Returns:
 ///  * true if the tab was successfully pressed, or false if there was a problem
@@ -475,7 +476,7 @@ static int window_focustab(lua_State* L) {
     AXUIElementRef win = get_window_arg(L, 1);
     CFIndex tabIndex = luaL_checkinteger(L, 2);
 
-    BOOL worked = window_presstab(win, tabIndex);
+    BOOL worked = window_presstab(win, tabIndex - 1);
     lua_pushboolean(L, worked);
     return 1;
 }

--- a/extensions/window/internal.m
+++ b/extensions/window/internal.m
@@ -140,6 +140,59 @@ static BOOL set_window_prop(AXUIElementRef win, NSString* propType, id value) {
     return NO;
 }
 
+
+static AXUIElementRef get_window_tabs(AXUIElementRef win) {
+    AXUIElementRef tabs = NULL;
+
+    CFArrayRef children = NULL;
+    if(AXUIElementCopyAttributeValues(win, kAXChildrenAttribute, 0, 100, &children) != noErr) goto cleanup;
+    CFIndex count = CFArrayGetCount(children);
+
+    CFTypeRef typeRef;
+    for (CFIndex i = 0; i < count; ++i) {
+        AXUIElementRef child = CFArrayGetValueAtIndex(children, i);
+        if(AXUIElementCopyAttributeValue(child, kAXRoleAttribute, &typeRef) != noErr) goto cleanup;
+        CFStringRef role = (CFStringRef)typeRef;
+        BOOL correctRole = kCFCompareEqualTo == CFStringCompare(role, kAXTabGroupRole, 0);
+        CFRelease(role);
+        if (correctRole) {
+            tabs = child;
+            CFRetain(tabs);
+            break;
+        }
+    }
+
+    cleanup:
+    if(children) CFRelease(children);
+
+    return tabs;
+}
+
+static BOOL window_presstab(AXUIElementRef win, CFIndex tabIndex) {
+    BOOL worked = NO;
+    CFArrayRef children = NULL;
+    AXUIElementRef tab = NULL;
+
+    AXUIElementRef tabs = get_window_tabs(win);
+    if(tabs == NULL) goto cleanup;
+
+    if(AXUIElementCopyAttributeValues(tabs, kAXTabsAttribute, 0, 100, &children) != noErr) goto cleanup;
+    CFIndex count = CFArrayGetCount(children);
+
+    CFIndex i = tabIndex;
+    if(i >= count || i < 0) i = count - 1;
+    tab = CFArrayGetValueAtIndex(children, i);
+
+    if (AXUIElementPerformAction(tab, kAXPressAction) != noErr) goto cleanup;
+
+    worked = YES;
+cleanup:
+    if (tab) CFRelease(tab);
+    if (tabs) CFRelease(tabs);
+
+    return worked;
+}
+
 /// hs.window:title() -> string
 /// Method
 /// Gets the title of the window
@@ -388,6 +441,26 @@ cleanup:
 ///  * True if the operation succeeded, false if not
 static int window__close(lua_State* L) {
     return window_pressbutton(L, kAXCloseButtonAttribute);
+}
+
+/// hs.window:focusTab(index) -> bool
+/// Method
+/// Focuses the tab in the window's tab group at index, or the last tab if
+/// index is out of bounds. Returns true if a tab was pressed.
+///
+/// Parameters:
+///  * index - A number, true if the window should be set fullscreen, false if not
+///
+/// Returns:
+///  * The `hs.window` object
+static int window_focustab(lua_State* L) {
+    AXUIElementRef win = get_window_arg(L, 1);
+    double indexDouble = luaL_checknumber(L, 2);
+    CFIndex tabIndex = indexDouble;
+
+    BOOL worked = window_presstab(win, tabIndex);
+    lua_pushboolean(L, worked);
+    return 1;
 }
 
 /// hs.window:setFullScreen(fullscreen) -> window
@@ -756,6 +829,7 @@ static const luaL_Reg windowlib[] = {
     {"isMinimized", window_isminimized},
     {"pid", window_pid},
     {"application", window_application},
+    {"focusTab", window_focustab},
     {"becomeMain", window_becomemain},
     {"raise", window_raise},
     {"id", window_id},


### PR DESCRIPTION
macOS Sierra added the ability to use tabs with any document-based app.
Unfortunately for some apps like Sublime Text, there's no way by default
to use keyboard shortcuts to switch between these tabs.

This adds an API for doing so.