### PR TITLE
Issue #1751 - Fixed Typos in `hs.menubar:isInMenuBar()`

### DIFF
--- a/extensions/menubar/internal.m
+++ b/extensions/menubar/internal.m
@@ -991,7 +991,7 @@ static int menubar_returnToMenuBar(lua_State *L) {
 ///
 /// Returns:
 ///  * a boolean indicating whether or not the specified menu is currently in the OS X menubar
-static int menubar_isInMenubar(lua_State *L) {
+static int menubar_isInMenuBar(lua_State *L) {
     menubaritem_t *menuBarItem     = get_item_arg(L, 1);
     lua_pushboolean(L, !(menuBarItem->removed)) ;
     return 1;
@@ -1190,7 +1190,7 @@ static const luaL_Reg menubar_metalib[] = {
     {"stateImageSize",    menubarStateImageSize},
     {"_frame",            menubarFrame},
     {"priority",          menubarPriority},
-    {"isInMenubar",       menubar_isInMenubar},
+    {"isInMenuBar",       menubar_isInMenuBar},
 
     {"__tostring",        userdata_tostring},
     {"__gc",              menubaritem_gc},


### PR DESCRIPTION
- Fixed Typos in `hs.menubar:isInMenuBar()`
- Closes #1751