### PR TITLE
add `noaction` command to hs.window.layout

### DIFF
--- a/extensions/window/filter.lua
+++ b/extensions/window/filter.lua
@@ -224,6 +224,7 @@ local function checkWindowAllowed(filter,win)
     if filter.allowScreens and not filter._allowedScreens[win.screen] then return false,'allowScreens' end
     if filter.rejectScreens and filter._rejectedScreens[win.screen] then return false,'rejectScreens' end
   end
+  if filter.hasTitlebar~=nil and win.hasTitlebar~=filter.hasTitlebar then return false,'hasTitlebar' end
   local approles = filter.allowRoles or windowfilter.allowedWindowRoles
   if approles~='*' and not approles[win.role] then return false,'allowRoles' end
   return true,''
@@ -442,6 +443,7 @@ end
 ---    * visible - if `true`, only allow visible windows (in any Space); if `false`, reject visible windows; if omitted, this rule is ignored
 ---    * currentSpace - if `true`, only allow windows in the current Mission Control Space (minimized and hidden windows are included, as they're considered to belong to all Spaces); if `false`, reject windows in the current Space (including all minimized and hidden windows); if omitted, this rule is ignored
 ---    * fullscreen - if `true`, only allow fullscreen windows; if `false`, reject fullscreen windows; if omitted, this rule is ignored
+---    * hasTitlebar - if `true`, only allow windows with titlebar; if `false`, reject window with titlebar; if omitted, this rule is ignored
 ---    * focused - if `true`, only allow a window while focused; if `false`, reject the focused window; if omitted, this rule is ignored
 ---    * activeApplication - only allow any of this app's windows while it is (if `true`) or it's not (if `false`) the active application; if omitted, this rule is ignored
 ---    * allowTitles
@@ -562,7 +564,7 @@ function WF:setAppFilter(appname,ft,batch)
           logs=sformat('%s%s={%s}, ',logs,k,first)
         else logs=sformat('%s%s=%s, ',logs,k,v) end
         filter.allowRoles=r
-      elseif k=='visible' or k=='fullscreen' or k=='focused' or k=='currentSpace' or k=='activeApplication' then
+      elseif k=='visible' or k=='fullscreen' or k=='focused' or k=='currentSpace' or k=='activeApplication' or 'hasTitlebar' then
         if type(v)~='boolean' then error(k..' must be a boolean',2) end
         filter[k]=v logs=sformat('%s%s=%s, ',logs,k,ft[k])
       elseif k=='allowRegions' or k=='rejectRegions' then
@@ -1009,7 +1011,7 @@ function Window.new(win,id,app,watcher)
   --  local w = setmetatable({id=function()return id end},{__index=function(_,k)return function(self,...)return win[k](win,...)end end})
   -- hackity hack removed, turns out it was just for :snapshot (see gh#413)
   local o = setmetatable({app=app,window=win,id=id,watcher=watcher,frame=win:frame(),screen=win:screen():id(),
-    isMinimized=win:isMinimized(),isVisible=win:isVisible(),isFullscreen=win:isFullScreen(),
+    isMinimized=win:isMinimized(),isVisible=win:isVisible(),isFullscreen=win:isFullScreen(),hasTitlebar=(nil~=win:zoomButtonRect()),
     role=win:subrole(),title=win:title()}
   ,{__index=Window})
   o.isHidden = not o.isVisible and not o.isMinimized

--- a/extensions/window/filter.lua
+++ b/extensions/window/filter.lua
@@ -564,7 +564,7 @@ function WF:setAppFilter(appname,ft,batch)
           logs=sformat('%s%s={%s}, ',logs,k,first)
         else logs=sformat('%s%s=%s, ',logs,k,v) end
         filter.allowRoles=r
-      elseif k=='visible' or k=='fullscreen' or k=='focused' or k=='currentSpace' or k=='activeApplication' or 'hasTitlebar' then
+      elseif k=='visible' or k=='fullscreen' or k=='focused' or k=='currentSpace' or k=='activeApplication' or k=='hasTitlebar' then
         if type(v)~='boolean' then error(k..' must be a boolean',2) end
         filter[k]=v logs=sformat('%s%s=%s, ',logs,k,ft[k])
       elseif k=='allowRegions' or k=='rejectRegions' then

--- a/extensions/window/layout.lua
+++ b/extensions/window/layout.lua
@@ -20,6 +20,7 @@
 ---   - `tile`, `fit`: tiles the windows onto a specified rect, using `hs.window.tiling.tileWindows()`; for `fit`, the
 ---     `preserveRelativeArea` parameter will be set to true
 ---   - `hide`, `unhide`: hides or unhides the window's application (like when using cmd-h)
+---   - `noaction`: skip action on the window(s)
 --- * a **maxn** number, indicating how many windows from this rule's window pool will be affected (at most) by this command;
 ---   if omitted (or if explicitly the string `all`) all the remaining windows will be processed by this command; processed
 ---   windows are "consumed" and are excluded from the window pool for subsequent commands in this rule, and from subsequent rules
@@ -99,7 +100,7 @@ local function strip(s) return type(s)=='string' and s:gsub('%s+','') or s end
 local MOVE,TILE,FIT,HIDE,UNHIDE,MINIMIZE,MAXIMIZE,FULLSCREEN,RESTORE='move','tile','fit','hide','unhide','minimize','maximize','fullscreen','restore'
 local NOACTION='noaction'
 local CREATEDLAST,CREATEDFIRST,FOCUSEDLAST,CLOSEST='createdLast','created','focusedLast','closest'
-local ACTIONS={mov=MOVE,fra=MOVE,til=TILE,fit=FIT,hid=HIDE,unh=UNHIDE,sho=UNHIDE,max=MAXIMIZE,ful=FULLSCREEN,fs=FULLSCREEN,min=MINIMIZE,res=RESTORE}
+local ACTIONS={mov=MOVE,fra=MOVE,til=TILE,fit=FIT,hid=HIDE,unh=UNHIDE,sho=UNHIDE,max=MAXIMIZE,ful=FULLSCREEN,fs=FULLSCREEN,min=MINIMIZE,res=RESTORE,noa=NOACTION}
 local SELECTORS={cre=CREATEDLAST,new=CREATEDLAST,old=CREATEDFIRST,foc=FOCUSEDLAST,clo=CLOSEST,pos=CLOSEST}
 
 local function getaction(s,i)
@@ -171,7 +172,7 @@ local function validateCommand(command,ielem,icmd,irule,log)
     if not getselector(command.select,0) then error'selector'
     else logs=logs..' '..command.select end
   end
-  if action==MAXIMIZE or action==FULLSCREEN then
+  if action==MAXIMIZE or action==FULLSCREEN or action==NOACTION then
     if command.screen then
       if not validatescreen(command.screen,ielem) then error'screen'end
       logs=logs..' screen='..screenstr(command.screen)

--- a/extensions/window/layout.lua
+++ b/extensions/window/layout.lua
@@ -25,7 +25,8 @@
 ---   if omitted (or if explicitly the string `all`) all the remaining windows will be processed by this command; processed
 ---   windows are "consumed" and are excluded from the window pool for subsequent commands in this rule, and from subsequent rules
 --- * a **selector**, describing the sort order used to pick the first *maxn* windows from the window pool for this command;
----   it can be one of `focused` (pick *maxn* most recently focused windows), `newest` (most recently created), `oldest`
+---   it can be one of `focused` (pick *maxn* most recently focused windows), `frontmost` (pick the recent focused window if its  
+---   application is frontmost applicaion, otherwise the command will be skipped), `newest` (most recently created), `oldest`
 ---   (least recently created), or `closest` (pick the *maxn* windows that are closest to the destination rect); if omitted,
 ---   defaults to `closest` for move, tile and fit, and `newest` for everything else
 --- * an `hs.geometry` *size* (only valid for tile and fit) indicating the desired optimal aspect ratio for the tiled windows;
@@ -99,9 +100,9 @@ local function strip(s) return type(s)=='string' and s:gsub('%s+','') or s end
 
 local MOVE,TILE,FIT,HIDE,UNHIDE,MINIMIZE,MAXIMIZE,FULLSCREEN,RESTORE='move','tile','fit','hide','unhide','minimize','maximize','fullscreen','restore'
 local NOACTION='noaction'
-local CREATEDLAST,CREATEDFIRST,FOCUSEDLAST,CLOSEST='createdLast','created','focusedLast','closest'
+local CREATEDLAST,CREATEDFIRST,FOCUSEDLAST,CLOSEST,FRONTMOST='createdLast','created','focusedLast','closest','frontmost'
 local ACTIONS={mov=MOVE,fra=MOVE,til=TILE,fit=FIT,hid=HIDE,unh=UNHIDE,sho=UNHIDE,max=MAXIMIZE,ful=FULLSCREEN,fs=FULLSCREEN,min=MINIMIZE,res=RESTORE,noa=NOACTION}
-local SELECTORS={cre=CREATEDLAST,new=CREATEDLAST,old=CREATEDFIRST,foc=FOCUSEDLAST,clo=CLOSEST,pos=CLOSEST}
+local SELECTORS={cre=CREATEDLAST,new=CREATEDLAST,old=CREATEDFIRST,foc=FOCUSEDLAST,clo=CLOSEST,pos=CLOSEST,fro=FRONTMOST}
 
 local function getaction(s,i)
   if type(s)~='string' then return nil,i end
@@ -515,6 +516,14 @@ local function applyRule(rule)
       win=windowsCreated[1]
     elseif selector==CREATEDFIRST then
       win=windowsCreated[#windowsCreated]
+    elseif selector==FRONTMOST then
+      if windows[1]:application() == hs.application.frontmostApplication() then
+        win=windows[1]
+        nprocessed = 999
+      else 
+        icmd=icmd+1 nprocessed=0
+        goto _next_
+      end
     end
     --    hs.assert(win,'no window to apply rule',rule)
 
@@ -551,6 +560,7 @@ local function applyRule(rule)
       --          local w=readdUnhiddenWindows[i] tinsert(windows,w,1) tinsert(windowsCreated,w,1)
       --        end
     end
+    ::_next_::
   end
 end
 
@@ -654,7 +664,7 @@ function layout:resume()
     --timers and upvalues galore
     local hasFocusedSelector--,hasPositionSelector
     for _,cmd in ipairs(rule) do
-      if cmd.select==FOCUSEDLAST then hasFocusedSelector=true end
+      if cmd.select==FOCUSEDLAST or cmd.select==FRONTMOST then hasFocusedSelector=true end
       --      elseif cmd.select==CLOSEST then hasPositionSelector=true end
     end
     rule.callback=function()


### PR DESCRIPTION
add `noaction` command to ignore selected windows in certain case e.g. you may ignore the current focused window and move the rest.

add `hasTitlebar` filter to hs.window.filter, so that you can skip edge case like some auto-complete pop-ups

add `frontmost` selector to hs.window.layout, it's like `focused` but only apply to frontmost app
