### PR TITLE
[READY] add toolbar support to hs.chooser

### DIFF
--- a/extensions/_coresetup/init.lua
+++ b/extensions/_coresetup/init.lua
@@ -583,7 +583,7 @@ hs.fileDroppedToDockIconCallback = nil
 ---
 --- Notes:
 ---  * This is an `hs.toolbar` object that is shown by default in the Hammerspoon Console
----  * You can remove this toolbar by adding `hs.console.toolbar(nil)` to your config, or you can replace it with your own `hs.toolbar` object
+---  * You can remove this toolbar by adding `hs.console.toolbar(nil)` to your config, or you can replace it with your own `hs.webview.toolbar` object
   local toolbar = require("hs.webview.toolbar")
   local console = require("hs.console")
   local image = require("hs.image")

--- a/extensions/chooser/init.lua
+++ b/extensions/chooser/init.lua
@@ -10,6 +10,22 @@ require("hs.drawing.color")
 local chooser = require("hs.chooser.internal")
 local window = require("hs.window")
 
+--- hs.chooser:attachedToolbar([toolbar | nil]) -> hs.chooser object | currentValue
+--- Method
+--- Get or attach/detach a toolbar to/from the chooser.
+---
+--- Parameters:
+---  * `toolbar` - if an `hs.webview.toolbar` object is specified, it will be attached to the chooser.  If an explicit nil is specified, the current toolbar will be removed from the chooser.
+---
+--- Returns:
+---  * if a toolbarObject or explicit nil is specified, returns the hs.chooser object; otherwise returns the current toolbarObject or nil, if no toolbar is attached to the chooser.
+---
+--- Notes:
+---  * this method is a convenience wrapper for the `hs.webview.toolbar.attachToolbar` function.
+---
+---  * If the toolbarObject is currently attached to another window when this method is called, it will be detached from the original window and attached to the chooser.  If you wish to attach the same toolbar to multiple chooser objects, see `hs.webview.toolbar:copy`.
+hs.getObjectMetatable("hs.chooser").attachedToolbar = require"hs.webview.toolbar".attachToolbar
+
 --- hs.chooser.globalCallback
 --- Variable
 --- A global callback function used for various hs.chooser events

--- a/extensions/chooser/internal.m
+++ b/extensions/chooser/internal.m
@@ -780,6 +780,13 @@ static int userdata_gc(lua_State* L) {
             chooser.completionCallbackRef = [skin luaUnref:refTable ref:chooser.completionCallbackRef];
             chooser.rightClickCallbackRef = [skin luaUnref:refTable ref:chooser.rightClickCallbackRef];
             chooser.isObservingThemeChanges = NO;  // Stop observing for interface theme changes.
+
+            NSWindow *theWindow = chooser.window ;
+            if (theWindow.toolbar) {
+                theWindow.toolbar.visible = NO ;
+                theWindow.toolbar = nil ;
+            }
+
             chooser = nil;
         }
     }

--- a/extensions/console/internal.m
+++ b/extensions/console/internal.m
@@ -545,7 +545,9 @@ static int console_behavior(lua_State *L) {
 ///  * a string of "visible" or "hidden" specifying the current (possibly changed) state of the window title's visibility.
 ///
 /// Notes:
-///  * When a toolbar is attached to the Hammerspoon console (see the `hs.webview.toolbar` module documentation), this function can be used to specify whether the Toolbar appears underneath the console window's title ("visible") or in the window's title bar itself, as seen in applications like Safari ("hidden").
+///  * When a toolbar is attached to the Hammerspoon console (see the `hs.webview.toolbar` module documentation), this function can be used to specify whether the Toolbar appears underneath the console window's title ("visible") or in the window's title bar itself, as seen in applications like Safari ("hidden"). When the title is hidden, the toolbar will only display the buttons as small icons without labels, regardless of the toolbar settings.
+///
+///  * If a toolbar is attached to the console, you can achieve the same effect as this function with `hs.console.toolbar():inTitleBar(boolean)`
 static int console_titleVisibility(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared] ;
     [skin checkArgs:LS_TSTRING | LS_TOPTIONAL, LS_TBREAK] ;

--- a/extensions/console/internal.m
+++ b/extensions/console/internal.m
@@ -545,7 +545,7 @@ static int console_behavior(lua_State *L) {
 ///  * a string of "visible" or "hidden" specifying the current (possibly changed) state of the window title's visibility.
 ///
 /// Notes:
-///  * When a toolbar is attached to the Hammerspoon console (see the `hs.webview.toolbar` module documentation), this function can be used to specify whether the Toolbar appears underneath the console window's title ("visible") or in the window's title bar itself, as seen in applications like Safari ("hidden"). When the title is hidden, the toolbar will only display the buttons as small icons without labels, regardless of the toolbar settings.
+///  * When a toolbar is attached to the Hammerspoon console (see the `hs.webview.toolbar` module documentation), this function can be used to specify whether the Toolbar appears underneath the console window's title ("visible") or in the window's title bar itself, as seen in applications like Safari ("hidden"). When the title is hidden, the toolbar will only display the toolbar items as icons without labels, and ignores changes made with `hs.webview.toolbar:displayMode`.
 ///
 ///  * If a toolbar is attached to the console, you can achieve the same effect as this function with `hs.console.toolbar():inTitleBar(boolean)`
 static int console_titleVisibility(lua_State *L) {

--- a/extensions/webview/internal.m
+++ b/extensions/webview/internal.m
@@ -2940,6 +2940,12 @@ static int userdata_gc(lua_State* L) {
         theWindow.windowCallback   = [skin luaUnref:refTable ref:theWindow.windowCallback] ;
         theView.navigationCallback = [skin luaUnref:refTable ref:theView.navigationCallback] ;
         theView.policyCallback     = [skin luaUnref:refTable ref:theView.policyCallback] ;
+
+        if (theWindow.toolbar) {
+            theWindow.toolbar.visible = NO ;
+            theWindow.toolbar = nil ;
+        }
+
         [theWindow close] ; // ensure a proper close when gc invoked during reload; nop if hs.webview:delete() is used
 
         // emancipate us from our parent

--- a/extensions/webview/internal.m
+++ b/extensions/webview/internal.m
@@ -2123,7 +2123,7 @@ static int webview_windowTitle(lua_State *L) {
 /// Notes:
 ///  * See also [hs.webview:windowStyle](#windowStyle) and [hs.webview.windowMasks](#windowMasks).
 ///
-///  * When a toolbar is attached to the webview, this function can be used to specify whether the Toolbar appears underneath the webview window's title ("visible") or in the window's title bar itself, as seen in applications like Safari ("hidden"). When the title is hidden, the toolbar will only display the buttons as small icons without labels, regardless of the toolbar settings.
+///  * When a toolbar is attached to the webview, this function can be used to specify whether the Toolbar appears underneath the webview window's title ("visible") or in the window's title bar itself, as seen in applications like Safari ("hidden"). When the title is hidden, the toolbar will only display the toolbar items as icons without labels, and ignores changes made with `hs.webview.toolbar:displayMode`.
 ///
 ///  * If a toolbar is attached to the webview, you can achieve the same effect as this method with `hs.webview:attachedToolbar():inTitleBar(boolean)`
 static int webview_titleVisibility(lua_State *L) {

--- a/extensions/webview/toolbar_internal.m
+++ b/extensions/webview/toolbar_internal.m
@@ -945,7 +945,7 @@ static int attachToolbar(lua_State *L) {
 ///  * if a parameter is specified, returns the toolbar object, otherwise the current value.
 ///
 /// Notes:
-///  * When this value is true, the toolbar, when visible, will appear in the window's title bar similar to the toolbar as seen in applications like Safari.  In this state, the toolbar will set the display of the toolbar items to small icons without labels, ignoring subsequent changes set with [hs.webview.toolbar:displayMode](#displayMode), though you can still change the icon size with [hs.webview.toolbar:sizeMode](#sizeMode).
+///  * When this value is true, the toolbar, when visible, will appear in the window's title bar similar to the toolbar as seen in applications like Safari.  In this state, the toolbar will set the display of the toolbar items to icons without labels, ignoring changes made with [hs.webview.toolbar:displayMode](#displayMode).
 ///
 /// * This method is only valid when the toolbar is attached to a webview, chooser, or the console.
 static int toolbar_inTitleBar(lua_State *L) {

--- a/extensions/webview/toolbar_internal.m
+++ b/extensions/webview/toolbar_internal.m
@@ -193,6 +193,8 @@ static NSMenu *createCoreSearchFieldMenu() {
             if (ourWindow) {
                 if ([ourWindow isEqualTo:[[MJConsoleWindowController singleton] window]]) {
                     lua_pushstring(L, "console") ;
+                } else if (ourWindow.windowController) { // hs.chooser
+                    [skin pushNSObject:ourWindow.windowController withOptions:LS_NSDescribeUnknownTypes] ;
                 } else {
                     [skin pushNSObject:ourWindow withOptions:LS_NSDescribeUnknownTypes] ;
                 }
@@ -708,6 +710,8 @@ static NSMenu *createCoreSearchFieldMenu() {
             if (ourWindow) {
                 if ([ourWindow isEqualTo:[[MJConsoleWindowController singleton] window]]) {
                     lua_pushstring(L, "console") ;
+                } else if (ourWindow.windowController) { // hs.chooser
+                    [skin pushNSObject:ourWindow.windowController withOptions:LS_NSDescribeUnknownTypes] ;
                 } else {
                     [skin pushNSObject:ourWindow withOptions:LS_NSDescribeUnknownTypes] ;
                 }
@@ -735,6 +739,8 @@ static NSMenu *createCoreSearchFieldMenu() {
             if (ourWindow) {
                 if ([ourWindow isEqualTo:[[MJConsoleWindowController singleton] window]]) {
                     lua_pushstring(L, "console") ;
+                } else if (ourWindow.windowController) { // hs.chooser
+                    [skin pushNSObject:ourWindow.windowController withOptions:LS_NSDescribeUnknownTypes] ;
                 } else {
                     [skin pushNSObject:ourWindow withOptions:LS_NSDescribeUnknownTypes] ;
                 }
@@ -779,7 +785,7 @@ static NSMenu *createCoreSearchFieldMenu() {
 
 /// hs.webview.toolbar.new(toolbarName, [toolbarTable]) -> toolbarObject
 /// Constructor
-/// Creates a new toolbar for a webview or the console.
+/// Creates a new toolbar for a webview, chooser, or the console.
 ///
 /// Parameters:
 ///  * toolbarName  - a string specifying the name for this toolbar
@@ -789,7 +795,7 @@ static NSMenu *createCoreSearchFieldMenu() {
 ///  * a toolbarObject
 ///
 /// Notes:
-///  * Toolbar names must be unique, but a toolbar may be copied with [hs.webview.toolbar:copy](#copy) if you wish to attach it to multiple windows (webview or console).
+///  * Toolbar names must be unique, but a toolbar may be copied with [hs.webview.toolbar:copy](#copy) if you wish to attach it to multiple windows (webview, chooser, or console).
 ///  * See [hs.webview.toolbar:addItems](#addItems) for a description of the format for `toolbarTable`
 
 static int newHSToolbar(lua_State *L) {
@@ -815,19 +821,19 @@ static int newHSToolbar(lua_State *L) {
 
 /// hs.webview.toolbar.attachToolbar([obj1], [obj2]) -> obj1
 /// Function
-/// Get or attach/detach a toolbar to the console or webview.
+/// Get or attach/detach a toolbar to the webview, chooser, or console.
 ///
 /// Parameters:
 ///  * if no arguments are present, this function returns the current toolbarObject for the Hammerspoon console, or nil if one is not attached.
 ///  * if one argument is provided and it is a toolbarObject or nil, this function will attach or detach a toolbarObject to/from the Hammerspoon console.
-///  * if one argument is provided and it is a webviewObject, this function will return the current toolbarObject for the webview, or nil if one is not attached.
-///  * if two arguments are provided and the first is a webviewObject and the second is a toolbarObject or nil, this function will attach or detach a toolbarObject to/from the webview.
+///  * if one argument is provided and it is an hs.webview or hs.chooser object, this function will return the current toolbarObject for the object, or nil if one is not attached.
+///  * if two arguments are provided and the first is an hs.webview or hs.chooser object and the second is a toolbarObject or nil, this function will attach or detach a toolbarObject to/from the object.
 ///
 /// Returns:
-///  * if the function is used to attach/detach a toolbar, then the first object provided will be returned ; if this function is used to get the current toolbar object for a webview or the console, then the toolbarObject or nil will be returned.
+///  * if the function is used to attach/detach a toolbar, then the first object provided (the target) will be returned ; if this function is used to get the current toolbar object for a webview, chooser, or console, then the toolbarObject or nil will be returned.
 ///
 /// Notes:
-///  * This function is not expected to be used directly (though it can be) -- it is added to the `hs.webview` object metatable so that it may be invoked as `hs.webview:attachedToolbar([toolbarObject | nil])` and to the `hs.console` module so that it may be invoked as `hs.console.toolbar([toolbarObject | nil])`.
+///  * This function is not expected to be used directly (though it can be) -- it is added to the `hs.webview` and `hs.chooser` object metatables so that it may be invoked as `hs.webview:attachedToolbar([toolbarObject | nil])`/`hs.chooser:attachedToolbar([toolbarObject | nil])` and to the `hs.console` module so that it may be invoked as `hs.console.toolbar([toolbarObject | nil])`.
 ///
 ///  * If the toolbar is currently attached to another window when this function is called, it will be detached from the original window and attached to the new one specified by this function.
 static int attachToolbar(lua_State *L) {
@@ -835,6 +841,9 @@ static int attachToolbar(lua_State *L) {
     NSWindow  *theWindow ;
     HSToolbar *newToolbar ;
     BOOL      setToolbar = YES ;
+    BOOL      isChooser  = NO ;
+
+// hs.console
 
     if (lua_gettop(L) == 0) {
         theWindow  = [[MJConsoleWindowController singleton] window];
@@ -848,6 +857,9 @@ static int attachToolbar(lua_State *L) {
         theWindow  = [[MJConsoleWindowController singleton] window];
         newToolbar = [skin toNSObjectAtIndex:1] ;
         setToolbar = YES ;
+
+// hs.webview
+
     } else if (lua_gettop(L) == 1 && (lua_type(L, 1) == LUA_TUSERDATA) && luaL_testudata(L, 1, "hs.webview")) {
         theWindow = get_objectFromUserdata(__bridge NSWindow, L, 1, "hs.webview") ;
         newToolbar = nil ;
@@ -860,8 +872,30 @@ static int attachToolbar(lua_State *L) {
         theWindow = get_objectFromUserdata(__bridge NSWindow, L, 1, "hs.webview") ;
         newToolbar = [skin toNSObjectAtIndex:2] ;
         setToolbar = YES ;
+
+// hs.chooser
+
+    } else if (lua_gettop(L) == 1 && (lua_type(L, 1) == LUA_TUSERDATA) && luaL_testudata(L, 1, "hs.chooser")) {
+        NSWindowController *theController = get_objectFromUserdata(__bridge NSWindowController, L, 1, "hs.chooser") ;
+        theWindow = theController.window ;
+        newToolbar = nil ;
+        setToolbar = NO ;
+        isChooser = YES ;
+    } else if (lua_gettop(L) == 2 && (lua_type(L, 1) == LUA_TUSERDATA) && luaL_testudata(L, 1, "hs.chooser") && (lua_type(L, 2) == LUA_TNIL)) {
+        NSWindowController *theController = get_objectFromUserdata(__bridge NSWindowController, L, 1, "hs.chooser") ;
+        theWindow = theController.window ;
+        newToolbar = nil ;
+        setToolbar = YES ;
+        isChooser = YES ;
+    } else if (lua_gettop(L) == 2 && lua_type(L, 1) == LUA_TUSERDATA && luaL_testudata(L, 1, "hs.chooser") && (lua_type(L, 2) == LUA_TUSERDATA) && luaL_testudata(L, 2, USERDATA_TB_TAG)) {
+        NSWindowController *theController = get_objectFromUserdata(__bridge NSWindowController, L, 1, "hs.chooser") ;
+        theWindow = theController.window ;
+        newToolbar = [skin toNSObjectAtIndex:2] ;
+        setToolbar = YES ;
+        isChooser = YES ;
+
     } else {
-        return luaL_error(L, "%s:attachToolbar requires an optional hs.webview object and an %s object or nil", USERDATA_TB_TAG, USERDATA_TB_TAG) ;
+        return luaL_error(L, "%s:attachToolbar requires an optional window target object and an %s object or nil", USERDATA_TB_TAG, USERDATA_TB_TAG) ;
     }
 
     HSToolbar *oldToolbar = (HSToolbar *)theWindow.toolbar ;
@@ -869,11 +903,13 @@ static int attachToolbar(lua_State *L) {
         if (oldToolbar) {
             oldToolbar.visible = NO ;
             theWindow.toolbar = nil ;
+            if (isChooser) theWindow.styleMask &= ~NSWindowStyleMaskTitled  ; // chooser isn't normally titled
             if ([oldToolbar isKindOfClass:[HSToolbar class]]) oldToolbar.windowUsingToolbar = nil ;
         }
         if (newToolbar) {
             NSWindow *newTBWindow = newToolbar.windowUsingToolbar ;
             if (newTBWindow) newTBWindow.toolbar = nil ;
+            if (isChooser) theWindow.styleMask |= NSWindowStyleMaskTitled  ; // only titled windows can have toolbars
             theWindow.toolbar             = newToolbar ;
             newToolbar.windowUsingToolbar = theWindow ;
             newToolbar.visible            = YES ;
@@ -917,7 +953,7 @@ static int isAttachedToWindow(lua_State *L) {
 ///  * None
 ///
 /// Returns:
-///  * a copy of the toolbar which can be attached to another window (webview or console).
+///  * a copy of the toolbar which can be attached to another window (webview, chooser, or console).
 static int copyToolbar(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared] ;
     [skin checkArgs:LS_TUSERDATA, USERDATA_TB_TAG, LS_TBREAK] ;
@@ -938,7 +974,7 @@ static int copyToolbar(lua_State *L) {
 /// Parameters:
 ///  * fn - a function to set as the global callback for the toolbar, or nil to remove the global callback.
 ///
-///  The function should expect three (four, if the item is a `searchfield` or `notifyOnChange` is true) arguments and return none: the toolbar object, "console" or the webview object the toolbar is attached to, and the toolbar item identifier that was clicked.
+///  The function should expect three (four, if the item is a `searchfield` or `notifyOnChange` is true) arguments and return none: the toolbar object, "console" or the webview/chooser object the toolbar is attached to, and the toolbar item identifier that was clicked.
 /// Returns:
 ///  * the toolbar object.
 ///

--- a/extensions/webview/toolbar_internal.m
+++ b/extensions/webview/toolbar_internal.m
@@ -903,13 +903,13 @@ static int attachToolbar(lua_State *L) {
         if (oldToolbar) {
             oldToolbar.visible = NO ;
             theWindow.toolbar = nil ;
-            if (isChooser) theWindow.styleMask &= ~NSWindowStyleMaskTitled  ; // chooser isn't normally titled
+            if (isChooser) theWindow.styleMask = NSWindowStyleMaskFullSizeContentView ;
             if ([oldToolbar isKindOfClass:[HSToolbar class]]) oldToolbar.windowUsingToolbar = nil ;
         }
         if (newToolbar) {
             NSWindow *newTBWindow = newToolbar.windowUsingToolbar ;
             if (newTBWindow) newTBWindow.toolbar = nil ;
-            if (isChooser) theWindow.styleMask |= NSWindowStyleMaskTitled  ; // only titled windows can have toolbars
+            if (isChooser) theWindow.styleMask = NSWindowStyleMaskTitled ; // only titled windows can have toolbars
             theWindow.toolbar             = newToolbar ;
             newToolbar.windowUsingToolbar = theWindow ;
             newToolbar.visible            = YES ;


### PR DESCRIPTION
Probably address #1681

This is not ready for prime time, but for those who want to give it a whirl, here is the preliminary support... still needs testing, but this sample should get you started:

~~~lua
local chooser = require("hs.chooser")
local toolbar = require("hs.webview.toolbar")
local canvas  = require("hs.canvas")
local inspect = require("hs.inspect")
local stext   = require("hs.styledtext")

local module = {}

local list1, list2, list3 = {}, {}, {}

for i = 1, 10, 1 do
    table.insert(list1, { text = string.char(96 + i) } )
    table.insert(list2, { text = tostring(i) })
    table.insert(list3, { text = string.char(64 + i) })
end

local changeChooserEntries = function(list, bar, parent, item)
    parent:choices(list)
    parent:query("")
    bar:selectedItem(item)
end

local toolbarItems = {
    {
        id         = "choice1",
        selectable = true,
        label      = "Lower Case",
        image      = canvas.new{ h = 50, w = 50 }:appendElements{
                            {
                                type = "rectangle",
                                strokeColor = { white = 1 },
                                fillColor   = { red   = .5 },
                            }, {
-- vertical centering is hard without putting the text into a local variable, finding its bounding box
-- with hs.canvas:minimumTextSize, then calculating the proper frame based on canvas dimensions... this
-- is "close enough" for this example...
                                frame = { h = 50, w = 50, x = 0, y = -6 },
                                text = stext.new("a", {
                                    font = { name = ".AppleSystemUIFont", size = 50 },
                                    paragraphStyle = { alignment = "center" }
                                }),
                                type = "text",
                            }
                    }:imageFromCanvas(),
        fn         = function(...) changeChooserEntries(list1, ...) end,
    },
    {
        id         = "choice2",
        selectable = true,
        label      = "Numeric",
        image      = canvas.new{ h = 50, w = 50 }:appendElements{
                            {
                                type = "rectangle",
                                strokeColor = { white = 1 },
                                fillColor   = { green = .5 },
                            }, {
                                frame = { h = 50, w = 50, x = 0, y = -6 },
                                text = stext.new("1", {
                                    font = { name = ".AppleSystemUIFont", size = 50 },
                                    paragraphStyle = { alignment = "center" }
                                }),
                                type = "text",
                            }
                    }:imageFromCanvas(),
        fn         = function(...) changeChooserEntries(list2, ...) end,
    },
    {
        id         = "choice3",
        selectable = true,
        label      = "Upper Case",
        image      = canvas.new{ h = 50, w = 50 }:appendElements{
                            {
                                type = "rectangle",
                                strokeColor = { white = 1 },
                                fillColor   = { blue  = .5 },
                            }, {
                                frame = { h = 50, w = 50, x = 0, y = -6 },
                                text = stext.new("A", {
                                    font = { name = ".AppleSystemUIFont", size = 50 },
                                    paragraphStyle = { alignment = "center" }
                                }),
                                type = "text",
                            }
                    }:imageFromCanvas(),
        fn         = function(...) changeChooserEntries(list3, ...) end,
    },
}

local _toolbar = toolbar.new("chooserToolbarTest")
                        :addItems(toolbarItems)
                        :canCustomize(true)
                        :setCallback(function(...)
                                          print("+++ Oops! You better assign me something to do!")
                                     end)

local _chooser = chooser.new(function(...)
    print("Chooser results = " .. inspect(table.pack(...), { newline = " ", indent = "" }))
end):attachedToolbar(_toolbar)

changeChooserEntries(list1, _toolbar, _chooser, "choice1")

module._toolbar = _toolbar
module._chooser = _chooser

module.show = function() _chooser:show() end

return module
~~~

Save that somewhere, then do:

~~~
> test = dofile("_scratch/chooserToolbar.lua")

> test.show()
~~~

If you want to make changes for testing and avoid reloading Hammersoon, make sure to do:

~~~
> test._chooser:delete()

> test._toolbar:delete()
~~~

before re-entering the `dofile` line.