### PR TITLE
[REVIEW] adds hs.screen:setOrigin() method

### DIFF
--- a/Hammerspoon Tests/HSscreen.m
+++ b/Hammerspoon Tests/HSscreen.m
@@ -58,6 +58,10 @@
     RUN_LUA_TEST()
 }
 
+- (void)testSetOrigin {
+    RUN_LUA_TEST()
+}
+
 - (void)testFrames {
     RUN_LUA_TEST()
 }

--- a/extensions/screen/test_screen.lua
+++ b/extensions/screen/test_screen.lua
@@ -270,6 +270,16 @@ function testSetMode()
   return success()
 end
 
+function testSetOrigin()
+  local primary = hs.screen.primaryScreen()
+  assertIsUserdataOfType("hs.screen", primary)
+
+  local origin = primary:fullFrame()
+  assertTrue(primary:setOrigin(origin["_x"], origin["_y"]))
+
+  return success()
+end
+
 function testSetPrimary()
   local primary = hs.screen.primaryScreen()
   assertIsUserdataOfType("hs.screen", primary)


### PR DESCRIPTION
This adds a new method to the hs.screen API to allow a displays origin to be set  from lua.

An example of calling the code might be:

```lua
hs.screen.mainScreen():setOrigin(100,100)
```

Relates to the conversation https://freenode.logbot.info/hammerspoon/20191112#c2857975