### PR TITLE
Allow hs.eventtap.event.newMouseEvent() to accept mouseMoved

### DIFF
--- a/extensions/eventtap/event.m
+++ b/extensions/eventtap/event.m
@@ -860,6 +860,8 @@ static int eventtap_event_newMouseEvent(lua_State* L) {
         button = kCGMouseButtonRight;
     else if (strcmp(buttonString, "other") == 0)
         button = kCGMouseButtonCenter;
+    else if (strcmp(buttonString, "none") == 0)
+        button = 0;
 
     if (!lua_isnoneornil(L, 4) && (lua_type(L, 4) == LUA_TTABLE)) {
         lua_pushnil(L);

--- a/extensions/eventtap/init.lua
+++ b/extensions/eventtap/init.lua
@@ -140,7 +140,7 @@ end
 --- Creates a new mouse event
 ---
 --- Parameters:
----  * eventtype - One of the values from `hs.eventtap.event.types`
+---  * eventtype - One of the mouse related values from `hs.eventtap.event.types`
 ---  * point - An hs.geometry point table (i.e. of the form `{x=123, y=456}`) indicating the location where the mouse event should occur
 ---  * modifiers - An optional table containing zero or more of the following keys:
 ---   * cmd
@@ -160,6 +160,8 @@ function module.event.newMouseEvent(eventtype, point, modifiers)
         button = "right"
     elseif eventtype == types["otherMouseDown"] or eventtype == types["otherMouseUp"] or eventtype == types["otherMouseDragged"] then
         button = "other"
+    elseif eventtype == types["mouseMoved"] then
+        button = "none"
     else
         print("Error: unrecognised mouse button eventtype: " .. tostring(eventtype))
         return nil


### PR DESCRIPTION
@asmagill someone on IRC brought up a question about how to send mouse movements with `hs.eventtap` and in digging around with the `mouseEventDeltaX` property, I can't get it to work.

I've tried both:

```lua
foo= hs.eventtap.event.newEvent()
foo:setType(hs.eventtap.event.types.mouseMoved)
foo:setProperty(hs.eventtap.event.properties.mouseEventDeltaY, 100)
foo:location(foo:location())
foo:post()
```

and (with this PR applied):

```lua
foo= hs.eventtap.event.newMouseEvent(hs.eventtap.event.types.mouseMoved, hs.mouse.getAbsolutePosition())
foo:setProperty(hs.eventtap.event.properties.mouseEventDeltaY, 100)
foo:post()
```

but neither seems to cause the mouse pointer to actually move.

Am I doing something wrong, or is this broken somehow?