### PR TITLE
[READY] Changed CFBundleVersion instances to CFBundleShortVersionString

### DIFF
--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -186,7 +186,8 @@ static int core_reload(lua_State* L) {
 static int push_hammerAppInfo(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
     NSDictionary *appInfo = @{
-                              @"version": [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"],
+                              @"version": [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"],
+                              @"build": [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"],
                               @"resourcePath": @([[[NSBundle mainBundle] resourcePath] fileSystemRepresentation]),
                               @"bundlePath": @([[[NSBundle mainBundle] bundlePath] fileSystemRepresentation]),
                               @"executablePath": @([[[NSBundle mainBundle] executablePath] fileSystemRepresentation]),

--- a/scripts/librelease.sh
+++ b/scripts/librelease.sh
@@ -150,7 +150,7 @@ function assert_fabric_token() {
 
 function assert_version_in_xcode() {
   echo "Checking Xcode build version..."
-  XCODEVER="$(defaults read "${HAMMERSPOON_HOME}/Hammerspoon/Hammerspoon-Info" CFBundleVersion)"
+  XCODEVER="$(defaults read "${HAMMERSPOON_HOME}/Hammerspoon/Hammerspoon-Info" CFBundleShortVersionString)"
 
   if [ "$VERSION" != "$XCODEVER" ]; then
       fail "You asked for $VERSION to be released, but Xcode will build $XCODEVER"


### PR DESCRIPTION
- `hs.processInfo.version` now refers to `CFBundleShortVersionString`
- `hs.processInfo.build` now refers to `CFBundleVersion `
- Updated release script
- Closes #2152