### PR TITLE
Update itunes extension to support Catalina's Music app

### DIFF
--- a/extensions/itunes/init.lua
+++ b/extensions/itunes/init.lua
@@ -8,6 +8,11 @@ local alert = require "hs.alert"
 local as = require "hs.applescript"
 local app = require "hs.application"
 
+local applicationName = 'iTunes'
+if hs.host.operatingSystemVersion().minor >= 15 then
+  applicationName = 'Music'
+end
+
 --- hs.itunes.state_paused
 --- Constant
 --- Returned by `hs.itunes.getPlaybackState()` to indicates iTunes is paused
@@ -25,7 +30,7 @@ itunes.state_stopped = "kPSS"
 
 -- Internal function to pass a command to Applescript.
 local function tell(cmd)
-  local _cmd = 'tell application "iTunes" to ' .. cmd
+  local _cmd = 'tell application "' .. applicationName .. '" to ' .. cmd
   local ok, result = as.applescript(_cmd)
   if ok then
     return result
@@ -180,7 +185,7 @@ end
 --- Returns:
 ---  * A boolean value indicating whether the iTunes application is running.
 function itunes.isRunning()
-   return app.get("iTunes") ~= nil
+   return app.get(applicationName) ~= nil
 end
 
 --- hs.itunes.isPlaying()


### PR DESCRIPTION
Basically just implementing what's in [this comment](https://github.com/Hammerspoon/hammerspoon/pull/2207#issuecomment-543787271) changing the referenced application from `iTunes` to `Music` in Catalina.

My vote is for backwards-compatibility of this behaviour for now but as mentioned in that original PR we may want to rethink how Hammerspoon controls audio apps as there's now Podcasts to deal with.