### PR TITLE
Fix small issues/typos in docs

### DIFF
--- a/extensions/deezer/init.lua
+++ b/extensions/deezer/init.lua
@@ -302,7 +302,7 @@ end
 ---  * None
 function deezer.ff() return deezer.setPosition(deezer.getPosition() + 5) end
 
---- hs.deezer.rw
+--- hs.deezer.rw()
 --- Function
 --- Skips the playback position backwards by 5 seconds
 ---

--- a/extensions/deezer/init.lua
+++ b/extensions/deezer/init.lua
@@ -1,7 +1,8 @@
 --- === hs.deezer ===
---- Heavily inspired by 'hs.spotify', credits to the original author.
 ---
---- Controls for Deezer music player
+--- Controls for Deezer music player.
+---
+--- Heavily inspired by 'hs.spotify', credits to the original author.
 
 local deezer = {}
 

--- a/extensions/midi/internal.m
+++ b/extensions/midi/internal.m
@@ -1516,7 +1516,6 @@ static int midi_isVirtual(lua_State *L) {
 
 /// hs.midi.commandTypes[]
 /// Constant
-///
 /// A table containing the numeric value for the possible flags returned by the `commandType` parameter of the callback function.
 ///
 /// Defined keys are:

--- a/extensions/network/reachabilityinternal.m
+++ b/extensions/network/reachabilityinternal.m
@@ -321,7 +321,6 @@ static int reachabilityStopWatcher(lua_State *L) {
 
 /// hs.network.reachability.flags[]
 /// Constant
-///
 /// A table containing the numeric value for the possible flags returned by the [hs.network.reachability:status](#status) method or in the `flags` parameter of the callback function.
 ///
 /// * transientConnection  - indicates if the destination is reachable through a transient connection

--- a/extensions/spotify/init.lua
+++ b/extensions/spotify/init.lua
@@ -306,7 +306,7 @@ end
 ---  * None
 function spotify.ff() return spotify.setPosition(spotify.getPosition()+5) end
 
---- hs.spotify.rw
+--- hs.spotify.rw()
 --- Function
 --- Skips the playback position backwards by 5 seconds
 ---


### PR DESCRIPTION
`hs.deezer.rw()` and `hs.spotify.rw()` are both missing the parens in their function definitions in their documentation.