### PR TITLE
hs.expose: check for nil in windowUnfocused

### DIFF
--- a/extensions/expose/init.lua
+++ b/extensions/expose/init.lua
@@ -773,8 +773,11 @@ local function getSnapshot(w,id)
   if w.thumb then w.thumb:setImage(window.snapshotForID(id) or UNAVAILABLE) end
 end
 local function windowUnfocused(self,win,appname,screen)
-  local id=win:id() local w=screen.windows[id]
-  if w then return getSnapshot(w,id) end
+  local id=win:id()
+  if screen.windows then
+    local w=screen.windows[id]
+    if w then return getSnapshot(w,id) end
+  end
 end
 local function windowMoved(self,win,appname,screen)
   local id=win:id() local w=screen.windows[id]


### PR DESCRIPTION
In some situations (unknown root cause) screen.windows can be nil. This
adds a check to ensure it doesn't throw an error.

Using the following code `expose = hs.expose.new()` the following stack trace is thrown every time the window focus changes.

```2019-09-18 08:03:32: 08:03:32 ERROR:   LuaSkin: hs.application.watcher callback: ...oon.app/Contents/Resources/extensions/hs/expose/init.lua:778: attempt to index a nil value (field 'windows')
stack traceback:
	...oon.app/Contents/Resources/extensions/hs/expose/init.lua:778: in function <...oon.app/Contents/Resources/extensions/hs/expose/init.lua:777>
	(...tail calls...)
	...n.app/Contents/Resources/extensions/hs/window/filter.lua:944: in upvalue 'emit'
	...n.app/Contents/Resources/extensions/hs/window/filter.lua:970: in method 'filterEmitEvent'
	...n.app/Contents/Resources/extensions/hs/window/filter.lua:1004: in method 'emitEvent'
	...n.app/Contents/Resources/extensions/hs/window/filter.lua:1096: in method 'unfocused'
	...n.app/Contents/Resources/extensions/hs/window/filter.lua:1285: in method 'deactivated'
	...n.app/Contents/Resources/extensions/hs/window/filter.lua:1270: in function <...n.app/Contents/Resources/extensions/hs/window/filter.lua:1267>
	(...tail calls...)
2019-09-18 08:03:32: ********
```

Affects Version: 0.9.75