### PR TITLE
*CL Addition* adds functions to get fonts by family name

### DIFF
--- a/extensions/styledtext/init.lua
+++ b/extensions/styledtext/init.lua
@@ -239,7 +239,7 @@ module.fontsForFamily = function(...)
             { "ultra", "ultrablack", "fat" },
             { "extrablack", "obese", "nord" }
         }
-        for i,v in ipairs(results) do
+        for _,v in ipairs(results) do
             v[3] = fontWeights[v[3]] or string.format("** unrecognized font weight: %d", v[3])
             local style, styleTable = v[4], { _numeric = v[4] }
             for k, v2 in pairs(module.fontTraits) do

--- a/extensions/styledtext/init.lua
+++ b/extensions/styledtext/init.lua
@@ -179,11 +179,84 @@ module.lineStyles    = ls.makeConstantsTable(module.lineStyles)
 module.lineAppliesTo = ls.makeConstantsTable(module.lineAppliesTo)
 
 module.fontNames = function(...)
-    return ls.makeConstantsTable(module._fontNames(...))
+    local results = module._fontNames(...)
+    return results and ls.makeConstantsTable(results) or nil
+end
+
+module.fontFamilies = function(...)
+    local results = module._fontFamilies(...)
+    return results and ls.makeConstantsTable(results) or nil
 end
 
 module.fontNamesWithTraits = function(...)
-    return ls.makeConstantsTable(module._fontNamesWithTraits(...))
+    local results = module._fontNamesWithTraits(...)
+    return results and ls.makeConstantsTable(results) or nil
+end
+
+--- hs.styledtext.fontsForFamily(familyName) -> table
+--- Function
+--- Returns an array containing fonts available for the specified font family or nil if no fonts for the specified family are present.
+---
+--- Parameters:
+---  * `familyName` - a string specifying the font family to return available fonts for. The strings should be one of the values returned by the [hs.styledtext.fontFamiles](#fontFamilies) function.
+---
+--- Returns:
+---  * a table containing an array of available fonts for the specified family. Each array entry will be a table, also as an array, in the following order:
+---    * a string specifying the font name which can be used in the `hs.drawing:setTextFont(fontname)` method.
+---    * a string specifying the basic style of the font (e.g. Bold, Italic, Roman, etc.)
+---    * a table containing one or more strings specifying common names for the weight of the font. ISO equivalent names are preceded with "ISO:". Possible values are:
+---             `{ "ultralight" }`
+---             `{ "thin", "ISO:ultralight" }`
+---             `{ "light", "extralight", "ISO:extralight" }`
+---             `{ "book", "ISO:light" }`
+---             `{ "regular", "plain", "display", "roman", "ISO:semilight" }`
+---             `{ "medium", "ISO:medium" }`
+---             `{ "demi", "demibold" }`
+---             `{ "semi", "semibold", "ISO:semibold" }`
+---             `{ "bold", "ISO:bold" }`
+---             `{ "extra", "extrabold", "ISO:extrabold" }`
+---             `{ "heavy", "heavyface" }`
+---             `{ "black", "super", "ISO:ultrabold" }`
+---             `{ "ultra", "ultrablack", "fat" }`
+---             `{ "extrablack", "obese", "nord" }`
+---    * a table specifying zero or more traits for the font as defined in the [hs.styledtext.fontTraits](#fontTraits) table. A field with the key `_numeric` is also set which specified the numeric value corresponding to the traits for easy use with the [hs.styledtext.convertFont](#convertFont) function.
+module.fontsForFamily = function(...)
+    local results = module._fontsForFamily(...)
+    if results then
+        local fontWeights = {
+            { "ultralight" },
+            { "thin", "ISO:ultralight" },
+            { "light", "extralight", "ISO:extralight" },
+            { "book", "ISO:light" },
+            { "regular", "plain", "display", "roman", "ISO:semilight" },
+            { "medium", "ISO:medium" },
+            { "demi", "demibold" },
+            { "semi", "semibold", "ISO:semibold" },
+            { "bold", "ISO:bold" },
+            { "extra", "extrabold", "ISO:extrabold" },
+            { "heavy", "heavyface" },
+            { "black", "super", "ISO:ultrabold" },
+            { "ultra", "ultrablack", "fat" },
+            { "extrablack", "obese", "nord" }
+        }
+        for i,v in ipairs(results) do
+            v[3] = fontWeights[v[3]] or string.format("** unrecognized font weight: %d", v[3])
+            local style, styleTable = v[4], { _numeric = v[4] }
+            for k, v2 in pairs(module.fontTraits) do
+                if style & v2 == v2 then
+                    table.insert(styleTable, k)
+                    style = style - v2
+                end
+            end
+            if style ~= 0 then
+                table.insert(styleTable, string.format("** unrcognized font trait flags: %d", style))
+            end
+            v[4] = styleTable
+        end
+        return ls.makeConstantsTable(results)
+    else
+        return nil
+    end
 end
 
 module.fontInfo = function(...)

--- a/extensions/styledtext/internal.m
+++ b/extensions/styledtext/internal.m
@@ -425,6 +425,31 @@ static int fontTraits(lua_State *L) {
     return 1;
 }
 
+/// hs.styledtext.validFont(font) -> boolean
+/// Function
+/// Checks to see if a font is valid.
+///
+/// Parameters:
+///  * font - a string containing the name of the font you want to check.
+///
+/// Returns:
+///  * `true` if valid, otherwise `false`.
+static int validFont(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs: LS_TSTRING, LS_TBREAK];
+
+    NSString* fontName = [skin toNSObjectAtIndex:1];
+
+    NSFont *theFont = [NSFont fontWithName:fontName size:1];
+    if (theFont) {
+        lua_pushboolean(L,TRUE);
+    } else {
+        lua_pushboolean(L,FALSE);
+    }
+
+    return 1;
+}
+
 /// hs.styledtext.fontInfo(font) -> table
 /// Function
 /// Get information about the font Specified in the attributes table.
@@ -2292,6 +2317,7 @@ static luaL_Reg moduleLib[] = {
     //     {"luaToObjCMap"         , luaToObjCMap},
 
     {"convertFont", font_convertFont},
+    {"validFont", validFont},
     {"_fontInfo", fontInformation},
     {"_fontNames", fontNames},
     {"_fontFamilies", fontFamilies},

--- a/extensions/styledtext/internal.m
+++ b/extensions/styledtext/internal.m
@@ -1,5 +1,5 @@
-#import <Cocoa/Cocoa.h>
-#import <LuaSkin/LuaSkin.h>
+@import Cocoa ;
+@import LuaSkin ;
 
 #define USERDATA_TAG "hs.styledtext"
 static int refTable;
@@ -79,7 +79,7 @@ NSDictionary *luaByteToObjCharMap(NSString *theString) {
 ///  * See the module description documentation (`help.hs.styledtext`) for a description of the attributes table format which can be provided for the optional second argument.
 ///
 ///  * Passing an `hs.styledtext` object as the first parameter without specifying an `attributes` table is the equivalent of invoking `hs.styledtext:copy`.
-static int string_new(__unused lua_State *L) {
+static int string_new(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TSTRING | LS_TNUMBER | LS_TTABLE,
                     LS_TTABLE | LS_TOPTIONAL,
@@ -261,11 +261,47 @@ static int fontNames(lua_State *L) {
     [skin checkArgs:LS_TBREAK];
 
     NSArray *fontNames = [[NSFontManager sharedFontManager] availableFonts];
+    if (fontNames) {
+        [skin pushNSObject:[fontNames sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)]] ;
+    } else {
+        lua_pushnil(L) ;
+    }
+    return 1;
+}
 
-    lua_newtable(L);
-    for (unsigned long indFont = 0; indFont < [fontNames count]; ++indFont) {
-        lua_pushstring(L, [[fontNames objectAtIndex:indFont] UTF8String]);
-        lua_rawseti(L, -2, (lua_Integer)indFont + 1);
+/// hs.styledtext.fontFamilies() -> table
+/// Function
+/// Returns the names of all font families installed for the system.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a table containing the names of every font family installed for the system.
+static int fontFamilies(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TBREAK];
+
+    NSArray *familyNames = [[NSFontManager sharedFontManager] availableFontFamilies];
+    if (familyNames) {
+        [skin pushNSObject:[familyNames sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)]] ;
+    } else {
+        lua_pushnil(L) ;
+    }
+    return 1;
+}
+
+static int fontsForFamily(lua_State *L) {
+    LuaSkin *skin = [LuaSkin shared];
+    [skin checkArgs:LS_TSTRING, LS_TBREAK];
+
+    NSString *fontFamily = [skin toNSObjectAtIndex:1] ;
+    if (fontFamily) {
+        NSArray *details = [[NSFontManager sharedFontManager] availableMembersOfFontFamily:fontFamily] ;
+        [skin pushNSObject:details] ;
+    } else {
+        lua_pushboolean(L, NO) ;
+//         lua_pushnil(L) ;
     }
     return 1;
 }
@@ -292,7 +328,7 @@ static int font_convertFont(lua_State *L) {
     }
     if (lua_type(L, 2) == LUA_TNUMBER) {
         [skin pushNSObject:[[NSFontManager sharedFontManager] convertFont:theFont
-                                                              toHaveTrait:(NSFontTraitMask)luaL_checkinteger(L, 2)]];
+                                                              toHaveTrait:(NSFontTraitMask)(luaL_checkinteger(L, 2))]];
     } else {
         [skin pushNSObject:[[NSFontManager sharedFontManager] convertWeight:(BOOL)lua_toboolean(L, 2)
                                                                      ofFont:theFont]];
@@ -323,11 +359,11 @@ static int fontNamesWithTraits(lua_State *L) {
         case LUA_TNONE:
             break;
         case LUA_TNUMBER:
-            theTraits = (enum NSFontTraitMask)luaL_checkinteger(L, 1);
+            theTraits = (enum NSFontTraitMask)(luaL_checkinteger(L, 1));
             break;
         case LUA_TTABLE:
             for (lua_pushnil(L); lua_next(L, 1); lua_pop(L, 1)) {
-                theTraits |= (enum NSFontTraitMask)lua_tointeger(L, -1);
+                theTraits |= (enum NSFontTraitMask)(lua_tointeger(L, -1));
             }
             break;
         default: // shouldn't happen with the checkArgs above...
@@ -386,31 +422,6 @@ static int fontTraits(lua_State *L) {
     lua_setfield(L, -2, "unboldFont");
     lua_pushinteger(L, NSUnitalicFontMask);
     lua_setfield(L, -2, "unitalicFont");
-    return 1;
-}
-
-/// hs.styledtext.validFont(font) -> boolean
-/// Function
-/// Checks to see if a font is valid.
-///
-/// Parameters:
-///  * font - a string containing the name of the font you want to check.
-///
-/// Returns:
-///  * `true` if valid, otherwise `false`.
-static int validFont(lua_State *L) {
-    LuaSkin *skin = [LuaSkin shared];
-    [skin checkArgs: LS_TSTRING, LS_TBREAK];
-
-	NSString* fontName = [skin toNSObjectAtIndex:1];
-
-    NSFont *theFont = [NSFont fontWithName:fontName size:1];
-    if (theFont) {
-        lua_pushboolean(L,TRUE);
-    } else {
-        lua_pushboolean(L,FALSE);
-	}
-
     return 1;
 }
 
@@ -1765,9 +1776,9 @@ static int NSParagraphStyle_toLua(lua_State *L, id obj) {
     lua_setfield(L, -2, "paragraphSpacingBefore");
     lua_pushnumber(L, [thePS lineHeightMultiple]);
     lua_setfield(L, -2, "lineHeightMultiple");
-    lua_pushnumber(L, [thePS hyphenationFactor]);
+    lua_pushnumber(L, (lua_Number)[thePS hyphenationFactor]);
     lua_setfield(L, -2, "hyphenationFactor");
-    lua_pushnumber(L, [thePS tighteningFactorForTruncation]);
+    lua_pushnumber(L, (lua_Number)[thePS tighteningFactorForTruncation]);
     lua_setfield(L, -2, "tighteningFactorForTruncation");
     if ([thePS respondsToSelector:@selector(allowsDefaultTighteningForTruncation)]) {
         lua_pushboolean(L, [thePS allowsDefaultTighteningForTruncation]);
@@ -1961,7 +1972,7 @@ static id table_toNSParagraphStyle(lua_State *L, int idx) {
         lua_pop(L, 1);
         if ([thePS respondsToSelector:@selector(allowsDefaultTighteningForTruncation)]) {
             if(lua_getfield(L, -1, "allowsTighteningForTruncation") == LUA_TBOOLEAN) {
-                thePS.allowsDefaultTighteningForTruncation = lua_toboolean(L, -1);
+                thePS.allowsDefaultTighteningForTruncation = (BOOL)lua_toboolean(L, -1);
             }
             lua_pop(L, 1);
         }
@@ -2171,8 +2182,9 @@ static int userdata_concat(lua_State *L) {
         NSMutableAttributedString *newString = [theString1 mutableCopy];
         if ((lua_type(L, 2) == LUA_TSTRING) || (lua_type(L, 2) == LUA_TNUMBER)) {
             // it's a string, so extend the given attributes
-            [newString replaceCharactersInRange:NSMakeRange([newString length], 0)
-                                     withString:[NSString stringWithUTF8String:lua_tostring(L, 2)]];
+            NSString *addition = [NSString stringWithUTF8String:lua_tostring(L, 2)] ;
+            if (addition) [newString replaceCharactersInRange:NSMakeRange([newString length], 0)
+                                                   withString:addition];
         } else {
             // it's an attributed string, so assume it includes its own attributes
             [newString appendAttributedString:get_objectFromUserdata(__bridge NSAttributedString, L, 2)];
@@ -2280,9 +2292,10 @@ static luaL_Reg moduleLib[] = {
     //     {"luaToObjCMap"         , luaToObjCMap},
 
     {"convertFont", font_convertFont},
-    {"validFont", validFont},
     {"_fontInfo", fontInformation},
     {"_fontNames", fontNames},
+    {"_fontFamilies", fontFamilies},
+    {"_fontsForFamily", fontsForFamily},
     {"_fontNamesWithTraits", fontNamesWithTraits},
 
     {"_defaultFonts", defineDefaultFonts},
@@ -2295,7 +2308,7 @@ static luaL_Reg moduleLib[] = {
 //     {NULL,   NULL}
 // };
 
-int luaopen_hs_styledtext_internal(lua_State *__unused L) {
+int luaopen_hs_styledtext_internal(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared];
     refTable      = [skin registerLibraryWithObject:USERDATA_TAG
                                      functions:moduleLib


### PR DESCRIPTION
Adds

~~~
Function: hs.styledtext.fontFamilies() -> table

Returns the names of all font families installed for the system.

Parameters:
 * None

Returns:
 * a table containing the names of every font family installed for the system.
~~~

and

~~~
Function: hs.styledtext.fontsForFamily(familyName) -> table

Returns an array containing fonts available for the specified font family or nil if no fonts for the specified family are present.

Parameters:
 * `familyName` - a string specifying the font family to return available fonts for. The strings should be one of the values returned by the `hs.styledtext.fontFamiles` function.

Returns:
 * a table containing an array of available fonts for the specified family. Each array entry will be a table, also as an array, in the following order:
   * a string specifying the font name which can be used in the `hs.drawing:setTextFont(fontname)` method.
   * a string specifying the basic style of the font (e.g. Bold, Italic, Roman, etc.)
   * a table containing one or more strings specifying common names for the weight of the font. ISO equivalent names are preceded with "ISO:". Possible values are:
            `{ "ultralight" }`
            `{ "thin", "ISO:ultralight" }`
            `{ "light", "extralight", "ISO:extralight" }`
            `{ "book", "ISO:light" }`
            `{ "regular", "plain", "display", "roman", "ISO:semilight" }`
            `{ "medium", "ISO:medium" }`
            `{ "demi", "demibold" }`
            `{ "semi", "semibold", "ISO:semibold" }`
            `{ "bold", "ISO:bold" }`
            `{ "extra", "extrabold", "ISO:extrabold" }`
            `{ "heavy", "heavyface" }`
            `{ "black", "super", "ISO:ultrabold" }`
            `{ "ultra", "ultrablack", "fat" }`
            `{ "extrablack", "obese", "nord" }`
   * a table specifying zero or more traits for the font as defined in the `hs.styledtext.fontTraits` table. A field with the key `_numeric` is also set which specified the numeric value corresponding to the traits for easy use with the `hs.styledtext.convertFont` function.
~~~

These are first steps for a planned font browser spoon I hope to work on later in July