### PR TITLE
move webview load checks back to main thread

### DIFF
--- a/extensions/webview/internal.m
+++ b/extensions/webview/internal.m
@@ -879,7 +879,7 @@ static int webview_url(lua_State *L) {
         NSURLRequest *theNSURL = [skin luaObjectAtIndex:2 toClass:"NSURLRequest"] ;
         if (theNSURL) {
             if (theView.loading) [theView stopLoading] ;
-            dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            dispatch_async(dispatch_get_main_queue(), ^{
                 while (theView.loading) {}
                 WKNavigation *navID = [theView loadRequest:theNSURL] ;
                 theView.trackingID = navID ;
@@ -1158,7 +1158,7 @@ static int webview_reload(lua_State *L) {
     HSWebViewView   *theView = theWindow.contentView ;
 
     if (theView.loading) [theView stopLoading] ;
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         while (theView.loading) {}
         WKNavigation *navID ;
         if (lua_type(L, 2) == LUA_TBOOLEAN && lua_toboolean(L, 2))
@@ -1374,7 +1374,7 @@ static int webview_html(lua_State *L) {
     NSString *theBaseURL = (lua_type(L, 3) == LUA_TSTRING) ? [skin toNSObjectAtIndex:3] : nil ;
 
     if (theView.loading) [theView stopLoading] ;
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         while (theView.loading) {}
         WKNavigation *navID = [theView loadHTMLString:theHTML baseURL:[NSURL URLWithString:theBaseURL]] ;
         theView.trackingID = navID ;
@@ -1990,9 +1990,9 @@ static int webview_deleteOnClose(lua_State *L) {
 static int webview_darkMode(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared] ;
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
-    
+
     HSWebViewWindow *theWindow = get_objectFromUserdata(__bridge HSWebViewWindow, L, 1, USERDATA_TAG) ;
-    
+
     if (lua_type(L, 2) == LUA_TNONE) {
         lua_pushboolean(L, theWindow.darkMode) ;
     } else {
@@ -2993,7 +2993,7 @@ static const luaL_Reg userdata_metaLib[] = {
 
     // Window related
     {"darkMode",                   webview_darkMode},
-    
+
     {"show",                       webview_show},
     {"hide",                       webview_hide},
     {"closeOnEscape",              webview_closeOnEscape},


### PR DESCRIPTION
@cmsj, per #1625, I can confirm running Hammerspoon in XCode shows "Main Thread Checker: UI API called on a background thread" for the WKWebView loading property because running within XCode includes the wrapper library described here: https://developer.apple.com/documentation/code_diagnostics/main_thread_checker

In this particular case, I think the checker is being a little overprotective, but that doesn't mean it won't change in the future, so... as suggested, I've moved the checks back into the main queue, though still in an async block to hopefully continue to prevent the issue described in #1151.

@latenitefilms, can you test this pull and see if this modification of #1153 still prevents the -999 errors you were seeing?