### PR TITLE
Fixed doc comment line break

### DIFF
--- a/extensions/grid/init.lua
+++ b/extensions/grid/init.lua
@@ -299,7 +299,7 @@ end
 ---  * win - an `hs.window` object representing the window to operate on
 ---  * cell - a cell object, i.e. an `hs.geometry` rect or argument to construct one, to apply to the window
 ---  * screen - (optional) an `hs.screen` object or argument to `hs.screen.find()` representing the screen to place the window on; if omitted
----             the window's current screen will be used
+---    the window's current screen will be used
 ---
 --- Returns:
 ---  * the `hs.grid` module for method chaining


### PR DESCRIPTION
[hs.grid](http://www.hammerspoon.org/docs/hs.grid.html) has an erroneous code/line-break in the documentation for the hs.grid.set function: "...the window's current screen will be used"

![image](https://user-images.githubusercontent.com/539765/74106205-2a620d00-4b2a-11ea-878b-fc0a26ae2ade.png)

I've never contributed to the documentation before, so it's likely I haven't done this right - my apologies!