### PR TITLE
Fixed: `hs.builder.genComments` will now follow symlinked directories…

### DIFF
--- a/extensions/doc/builder.lua
+++ b/extensions/doc/builder.lua
@@ -54,7 +54,7 @@ module.genComments = function(where, recurse)
     if type(recurse) == "nil" then recurse = true end
     local maxDepth = recurse and " -maxdepth 1" or ""
     for _, path in ipairs(where) do
-        for _, file in ipairs(fnutils.split(hs.execute("find "..path..maxDepth.." -name \\*.lua -print -o -name \\*.m -print"), "[\r\n]")) do
+        for _, file in ipairs(fnutils.split(hs.execute("find -L "..path..maxDepth.." -name \\*.lua -print -o -name \\*.m -print"), "[\r\n]")) do
             if file ~= "" then
                 local comment, incomment = {}, false
                 for line in io.lines(file) do


### PR DESCRIPTION
… rather than silently failing to build anything.

My Spoons directory is assembled from Spoons checked out into their own folders in my code directory, and this bug means they don't build (and `hs.doc.spoonsupport.updateDocsFiles()` calls this, so doesn't build either).