### PR TITLE
Rigid following of stickler "suggestions" broke metatables for canvas elements

### DIFF
--- a/extensions/canvas/init.lua
+++ b/extensions/canvas/init.lua
@@ -530,8 +530,8 @@ elementMT.__newindex = function(_, k, v)
     end
 end
 
-elementMT.__pairs = function(_)
-    local obj = elementMT.__e[_]
+elementMT.__pairs = function(s)
+    local obj = elementMT.__e[s]
     local keys = {}
     if obj.field then
         keys = obj.value[obj.field]
@@ -539,9 +539,9 @@ elementMT.__pairs = function(_)
         keys = obj.value
     else
         if obj.index == "_default" then
-            for _, k in ipairs(obj.self:canvasDefaultKeys()) do keys[k] = _[k] end
+            for _, k in ipairs(obj.self:canvasDefaultKeys()) do keys[k] = s[k] end
         else
-            for _, k in ipairs(obj.self:elementKeys(obj.index)) do keys[k] = _[k] end
+            for _, k in ipairs(obj.self:elementKeys(obj.index)) do keys[k] = s[k] end
         end
     end
     return function(_, k)


### PR DESCRIPTION
By rigidly following stickler's suggestions without considering the surrounding code, a case where `_` was being used as a real parameter and not just as a place holder broke and caused metatables for canvas elements to break.

To see what I mean, take a canvas object you've created for something and type `canvasObject[1]` (where `canvasObject` is whatever variable you're storing the canvas in, of course) into the console before and after applying these changes...