### PR TITLE
Fix caffeinate.startScreensaver() to work under High Sierra

### DIFF
--- a/extensions/caffeinate/init.lua
+++ b/extensions/caffeinate/init.lua
@@ -128,7 +128,7 @@ end
 --- Returns:
 ---  * None
 function caffeinate.startScreensaver()
-    os.execute("open /System/Library/Frameworks/ScreenSaver.framework/Versions/A/Resources/ScreenSaverEngine.app")
+    os.execute("open -a ScreenSaverEngine")
 end
 
 --- hs.caffeinate.logOut()


### PR DESCRIPTION
The path in High Sierra has changed, so this no longer works.  Calling
the ScreenSaverEngine application seems to be a more stable and correct
way to trigger the screensaver that works across versions.