### PR TITLE
remove check for docs.json file for IPC

### DIFF
--- a/extensions/doc/init.lua
+++ b/extensions/doc/init.lua
@@ -208,12 +208,13 @@ module.validateJSONFile = function(jsonFile)
     end
 end
 
---- hs.doc.registerJSONFile(jsonfile) -> status[, message]
+--- hs.doc.registerJSONFile(jsonfile, [isSpoon]) -> status[, message]
 --- Function
 --- Register a JSON file for inclusion when Hammerspoon generates internal documentation.
 ---
 --- Parameters:
 ---  * jsonfile - A string containing the location of a JSON file
+---  * isSpoon  - an optional boolean, default false, specifying that the documentation should be added to the `spoons` sub heading in the documentation hierarchy.
 ---
 --- Returns:
 ---  * status - Boolean flag indicating if the file was registered or not.  If the file was not registered, then a message indicating the error is also returned.
@@ -263,13 +264,12 @@ module.registerJSONFile = function(docFile, isSpoon)
     return status, message
 end
 
---- hs.doc.unregisterJSONFile(jsonfile, [isSpoon]) -> status[, message]
+--- hs.doc.unregisterJSONFile(jsonfile) -> status[, message]
 --- Function
 --- Remove a JSON file from the list of registered files.
 ---
 --- Parameters:
 ---  * jsonfile - A string containing the location of a JSON file
----  * isSpoon  - an optional boolean, default false, specifying that the documentation should be added to the `spoons` sub heading in the documentation hierarchy.
 ---
 --- Returns:
 ---  * status - Boolean flag indicating if the file was unregistered or not.  If the file was not unregistered, then a message indicating the error is also returned.

--- a/extensions/ipc/init.lua
+++ b/extensions/ipc/init.lua
@@ -9,14 +9,6 @@
 local USERDATA_TAG = "hs.ipc"
 local module       = require(USERDATA_TAG..".internal")
 
-local basePath = package.searchpath(USERDATA_TAG, package.path)
-if basePath then
-    basePath = basePath:match("^(.+)/init.lua$")
-    if require"hs.fs".attributes(basePath .. "/docs.json") then
-        require"hs.doc".registerJSONFile(basePath .. "/docs.json")
-    end
-end
-
 local timer    = require("hs.timer")
 local settings = require("hs.settings")
 local log      = require("hs.logger").new(USERDATA_TAG, (settings.get(USERDATA_TAG .. ".logLevel") or "warning"))


### PR DESCRIPTION
The latest incarnation of IPC was originally a third party module which tried to load its own documentation, if the `docs.json` file existed in its folder. This check is no longer necessary since the module is now part of core and its documentation is part of the built in provided documentation.