### PR TITLE
[READY] skip unknown warnings during xcode10 build

### DIFF
--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -277,6 +277,7 @@ NSString *specMaskToString(int spec) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconstant-conversion"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wsizeof-pointer-div"
     luaL_newlib(self.L, functions);
     if (metaFunctions != nil) {
@@ -319,6 +320,7 @@ NSString *specMaskToString(int spec) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconstant-conversion"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wsizeof-pointer-div"
     luaL_newlib(self.L, objectFunctions);
 #pragma GCC diagnostic pop


### PR DESCRIPTION
@cmsj, with your recent changes to better prepare for XCode 11, compiling under XCode 10 fails with an error about an unknown warning, specifically `-Wsizeof-pointer-div`...

This fix allows it to compile without error under XCode 10... since you're listing `-Wsizeof-pointer-div` as something to ignore anyways, I don't think these additions should be an issue with the master branch and the future with XCode 11, but I defer to your judgement.
