### PR TITLE
hs.socket removed debugging

### DIFF
--- a/extensions/socket/internal.m
+++ b/extensions/socket/internal.m
@@ -120,13 +120,13 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didWriteDataWithTag:(long)tag {
-    [LuaSkin logDebug:@"Data written to TCP socket"];
+    //[LuaSkin logDebug:@"Data written to TCP socket"];
     if (self.writeCallback != LUA_NOREF)
         writeCallback(self, tag);
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag  {
-    [LuaSkin logDebug:@"Data read from TCP socket"];
+    //[LuaSkin logDebug:@"Data read from TCP socket"];
     if (self.readCallback != LUA_NOREF)
         readCallback(self, data, tag);
 }


### PR DESCRIPTION
- Removed LuaSkin debug messages when writing and reading socket data,
as this was causing `hs.socket` to lock up when reading and writing a
lot of data quickly (i.e. when used in `hs.tangent`).