### PR TITLE
Fix focusWindowWest documentation typo

### DIFF
--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -771,7 +771,7 @@ end
 
 --- hs.window:focusWindowWest([candidateWindows[, frontmost[, strict]]]) -> boolean
 --- Method
---- Focuses the nearest possible window to the west (i.e. right)
+--- Focuses the nearest possible window to the west (i.e. left)
 ---
 --- (See `hs.window:focusWindowEast()`)
 


### PR DESCRIPTION
Fixes a tiny typo in the `focusWindowWest` documentation.
It should compare west to "left" instead of "right". 🗺 