### PR TITLE
Extended hs.osascript with functions to execute as/js from a file

### DIFF
--- a/extensions/osascript/LICENSE
+++ b/extensions/osascript/LICENSE
@@ -1,7 +1,8 @@
 The MIT License (MIT)
 
 Original work Copyright (c) 2014 Aaron Magill
-Modified work Copyright 2015 Michael Bujol
+Modified work Copyright (c) 2015 Michael Bujol
+Modified work Copyright (c) 2017 Rosco Kalis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/extensions/osascript/init.lua
+++ b/extensions/osascript/init.lua
@@ -26,6 +26,18 @@ local processResults = function(ok, object, rawDescriptor)
     return ok, object, descriptor
 end
 
+-- Reads the contents of a file found at fileName and returns the contents as a string.
+-- Will throw an error if the specified file can not be read.
+local importScriptFile = function(fileName)
+    local f = io.open(fileName, "rb")
+    if not f then
+        error("Can't read file " .. fileName)
+    end
+    local content = f:read("*all")
+    f:close()
+    return content
+end
+
 -- Public interface ------------------------------------------------------
 
 --- hs.osascript.applescript(source) -> bool, object, descriptor
@@ -47,6 +59,26 @@ module.applescript = function(source)
     return processResults(ok, object, descriptor)
 end
 
+--- hs.osascript.applescriptFromFile(fileName) -> bool, object, descriptor
+--- Function
+--- Runs AppleScript code from a source file.
+---
+--- Parameters:
+---  * fileName - A string containing the file name of an AppleScript file to execute.
+---
+--- Returns:
+---  * A boolean value indicating whether the code succeeded or not
+---  * An object containing the parsed output that can be any type, or nil if unsuccessful
+---  * If the code succeeded, the raw output of the code string. If the code failed, a table containing an error dictionary
+---
+--- Notes:
+---  * This function uses hs.osascript.applescript for execution.
+---  * Use hs.osascript._osascript(source, "AppleScript") if you always want the result as a string, even when a failure occurs. However, this function can only take a string, and not a file name.
+module.applescriptFromFile = function(fileName)
+    local source = importScriptFile(fileName)
+    return module.applescript(source)
+end
+
 
 --- hs.osascript.javascript(source) -> bool, object, descriptor
 --- Function
@@ -65,6 +97,26 @@ end
 module.javascript = function(source)
     local ok, object, descriptor = module._osascript(source, "JavaScript")
     return processResults(ok, object, descriptor)
+end
+
+--- hs.osascript.javascriptFromFile(fileName) -> bool, object, descriptor
+--- Function
+--- Runs JavaScript code from a source file.
+---
+--- Parameters:
+---  * fileName - A string containing the file name of an JavaScript file to execute.
+---
+--- Returns:
+---  * A boolean value indicating whether the code succeeded or not
+---  * An object containing the parsed output that can be any type, or nil if unsuccessful
+---  * If the code succeeded, the raw output of the code string. If the code failed, a table containing an error dictionary
+---
+--- Notes:
+---  * This function uses hs.osascript.javascript for execution.
+---  * Use hs.osascript._osascript(source, "JavaScript") if you always want the result as a string, even when a failure occurs. However, this function can only take a string, and not a file name.
+module.javascriptFromFile = function(fileName)
+    local source = importScriptFile(fileName)
+    return module.javascript(source)
 end
 
 setmetatable(module, { __call = function(_, ...) return module.applescript(...) end })


### PR DESCRIPTION
This allows people to import an AppleScript file to execute, instead of writing it inline in a Lua file. This also makes it easier to debug these scripts before integrating it with Hammerspoon as the files can be run separately first.