### PR TITLE
Show images from chooser choices with their original colors

### DIFF
--- a/extensions/chooser/HSChooserCell.m
+++ b/extensions/chooser/HSChooserCell.m
@@ -11,7 +11,7 @@
 @implementation HSChooserCell
 
 - (BOOL)allowsVibrancy {
-    return YES;
+    return NO;
 }
 
 @end

--- a/extensions/chooser/HSChooserTableView.m
+++ b/extensions/chooser/HSChooserTableView.m
@@ -60,7 +60,7 @@
 }
 
 - (BOOL) allowsVibrancy {
-    return YES;
+    return NO;
 }
 
 @end


### PR DESCRIPTION
- fixes #2180
- inspired by #2212
- by only disabling vibrancy for Cell and TableView, we can keep the blurry effect

after:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/4723751/72202712-b33f4780-349d-11ea-8f06-2719514fe829.png">


(notice the blurry effect for the `Create pull request` button behind the chooser)