### PR TITLE
[READY] Add secure text prompt

### DIFF
--- a/extensions/dialog/internal.m
+++ b/extensions/dialog/internal.m
@@ -655,7 +655,7 @@ static int blockAlert(lua_State *L) {
 
 #pragma mark - Text Prompt
 
-/// hs.dialog.textPrompt(message, informativeText, [defaultText], [buttonOne], [buttonTwo]) -> string, string
+/// hs.dialog.textPrompt(message, informativeText, [defaultText], [buttonOne], [buttonTwo], [secureField]) -> string, string
 /// Function
 /// Displays a simple text input dialog box.
 ///
@@ -665,6 +665,7 @@ static int blockAlert(lua_State *L) {
 ///  * [defaultText] - The informative text to display
 ///  * [buttonOne] - An optional value for the first button as a string
 ///  * [buttonTwo] - An optional value for the second button as a string
+///  * [secureField] - An optional boolean. If true, PasswordField instead of TextField. Defaults to false.
 ///
 /// Returns:
 ///  * The value of the button as a string
@@ -677,19 +678,21 @@ static int blockAlert(lua_State *L) {
 ///      `hs.dialog.textPrompt("Main message.", "Please enter something:")`
 ///      `hs.dialog.textPrompt("Main message.", "Please enter something:", "Default Value", "OK")`
 ///      `hs.dialog.textPrompt("Main message.", "Please enter something:", "Default Value", "OK", "Cancel")`
+///      `hs.dialog.textPrompt("Main message.", "Please enter something:", "", "OK", "Cancel", true)`
 static int textPrompt(lua_State *L) {
     NSString* defaultButton = @"OK";
 
     LuaSkin *skin = [LuaSkin shared];
     //              message,    informativeText,
     //                                      [defaultText],             [buttonOne],               [buttonTwo]
-    [skin checkArgs:LS_TSTRING, LS_TSTRING, LS_TSTRING | LS_TOPTIONAL, LS_TSTRING | LS_TOPTIONAL, LS_TSTRING | LS_TOPTIONAL, LS_TBREAK];
+    [skin checkArgs:LS_TSTRING, LS_TSTRING, LS_TSTRING | LS_TOPTIONAL, LS_TSTRING | LS_TOPTIONAL, LS_TSTRING | LS_TOPTIONAL, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK];
 
     NSString* message = [skin toNSObjectAtIndex:1];
     NSString* informativeText = [skin toNSObjectAtIndex:2];
     NSString* defaultText = [skin toNSObjectAtIndex:3];
     NSString* buttonOne = [skin toNSObjectAtIndex:4];
     NSString* buttonTwo = [skin toNSObjectAtIndex:5];
+    BOOL secureField = (lua_type(L, 6) == LUA_TBOOLEAN) ? (BOOL)lua_toboolean(L, 6) : false;
 
     NSAlert *alert = [[NSAlert alloc] init];
     [alert setMessageText:message];
@@ -719,7 +722,15 @@ static int textPrompt(lua_State *L) {
         [[alert.buttons objectAtIndex:0] setKeyEquivalent:@"\r"]; // Return
     }
 
-    NSTextField *input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
+    NSTextField *input;
+    if (secureField) {
+        input = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
+    }
+    else
+    {
+        input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
+    }
+
     if (defaultText == nil) {
         [input setStringValue:@""];
     }


### PR DESCRIPTION
Add `secureField` option to `hs.dialog.textPrompt` if true PasswordField field is going to be using instead of TextField.

It looks like this:
<img width="852" alt="screen shot 2019-01-26 at 8 21 47 pm" src="https://user-images.githubusercontent.com/10244928/51791284-9cbeb400-2198-11e9-8299-ef82f00fad16.png">
 
/reviewme @cmsj