### PR TITLE
Add hs.hid.led to control LEDs on the keyboard

### DIFF
--- a/Hammerspoon.xcodeproj/project.pbxproj
+++ b/Hammerspoon.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		D6F310F01BDF113900045CCD /* internal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F310D11BDF0E0000045CCD /* internal.m */; };
 		D6FD568A1C0422B400BAE238 /* LuaSkin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F9850E81B722CBF00F7E909 /* LuaSkin.framework */; };
 		D6FD56901C0422DE00BAE238 /* internal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6FD56821C04228800BAE238 /* internal.m */; };
+		DAED28EC20B95E8F004602CB /* led.m in Sources */ = {isa = PBXBuildFile; fileRef = DAED28EB20B95E8E004602CB /* led.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1333,6 +1334,7 @@
 		D6FD56811C04228800BAE238 /* init.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = init.lua; path = extensions/console/init.lua; sourceTree = "<group>"; };
 		D6FD56821C04228800BAE238 /* internal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = internal.m; path = extensions/console/internal.m; sourceTree = "<group>"; };
 		D6FD568F1C0422B400BAE238 /* libconsole.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libconsole.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAED28EB20B95E8E004602CB /* led.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = led.m; path = extensions/hid/led.m; sourceTree = "<group>"; };
 		DE2547C1592A3EDD90D9815D /* Pods-Hammerspoon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hammerspoon.release.xcconfig"; path = "Pods/Target Support Files/Pods-Hammerspoon/Pods-Hammerspoon.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -3169,6 +3171,7 @@
 		B8524F23201A874600844F3D /* hid */ = {
 			isa = PBXGroup;
 			children = (
+				DAED28EB20B95E8E004602CB /* led.m */,
 				B8524F24201A875600844F3D /* init.lua */,
 				B8524F25201A875600844F3D /* internal.m */,
 			);
@@ -6366,6 +6369,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B8524F32201A896000844F3D /* internal.m in Sources */,
+				DAED28EC20B95E8F004602CB /* led.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/extensions/hid/init.lua
+++ b/extensions/hid/init.lua
@@ -50,6 +50,25 @@ module.capslock.set = function(state)
 	end
 end
 
+
+module.led = {}
+
+--- hs.hid.led.set(name, state) -> bool
+--- Function
+--- Assigns HID LED to the desired state
+--- Note that this function controls the LED state only,
+--- to modify capslock state, use hs.hid.capslock.set
+---
+--- Parameters:
+---  * name  - LED name: "caps", "scroll" or "num"
+---  * state - A boolean indicating desired state
+---
+--- Returns:
+---  * true if success, false if error
+module.led.set = function(name, state)
+    return module._led_set(name, state)
+end
+
 -- Return Module Object --------------------------------------------------
 
 return module

--- a/extensions/hid/led.m
+++ b/extensions/hid/led.m
@@ -1,0 +1,128 @@
+#import <Foundation/Foundation.h>
+#include <mach/mach_error.h>
+#include <IOKit/hid/IOHIDUsageTables.h>
+
+static NSMutableDictionary* _CreateMatchingDict(Boolean isDeviceNotElement,
+                                                uint32_t inUsagePage,
+                                                uint32_t inUsage);
+
+static NSMutableDictionary* _CreateMatchingDict(Boolean isDeviceNotElement,
+                                                uint32_t inUsagePage,
+                                                uint32_t inUsage)
+{
+    NSMutableDictionary* dic = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
+                                [NSNumber numberWithUnsignedInt:inUsagePage],
+                                (isDeviceNotElement)?
+                                CFSTR(kIOHIDDeviceUsagePageKey):
+                                CFSTR(kIOHIDElementUsagePageKey),
+                                NULL];
+    if (inUsage) [dic setObject:[NSNumber numberWithUnsignedInt:inUsage]
+                         forKey:(isDeviceNotElement)?
+                  (NSString*)CFSTR(kIOHIDDeviceUsageKey):
+                  (NSString*)CFSTR(kIOHIDElementUsageKey)];
+    return dic;
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+
+bool hidled_set(uint32 usage, long target_value) {
+    bool success = false;
+    CFSetRef deviceCFSetRef = NULL;
+    IOHIDDeviceRef * refs = NULL;
+    // create a IO HID Manager reference
+    IOHIDManagerRef mgr = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+    if(!mgr)
+        return false;
+    // Create a device matching dictionary
+    NSDictionary* dic = _CreateMatchingDict(true, kHIDPage_GenericDesktop,
+                                            kHIDUsage_GD_Keyboard);
+    if (!dic)
+        goto Oops;
+    // set the HID device matching dictionary
+    IOHIDManagerSetDeviceMatching(mgr, (__bridge CFDictionaryRef)dic);
+    //    [dic release];
+    // Now open the IO HID Manager reference
+    IOReturn err = IOHIDManagerOpen(mgr, kIOHIDOptionsTypeNone);
+    if (err != 0)
+        goto Oops;
+    // and copy out its devices
+    deviceCFSetRef = IOHIDManagerCopyDevices(mgr);
+    if (!deviceCFSetRef)
+        goto Oops;
+    // how many devices in the set?
+    CFIndex deviceIndex, deviceCount = CFSetGetCount(deviceCFSetRef);
+    // allocate a block of memory to extact the device refs from the set into
+    refs = malloc(sizeof(IOHIDDeviceRef) * deviceCount);
+    if (!refs)
+        goto Oops;
+    // now extract the device refs from the set
+    CFSetGetValues(deviceCFSetRef, (const void **)(void *)refs);
+    // before we get into the device loop set up element matching dictionary
+    dic = _CreateMatchingDict(false, kHIDPage_LEDs, 0);
+    if (!dic)
+        goto Oops;
+    
+    for (deviceIndex = 0; deviceIndex < deviceCount; deviceIndex++)
+    {
+        // if this isn't a keyboard device...
+        if (!IOHIDDeviceConformsTo((IOHIDDeviceRef)refs[deviceIndex], kHIDPage_GenericDesktop,
+                                   kHIDUsage_GD_Keyboard))
+        {
+            continue;  // ...skip it
+        }
+        // copy all the elements
+        CFArrayRef elements = IOHIDDeviceCopyMatchingElements(refs[deviceIndex],
+                                                              (__bridge CFDictionaryRef)dic,
+                                                              kIOHIDOptionsTypeNone);
+        if(!elements)
+            continue;
+        // iterate over all the elements
+        CFIndex i, n = CFArrayGetCount(elements);
+        for (i = 0; i < n; i++)
+        {
+            IOHIDElementRef element = (IOHIDElementRef)CFArrayGetValueAtIndex(elements, i);
+            if(!element)
+                continue;
+            uint32_t usagePage = IOHIDElementGetUsagePage(element);
+            // if this isn't an LED element, skip it
+            if (kHIDPage_LEDs != usagePage) continue;
+            uint32_t elusage = IOHIDElementGetUsage(element);
+            if (elusage == usage)
+            {
+                // set led
+                //err = IOHIDDeviceOpen(refs[deviceIndex], 0);
+                err = 0;
+                if (err == 0) {
+                    // create the IO HID Value to be sent to this LED element
+                    uint64_t timestamp = 0;
+                    IOHIDValueRef val = IOHIDValueCreateWithIntegerValue(kCFAllocatorDefault,
+                                                                         element, timestamp,
+                                                                         target_value);
+                    if (val)
+                    {
+                        // now set it on the device
+                        IOHIDDeviceSetValue(refs[deviceIndex], element, val);
+                        CFRelease(val);
+                        success = true;
+                    }
+                    //IOHIDDeviceClose(refs[deviceIndex], 0);
+                }
+                break;
+            }
+        }
+        CFRelease(elements);
+    }
+    CFRelease(mgr);
+    
+Oops:
+    if (deviceCFSetRef)
+        CFRelease(deviceCFSetRef);
+    if (refs)
+        free(refs);
+    
+    return success;
+}
+
+#pragma clang diagnostic pop

--- a/extensions/hid/led.m
+++ b/extensions/hid/led.m
@@ -114,14 +114,17 @@ bool hidled_set(uint32 usage, long target_value) {
         }
         CFRelease(elements);
     }
-    CFRelease(mgr);
-    
+
 Oops:
+    if (mgr) {
+        IOHIDManagerClose(mgr, kIOHIDOptionsTypeNone);
+        CFRelease(mgr);
+    }
     if (deviceCFSetRef)
         CFRelease(deviceCFSetRef);
     if (refs)
         free(refs);
-    
+
     return success;
 }
 


### PR DESCRIPTION
#1680 

```
-- turn on caps lock LED
hs.hid.led.set("caps", true)
-- turn off num lock LED
hs.hid.led.set("num", false)
```

The key difference between `hs.hid.led.set("caps", true)` and `hs.hid.capslock.on()` (existing API) is that, `hs.hid.led` toggles the LED state directly without changing the caps lock.

The API is a little bit inconsistent with `hs.hid.capslock` but I didn't come out a better way.