### PR TITLE
wrap cstring->NSString shortcuts to prevent compile errors in Xcode 10

### DIFF
--- a/extensions/streamdeck/HSStreamDeckManager.m
+++ b/extensions/streamdeck/HSStreamDeckManager.m
@@ -48,11 +48,17 @@ static void HIDdisconnect(void *context, IOReturn result, void *sender, IOHIDDev
         // Create a HID device manager
         self.ioHIDManager = CFBridgingRelease(IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDManagerOptionNone));
         //NSLog(@"Created HID Manager: %p", (void *)self.ioHIDManager);
-
+        NSString *vendorKey  = @(kIOHIDVendorIDKey) ;
+        NSString *productKey = @(kIOHIDProductIDKey) ;
+        if (!vendorKey || !productKey) {
+            [LuaSkin logError:[NSString stringWithFormat:@"%s:init - vendorKey %s or productKey %s are not defined", USERDATA_TAG, kIOHIDVendorIDKey, kIOHIDProductIDKey]] ;
+            self.ioHIDManager = nil ;
+            return nil ;
+        }
         // Configure the HID manager to match against Stream Deck devices
         NSDictionary *match = @{
-                                @(kIOHIDVendorIDKey): @0x0fd9,
-                                @(kIOHIDProductIDKey): @0x0060,
+                                vendorKey: @0x0fd9,
+                                productKey: @0x0060,
                                 };
         IOHIDManagerSetDeviceMatching ((__bridge IOHIDManagerRef)self.ioHIDManager, (__bridge CFDictionaryRef)match);
 


### PR DESCRIPTION
The use of `@(cstring)` as a shortcut to converting a c style string to an objective-c one is considered nullable in Xcode 10 which prevents its use where non-nullable is required (e.g. as NSDictionary keys). This corrects that.

To compile under Xcode 10, you will also need to apply #1941 to the master branch.

I have not really tested this -- my setup loads and I haven't noticed any new warnings or loss of functionality, but that's not really a formal testing methodology 😜

Other Xcode 10/Mojave tweaks may follow, but I wanted to get this out to address #1944 so others can continue testing and working.