### PR TITLE
[READY] hs.updateAvailable() now returns the display version and build number

### DIFF
--- a/Hammerspoon/MJAppDelegate.h
+++ b/Hammerspoon/MJAppDelegate.h
@@ -19,4 +19,5 @@
 @property (nonatomic, copy) NSString *startupFile;
 @property (nonatomic, weak) id<HSOpenFileDelegate> openFileDelegate;
 @property (nonatomic, strong) NSString* updateAvailable;
+@property (nonatomic, strong) NSString* updateAvailableDisplayVersion;
 @end

--- a/Hammerspoon/MJAppDelegate.m
+++ b/Hammerspoon/MJAppDelegate.m
@@ -356,12 +356,14 @@
 
 #pragma mark - Sparkle delegate methods
 - (void)updater:(id)updater didFindValidUpdate:(id)update {
-    NSLog(@"Update found: %@", [update valueForKey:@"versionString"]);
+    NSLog(@"Update found: %@ (Build: %@)", [update valueForKey:@"displayVersionString"], [update valueForKey:@"versionString"]);
     self.updateAvailable = [update valueForKey:@"versionString"];
+    self.updateAvailableDisplayVersion = [update valueForKey:@"displayVersionString"];
 }
 
 - (void)updaterDidNotFindUpdate:(id)update {
     self.updateAvailable = nil;
+    self.updateAvailableDisplayVersion = nil;
 }
 
 @end

--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -317,15 +317,16 @@ static int checkForUpdates(lua_State *L) {
     return 0 ;
 }
 
-/// hs.updateAvailable() -> string or false
+/// hs.updateAvailable() -> string or false, string
 /// Function
-/// Gets the version number of an available update
+/// Gets the version & build number of an available update
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
-///  * A string containing the version number of the latest release, or a boolean false if no update is available
+///  * A string containing the display version of the latest release, or a boolean false if no update is available
+///  * A string containing the build number of the latest release, or `nil` if no update is available
 ///
 /// Notes:
 ///  * This is not a live check, it is a cached result of whatever the previous update check found. By default Hammerspoon checks for updates every few hours, but you can also add your own timer to check for updates more frequently with `hs.checkForUpdates()`
@@ -339,14 +340,17 @@ static int updateAvailable(lua_State *L) {
 #pragma clang diagnostic ignored "-Wundeclared-selector"
 
     NSString *updateAvailable = [appDelegate performSelector:@selector(updateAvailable)];
+    NSString *updateAvailableDisplayVersion = [appDelegate performSelector:@selector(updateAvailableDisplayVersion)];
     if (updateAvailable == nil) {
         lua_pushboolean(L, 0);
+        return 1;
     } else {
+        [skin pushNSObject:updateAvailableDisplayVersion];
         [skin pushNSObject:updateAvailable];
+        return 2;
     }
 
 #pragma clang diagnostic pop
-    return 1;
 }
 
 /// hs.canCheckForUpdates() -> boolean


### PR DESCRIPTION
- `hs.updateAvailable()` now returns both the display version and the
build number.
- Closes #2188