### PR TITLE
[REVIEW] Fix (potentially) buggy dispatches in various modules

### DIFF
--- a/extensions/application/internal.m
+++ b/extensions/application/internal.m
@@ -7,6 +7,8 @@
 #define get_app(L, idx) *((AXUIElementRef*)luaL_checkudata(L, idx, "hs.application"))
 #define nsobject_for_app(L, idx) [NSRunningApplication runningApplicationWithProcessIdentifier: pid_for_app(L, idx)]
 
+static NSMutableSet *backgroundCallbacks ;
+
 static pid_t pid_for_app(lua_State* L, int idx) {
     get_app(L, idx); // type-checking
     lua_getuservalue(L, idx);
@@ -19,6 +21,11 @@ static pid_t pid_for_app(lua_State* L, int idx) {
 static int application_gc(lua_State* L) {
     AXUIElementRef app = get_app(L, 1);
     CFRelease(app);
+
+    [backgroundCallbacks enumerateObjectsUsingBlock:^(NSNumber *ref, __unused BOOL *stop) {
+        luaL_unref(L, LUA_REGISTRYINDEX, ref.intValue) ;
+    }] ;
+    [backgroundCallbacks removeAllObjects] ;
     return 0;
 }
 
@@ -1096,20 +1103,25 @@ static int application_getMenus(lua_State* L) {
     } else {
         lua_pushvalue(L, 2) ;
         int fnRef = luaL_ref(L, LUA_REGISTRYINDEX) ;
+        [backgroundCallbacks addObject:@(fnRef)] ;
+
         dispatch_async(dispatch_get_main_queue(), ^{
-            NSMutableDictionary *menus = nil;
-            AXUIElementRef menuBar;
+            if ([backgroundCallbacks containsObject:@(fnRef)]) {
+                NSMutableDictionary *menus = nil;
+                AXUIElementRef menuBar;
 
-            if (AXUIElementCopyAttributeValue(app, kAXMenuBarAttribute, (CFTypeRef *)&menuBar) == kAXErrorSuccess) {
-                menus = _getMenuStructure(menuBar);
-                CFRelease(menuBar);
+                if (AXUIElementCopyAttributeValue(app, kAXMenuBarAttribute, (CFTypeRef *)&menuBar) == kAXErrorSuccess) {
+                    menus = _getMenuStructure(menuBar);
+                    CFRelease(menuBar);
+                }
+
+                LuaSkin *_skin = [LuaSkin shared];
+                lua_rawgeti(_skin.L, LUA_REGISTRYINDEX, fnRef) ;
+                [_skin pushNSObject:menus] ;
+                [_skin protectedCallAndError:@"hs.application:getMenus()" nargs:1 nresults:0];
+                luaL_unref(_skin.L, LUA_REGISTRYINDEX, fnRef) ;
+                [backgroundCallbacks removeObject:@(fnRef)] ;
             }
-
-            LuaSkin *_skin = [LuaSkin shared];
-            lua_rawgeti(_skin.L, LUA_REGISTRYINDEX, fnRef) ;
-            [_skin pushNSObject:menus] ;
-            [_skin protectedCallAndError:@"hs.application:getMenus()" nargs:1 nresults:0];
-            luaL_unref(_skin.L, LUA_REGISTRYINDEX, fnRef) ;
         }) ;
         lua_pushvalue(L, 1) ;
     }
@@ -1284,6 +1296,8 @@ int luaopen_hs_application_internal(lua_State* L) {
     [skin registerLuaObjectHelper:lua_tonsrunningapplication
                          forClass:"NSRunningApplication"
               withUserdataMapping:"hs.application"] ;
+
+    backgroundCallbacks = [NSMutableSet set] ;
 
     return 1;
 }

--- a/extensions/battery/watcher.m
+++ b/extensions/battery/watcher.m
@@ -29,8 +29,10 @@ static void callback(void *info) {
 
     battery_watcher_t* t = info;
 
-    [skin pushLuaRef:refTable ref:t->fn];
-    [skin protectedCallAndError:@"hs.battery.watcher callback" nargs:0 nresults:0];
+    if (t->fn != LUA_NOREF) {
+        [skin pushLuaRef:refTable ref:t->fn];
+        [skin protectedCallAndError:@"hs.battery.watcher callback" nargs:0 nresults:0];
+    }
     _lua_stackguard_exit(skin.L);
 }
 

--- a/extensions/caffeinate/watcher.m
+++ b/extensions/caffeinate/watcher.m
@@ -102,15 +102,17 @@ typedef enum _event_t {
 
 // Call the lua callback function and pass the event type.
 - (void)callback:(NSDictionary* __unused)dict withEvent:(event_t)event {
-    LuaSkin *skin = [LuaSkin shared];
-    lua_State *L = skin.L;
-    _lua_stackguard_entry(L);
+    if (self.object->fn != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared];
+        lua_State *L = skin.L;
+        _lua_stackguard_entry(L);
 
-    [skin pushLuaRef:refTable ref:self.object->fn];
-    lua_pushinteger(L, event); // Parameter 1: the event type
+        [skin pushLuaRef:refTable ref:self.object->fn];
+        lua_pushinteger(L, event); // Parameter 1: the event type
 
-    [skin protectedCallAndError:@"hs.caffeinate.watcher callback" nargs:1 nresults:0];
-    _lua_stackguard_exit(L);
+        [skin protectedCallAndError:@"hs.caffeinate.watcher callback" nargs:1 nresults:0];
+        _lua_stackguard_exit(L);
+    }
 }
 
 - (void)caffeinateDidWake:(NSNotification*)notification {

--- a/extensions/canvas/internal.m
+++ b/extensions/canvas/internal.m
@@ -947,7 +947,7 @@ static int userdata_gc(lua_State* L) ;
       [[NSAnimationContext currentContext] setCompletionHandler:^{
           // unlikely that bself will go to nil after this starts, but this keeps the warnings down from [-Warc-repeated-use-of-weak]
           HSCanvasWindow *mySelf = bself ;
-          if (mySelf) {
+          if (mySelf && (((HSCanvasView *)mySelf.contentView).selfRef != LUA_NOREF)) {
               if (deleteCanvas) {
                   LuaSkin *skin = [LuaSkin shared] ;
                   lua_State *L = [skin L] ;
@@ -1141,7 +1141,7 @@ static int userdata_gc(lua_State* L) ;
         LuaSkin *skin = [LuaSkin shared];
         _lua_stackguard_entry(skin.L);
         [skin pushLuaRef:refTable ref:_mouseCallbackRef];
-        [skin pushLuaRef:refTable ref:_selfRef] ;
+        [skin pushNSObject:self] ;
         [skin pushNSObject:message] ;
         [skin pushNSObject:elementIdentifier] ;
         lua_pushnumber(skin.L, location.x) ;
@@ -1157,7 +1157,7 @@ static int userdata_gc(lua_State* L) ;
         LuaSkin *skin = [LuaSkin shared];
         _lua_stackguard_entry(skin.L);
         [skin pushLuaRef:refTable ref:_mouseCallbackRef];
-        [skin pushLuaRef:refTable ref:_selfRef] ;
+        [skin pushNSObject:self] ;
         [skin pushNSObject:@"_subview_"] ;
         [skin pushNSObject:sender] ;
         [skin protectedCallAndError:@"hs.canvas:buttonCallback" nargs:3 nresults:0];

--- a/extensions/dialog/internal.m
+++ b/extensions/dialog/internal.m
@@ -36,15 +36,17 @@ static int refTable = LUA_NOREF ;
 - (void)colorClose:(__unused NSNotification*)note {
     if (_callbackRef != LUA_NOREF) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            LuaSkin   *skin = [LuaSkin shared] ;
-            _lua_stackguard_entry(skin.L);
-            lua_State *L    = [skin L] ;
-            NSColorPanel *cp = [NSColorPanel sharedColorPanel];
-            [skin pushLuaRef:refTable ref:self->_callbackRef] ;
-            [skin pushNSObject:cp.color] ;
-            lua_pushboolean(L, YES) ;
-            [skin protectedCallAndError:@"hs.dialog color close callback" nargs:2 nresults:0];
-            _lua_stackguard_exit(skin.L);
+            if (_callbackRef != LUA_NOREF) {
+                LuaSkin   *skin = [LuaSkin shared] ;
+                _lua_stackguard_entry(skin.L);
+                lua_State *L    = [skin L] ;
+                NSColorPanel *cp = [NSColorPanel sharedColorPanel];
+                [skin pushLuaRef:refTable ref:self->_callbackRef] ;
+                [skin pushNSObject:cp.color] ;
+                lua_pushboolean(L, YES) ;
+                [skin protectedCallAndError:@"hs.dialog color close callback" nargs:2 nresults:0];
+                _lua_stackguard_exit(skin.L);
+            }
         }) ;
     }
 }
@@ -53,14 +55,16 @@ static int refTable = LUA_NOREF ;
 - (void)colorCallback:(NSColorPanel*)colorPanel {
     if (_callbackRef != LUA_NOREF) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            LuaSkin   *skin = [LuaSkin shared] ;
-            _lua_stackguard_entry(skin.L);
-            lua_State *L    = [skin L] ;
-            [skin pushLuaRef:refTable ref:self->_callbackRef] ;
-            [skin pushNSObject:colorPanel.color] ;
-            lua_pushboolean(L, NO) ;
-            [skin protectedCallAndError:@"hs.dialog color callback" nargs:2 nresults:0];
-            _lua_stackguard_exit(skin.L);
+            if (_callbackRef != LUA_NOREF) {
+                LuaSkin   *skin = [LuaSkin shared] ;
+                _lua_stackguard_entry(skin.L);
+                lua_State *L    = [skin L] ;
+                [skin pushLuaRef:refTable ref:self->_callbackRef] ;
+                [skin pushNSObject:colorPanel.color] ;
+                lua_pushboolean(L, NO) ;
+                [skin protectedCallAndError:@"hs.dialog color callback" nargs:2 nresults:0];
+                _lua_stackguard_exit(skin.L);
+            }
         }) ;
     }
 }

--- a/extensions/dialog/internal.m
+++ b/extensions/dialog/internal.m
@@ -36,7 +36,7 @@ static int refTable = LUA_NOREF ;
 - (void)colorClose:(__unused NSNotification*)note {
     if (_callbackRef != LUA_NOREF) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (_callbackRef != LUA_NOREF) {
+            if (self->_callbackRef != LUA_NOREF) {
                 LuaSkin   *skin = [LuaSkin shared] ;
                 _lua_stackguard_entry(skin.L);
                 lua_State *L    = [skin L] ;
@@ -55,7 +55,7 @@ static int refTable = LUA_NOREF ;
 - (void)colorCallback:(NSColorPanel*)colorPanel {
     if (_callbackRef != LUA_NOREF) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (_callbackRef != LUA_NOREF) {
+            if (self->_callbackRef != LUA_NOREF) {
                 LuaSkin   *skin = [LuaSkin shared] ;
                 _lua_stackguard_entry(skin.L);
                 lua_State *L    = [skin L] ;

--- a/extensions/host/locale/internal.m
+++ b/extensions/host/locale/internal.m
@@ -29,15 +29,15 @@ static HSLocaleChangeObserver *observerOfChanges = nil ;
 @implementation HSLocaleChangeObserver
 
 - (void) localeChanged:(__unused NSNotification*)notification {
-    if (callbackRef != LUA_NOREF) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (callbackRef != LUA_NOREF) {
             LuaSkin *skin = [LuaSkin shared];
             _lua_stackguard_entry(skin.L);
             [skin pushLuaRef:refTable ref:callbackRef];
             [skin protectedCallAndError:@"hs.host.locale callback" nargs:0 nresults:0];
             _lua_stackguard_exit(skin.L);
-        }) ;
-    }
+        }
+    }) ;
 }
 
 - (void) start {
@@ -349,7 +349,7 @@ static int locale_localizedString(lua_State *L) {
         lua_pushnil(L) ;
         return 1;
     }
-    
+
     // Checks to see if the supplied `localeCode` exists in `availableLocaleIdentifiers`:
     NSString *localeCode = [skin toNSObjectAtIndex:1] ;
     BOOL islocaleCodeValid = [availableLocales containsObject: localeCode];
@@ -357,10 +357,10 @@ static int locale_localizedString(lua_State *L) {
         lua_pushnil(L) ;
         return 1;
     }
-    
+
     NSString *localizedString = [theLocale localizedStringForLanguageCode:localeCode];
     NSString *localizedStringWithDialect = [theLocale displayNameForKey:NSLocaleIdentifier value:localeCode];
-    
+
     [skin pushNSObject:localizedString] ;
     [skin pushNSObject:localizedStringWithDialect] ;
     return 2;

--- a/extensions/http/internal.m
+++ b/extensions/http/internal.m
@@ -137,14 +137,16 @@ static void remove_delegate(__unused lua_State* L, connectionDelegate* delegate)
     }
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        LuaSkin *skin = [LuaSkin shared];
-        _lua_stackguard_entry(skin.L);
+        if (self.fn != LUA_NOREF) {
+            LuaSkin *skin = [LuaSkin shared];
+            _lua_stackguard_entry(skin.L);
 
-        [skin pushLuaRef:refTable ref:self.fn];
-        [skin pushNSObject:message];
+            [skin pushLuaRef:refTable ref:self.fn];
+            [skin pushNSObject:message];
 
-        [skin protectedCallAndError:@"hs.http.websocket callback" nargs:1 nresults:0];
-        _lua_stackguard_exit(skin.L);
+            [skin protectedCallAndError:@"hs.http.websocket callback" nargs:1 nresults:0];
+            _lua_stackguard_exit(skin.L);
+        }
     });
 }
 
@@ -183,7 +185,7 @@ static NSMutableURLRequest* getRequestFromStack(__unused lua_State* L, NSString*
     LuaSkin *skin = [LuaSkin shared];
     NSString* url = [skin toNSObjectAtIndex:1];
     NSString* method = [skin toNSObjectAtIndex:2];
-        
+
     NSUInteger selectedCachePolicy;
     if ([cachePolicy isEqualToString:@"protocolCachePolicy"]) {
         selectedCachePolicy = NSURLRequestUseProtocolCachePolicy;
@@ -251,7 +253,7 @@ static int http_doAsyncRequest(lua_State* L){
     [skin checkArgs:LS_TSTRING, LS_TSTRING, LS_TSTRING|LS_TNIL, LS_TTABLE|LS_TNIL, LS_TFUNCTION, LS_TSTRING | LS_TOPTIONAL, LS_TBREAK];
 
     NSString* cachePolicy = [skin toNSObjectAtIndex:6];
-    
+
     NSMutableURLRequest* request = getRequestFromStack(L, cachePolicy);
     getBodyFromStack(L, 3, request);
     extractHeadersFromStack(L, 4, request);
@@ -303,7 +305,7 @@ static int http_doRequest(lua_State* L) {
     [skin checkArgs:LS_TSTRING, LS_TSTRING, LS_TSTRING|LS_TNIL|LS_TOPTIONAL, LS_TTABLE|LS_TNIL|LS_TOPTIONAL, LS_TSTRING|LS_TOPTIONAL, LS_TBREAK];
 
     NSString* cachePolicy = [skin toNSObjectAtIndex:5];
-    
+
     NSMutableURLRequest *request = getRequestFromStack(L, cachePolicy);
     getBodyFromStack(L, 3, request);
     extractHeadersFromStack(L, 4, request);

--- a/extensions/httpserver/internal.m
+++ b/extensions/httpserver/internal.m
@@ -57,6 +57,8 @@ static int refTable;
     if (self) {
         self.httpPassword = nil;
         self.maxBodySize  = 10 * 1024 * 1024; // set initial max body size to 10 MB
+        self.wsCallback   = LUA_NOREF ;
+        self.fn           = LUA_NOREF ;
     }
     return self;
 }
@@ -75,21 +77,23 @@ static int refTable;
     __block NSData *response = nil;
 
     void (^responseCallbackBlock)(void) = ^{
-        LuaSkin *skin = [LuaSkin shared];
-        _lua_stackguard_entry(skin.L);
-        [skin pushLuaRef:refTable ref:self.callback];
-        lua_pushstring(skin.L, [msg UTF8String]);
+        if (self.callback != LUA_NOREF) {
+            LuaSkin *skin = [LuaSkin shared];
+            _lua_stackguard_entry(skin.L);
+            [skin pushLuaRef:refTable ref:self.callback];
+            lua_pushstring(skin.L, [msg UTF8String]);
 
-        if (![skin protectedCallAndTraceback:1 nresults:1]) {
-            const char *errorMsg = lua_tostring(skin.L, -1);
-            [skin logError:[NSString stringWithFormat:@"hs.httpserver:websocket callback error: %s", errorMsg]];
-            // No need to lua_pop() here, nresults is 1 so the lua_pop() below catches successful results and error messages
-        } else {
-            response = [skin toNSObjectAtIndex:-1];
+            if (![skin protectedCallAndTraceback:1 nresults:1]) {
+                const char *errorMsg = lua_tostring(skin.L, -1);
+                [skin logError:[NSString stringWithFormat:@"hs.httpserver:websocket callback error: %s", errorMsg]];
+                // No need to lua_pop() here, nresults is 1 so the lua_pop() below catches successful results and error messages
+            } else {
+                response = [skin toNSObjectAtIndex:-1];
+            }
+
+            lua_pop(skin.L, 1);
+            _lua_stackguard_exit(skin.L);
         }
-
-        lua_pop(skin.L, 1);
-        _lua_stackguard_exit(skin.L);
     };
 
     // Make sure we do all the above Lua work on the main thread
@@ -170,59 +174,61 @@ static int refTable;
     __block NSData *responseBody = nil;
 
     void (^responseCallbackBlock)(void) = ^{
-        LuaSkin *skin = [LuaSkin shared];
-        lua_State *L = skin.L;
-        _lua_stackguard_entry(L);
+        if (((HSHTTPServer *)self->config.server).fn != LUA_NOREF) {
+            LuaSkin *skin = [LuaSkin shared];
+            lua_State *L = skin.L;
+            _lua_stackguard_entry(L);
 
-        // add some headers for callback function to access
-        [self->request setHeaderField:@"X-Remote-Addr" value:self->asyncSocket.connectedHost];
-        [self->request setHeaderField:@"X-Remote-Port" value:[NSString stringWithFormat:@"%hu", self->asyncSocket.connectedPort]];
-        [self->request setHeaderField:@"X-Server-Addr" value:self->asyncSocket.localHost];
-        [self->request setHeaderField:@"X-Server-Port" value:[NSString stringWithFormat:@"%hu", self->asyncSocket.localPort]];
+            // add some headers for callback function to access
+            [self->request setHeaderField:@"X-Remote-Addr" value:self->asyncSocket.connectedHost];
+            [self->request setHeaderField:@"X-Remote-Port" value:[NSString stringWithFormat:@"%hu", self->asyncSocket.connectedPort]];
+            [self->request setHeaderField:@"X-Server-Addr" value:self->asyncSocket.localHost];
+            [self->request setHeaderField:@"X-Server-Port" value:[NSString stringWithFormat:@"%hu", self->asyncSocket.localPort]];
 
 
-        [skin pushLuaRef:refTable ref:((HSHTTPServer *)self->config.server).fn];
-        lua_pushstring(L, [method UTF8String]);
-        lua_pushstring(L, [path UTF8String]);
-        [skin pushNSObject:[self->request allHeaderFields]];
-        [skin pushNSObject:[self->request body] withOptions:LS_NSLuaStringAsDataOnly];
+            [skin pushLuaRef:refTable ref:((HSHTTPServer *)self->config.server).fn];
+            lua_pushstring(L, [method UTF8String]);
+            lua_pushstring(L, [path UTF8String]);
+            [skin pushNSObject:[self->request allHeaderFields]];
+            [skin pushNSObject:[self->request body] withOptions:LS_NSLuaStringAsDataOnly];
 
-        if (![skin protectedCallAndTraceback:4 nresults:3]) {
-            const char *errorMsg = lua_tostring(L, -1);
-            [skin logError:[NSString stringWithFormat:@"hs.httpserver:setCallback() callback error: %s", errorMsg]];
-            responseCode = 503;
-            responseBody = [NSData dataWithData:[@"An error occurred during hs.httpserver callback handling" dataUsingEncoding:NSUTF8StringEncoding]];
-            lua_pop(L, 1) ; // the error message
-        } else {
-            if (!(lua_type(L, -3) == LUA_TSTRING && lua_type(L, -2) == LUA_TNUMBER && lua_type(L, -1) == LUA_TTABLE)) {
-                [skin logError:@"hs.httpserver:setCallback() callbacks must return three values. A string for the response body, an integer response code, and a table of headers"];
+            if (![skin protectedCallAndTraceback:4 nresults:3]) {
+                const char *errorMsg = lua_tostring(L, -1);
+                [skin logError:[NSString stringWithFormat:@"hs.httpserver:setCallback() callback error: %s", errorMsg]];
                 responseCode = 503;
-                responseBody = [NSData dataWithData:[@"Callback handler returned invalid values" dataUsingEncoding:NSUTF8StringEncoding]];
+                responseBody = [NSData dataWithData:[@"An error occurred during hs.httpserver callback handling" dataUsingEncoding:NSUTF8StringEncoding]];
+                lua_pop(L, 1) ; // the error message
             } else {
-                responseBody = [skin toNSObjectAtIndex:-3 withOptions:LS_NSLuaStringAsDataOnly];
-                responseCode = (int)lua_tointeger(L, -2);
+                if (!(lua_type(L, -3) == LUA_TSTRING && lua_type(L, -2) == LUA_TNUMBER && lua_type(L, -1) == LUA_TTABLE)) {
+                    [skin logError:@"hs.httpserver:setCallback() callbacks must return three values. A string for the response body, an integer response code, and a table of headers"];
+                    responseCode = 503;
+                    responseBody = [NSData dataWithData:[@"Callback handler returned invalid values" dataUsingEncoding:NSUTF8StringEncoding]];
+                } else {
+                    responseBody = [skin toNSObjectAtIndex:-3 withOptions:LS_NSLuaStringAsDataOnly];
+                    responseCode = (int)lua_tointeger(L, -2);
 
-                responseHeaders = [[NSMutableDictionary alloc] init];
-                BOOL headerTypeError = NO;
-                // Push nil onto the stack, which means that the table has moved from -1 to -2
-                lua_pushnil(L);
-                while (lua_next(L, -2)) {
-                    if (lua_type(L, -1) == LUA_TSTRING && lua_type(L, -2) == LUA_TSTRING) {
-                        NSString *key = [skin toNSObjectAtIndex:-2];
-                        NSString *value = [skin toNSObjectAtIndex:-1];
-                        [responseHeaders setObject:value forKey:key];
-                    } else {
-                        headerTypeError = YES;
+                    responseHeaders = [[NSMutableDictionary alloc] init];
+                    BOOL headerTypeError = NO;
+                    // Push nil onto the stack, which means that the table has moved from -1 to -2
+                    lua_pushnil(L);
+                    while (lua_next(L, -2)) {
+                        if (lua_type(L, -1) == LUA_TSTRING && lua_type(L, -2) == LUA_TSTRING) {
+                            NSString *key = [skin toNSObjectAtIndex:-2];
+                            NSString *value = [skin toNSObjectAtIndex:-1];
+                            [responseHeaders setObject:value forKey:key];
+                        } else {
+                            headerTypeError = YES;
+                        }
+                        lua_pop(L, 1);
                     }
-                    lua_pop(L, 1);
+                    if (headerTypeError) {
+                        [skin logError:@"hs.httpserver:setCallback() callback returned a header table that contains non-strings"];
+                    }
                 }
-                if (headerTypeError) {
-                    [skin logError:@"hs.httpserver:setCallback() callback returned a header table that contains non-strings"];
-                }
+                lua_pop(L, 3) ; // our results... don't leave them on the stack
             }
-            lua_pop(L, 3) ; // our results... don't leave them on the stack
+            _lua_stackguard_exit(L);
         }
-        _lua_stackguard_exit(L);
     };
 
     // Make sure we do all the above Lua work on the main thread
@@ -395,7 +401,7 @@ static int httpserver_websocket(lua_State *L) {
     HSHTTPServer *server = getUserData(L, 1);
 
     server.wsPath = [skin toNSObjectAtIndex:2];
-    [skin luaUnref:refTable ref:server.wsCallback];
+    server.wsCallback = [skin luaUnref:refTable ref:server.wsCallback];
     lua_pushvalue(L, 3);
     server.wsCallback = [skin luaRef:refTable];
 
@@ -689,8 +695,8 @@ static int httpserver_objectGC(lua_State *L) {
     httpserver_t *httpServer = get_item_arg(L, 1);
     HSHTTPServer *server = (__bridge_transfer HSHTTPServer *)httpServer->server;
     [server stop];
-    [[LuaSkin shared] luaUnref:refTable ref:server.fn];
-    [[LuaSkin shared] luaUnref:refTable ref:server.wsCallback];
+    server.fn = [[LuaSkin shared] luaUnref:refTable ref:server.fn];
+    server.wsCallback = [[LuaSkin shared] luaUnref:refTable ref:server.wsCallback];
     server = nil;
 
     return 0;

--- a/extensions/image/internal.m
+++ b/extensions/image/internal.m
@@ -18,6 +18,8 @@ int refTable = LUA_NOREF;
 // for a single document image...
 static NSImage *missingIconForFile ;
 
+static NSMutableSet *backgroundCallbacks ;
+
 #pragma mark - Module Constants
 
 /// hs.image.systemImageNames[]
@@ -1033,19 +1035,24 @@ static int imageFromURL(lua_State *L) {
         [skin pushNSObject:[[NSImage alloc] initWithContentsOfURL:theURL]] ;
     } else {
         int fnRef = [skin luaRef:refTable atIndex:2];
+        [backgroundCallbacks addObject:@(fnRef)] ;
+
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
             NSImage *image = [[NSImage alloc] initWithContentsOfURL:theURL];
 
             dispatch_async(dispatch_get_main_queue(), ^(void){
-                LuaSkin *bgSkin = [LuaSkin shared];
-                _lua_stackguard_entry(bgSkin.L);
+                if ([backgroundCallbacks containsObject:@(fnRef)]) {
+                    LuaSkin *bgSkin = [LuaSkin shared];
+                    _lua_stackguard_entry(bgSkin.L);
 
-                [bgSkin pushLuaRef:refTable ref:fnRef];
-                [bgSkin pushNSObject:image];
-                [bgSkin protectedCallAndTraceback:1 nresults:0];
-                [bgSkin luaUnref:refTable ref:fnRef];
+                    [bgSkin pushLuaRef:refTable ref:fnRef];
+                    [bgSkin pushNSObject:image];
+                    [bgSkin protectedCallAndTraceback:1 nresults:0];
+                    [bgSkin luaUnref:refTable ref:fnRef];
 
-                _lua_stackguard_exit(bgSkin.L);
+                    _lua_stackguard_exit(bgSkin.L);
+                    [backgroundCallbacks removeObject:@(fnRef)] ;
+                }
             });
         });
         lua_pushnil(L);
@@ -1656,11 +1663,14 @@ static int userdata_gc(lua_State* L) {
     return 0 ;
 }
 
-// static int meta_gc(lua_State* __unused L) {
-//     [hsimageReferences removeAllIndexes];
-//     hsimageReferences = nil;
-//     return 0 ;
-// }
+static int meta_gc(lua_State* __unused L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [backgroundCallbacks enumerateObjectsUsingBlock:^(NSNumber *ref, __unused BOOL *stop) {
+        [skin luaUnref:refTable ref:ref.intValue] ;
+    }] ;
+    [backgroundCallbacks removeAllObjects] ;
+    return 0;
+}
 
 // Metatable for userdata objects
 static const luaL_Reg userdata_metaLib[] = {
@@ -1694,17 +1704,17 @@ static luaL_Reg moduleLib[] = {
     {NULL,                        NULL}
 };
 
-// // Metatable for module, if needed
-// static const luaL_Reg module_metaLib[] = {
-//     {"__gc",                meta_gc},
-//     {NULL,                  NULL}
-// };
+// Metatable for module, if needed
+static const luaL_Reg module_metaLib[] = {
+    {"__gc", meta_gc},
+    {NULL,   NULL}
+};
 
 int luaopen_hs_image_internal(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared] ;
     refTable = [skin registerLibraryWithObject:USERDATA_TAG
                                      functions:moduleLib
-                                 metaFunctions:nil
+                                 metaFunctions:module_metaLib
                                objectFunctions:userdata_metaLib];
 
     pushNSImageNameTable(L); lua_setfield(L, -2, "systemImageNames") ;
@@ -1714,6 +1724,8 @@ int luaopen_hs_image_internal(lua_State* L) {
     [skin registerLuaObjectHelper:HSImage_toNSImage forClass:"NSImage" withUserdataMapping:USERDATA_TAG] ;
 
     if (!missingIconForFile) missingIconForFile = [[NSWorkspace sharedWorkspace] iconForFile:@""] ; // see comment at top
+
+    backgroundCallbacks = [NSMutableSet set] ;
     return 1;
 }
 

--- a/extensions/keycodes/internal.m
+++ b/extensions/keycodes/internal.m
@@ -196,6 +196,14 @@ int keycodes_cachemap(lua_State* L) {
 
 @implementation MJKeycodesObserver
 
+- (instancetype)init {
+    self = [super init] ;
+    if (self) {
+        _ref = LUA_NOREF ;
+    }
+    return self ;
+}
+
 - (void) _inputSourceChanged:(NSNotification*)__unused note {
     [self performSelectorOnMainThread:@selector(inputSourceChanged:)
                                        withObject:nil
@@ -203,11 +211,13 @@ int keycodes_cachemap(lua_State* L) {
 }
 
 - (void) inputSourceChanged:(NSNotification*)__unused note {
-    LuaSkin *skin = [LuaSkin shared];
-    _lua_stackguard_entry(skin.L);
-    [skin pushLuaRef:refTable ref:self.ref];
-    [skin protectedCallAndError:@"hs.keycodes.inputSourceChanged" nargs:0 nresults:0];
-    _lua_stackguard_exit(skin.L);
+    if (self.ref != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared];
+        _lua_stackguard_entry(skin.L);
+        [skin pushLuaRef:refTable ref:self.ref];
+        [skin protectedCallAndError:@"hs.keycodes.inputSourceChanged" nargs:0 nresults:0];
+        _lua_stackguard_exit(skin.L);
+    }
 }
 
 - (void) start {

--- a/extensions/location/init.lua
+++ b/extensions/location/init.lua
@@ -70,8 +70,8 @@ local __dispatch = function(msg, ...)
                 end
             else
                 local _self = objectInternals[id]
-                if _self and _self.callback then
-                    _self.callback(_self, msg, ...)
+                if _self and _self._callbk then
+                    _self._callbk(_self, msg, ...)
                 end
             end
         end
@@ -81,7 +81,7 @@ local __dispatch = function(msg, ...)
             if type(k) == "string" then
                 local id, _self = k, v
 
-                if _self.callback then
+                if _self._callbk then
                     if msg:match("Region$") then
                         local args = table.pack(...)
                         local originalID = args[1].identifier
@@ -97,10 +97,10 @@ local __dispatch = function(msg, ...)
                             args[1].notifyOnExit  = _self.regions[originalID].notifyOnExit
                             -- return the objects name for the region, not the internal one
                             args[1].identifier = _self.regions[originalID].identifier
-                            _self.callback(_self, msg, table.unpack(args))
+                            _self._callbk(_self, msg, table.unpack(args))
                         end
                     else
-                        _self.callback(_self, msg, ...)
+                        _self._callbk(_self, msg, ...)
                     end
                 end
             end
@@ -243,7 +243,7 @@ objectMT.__eq = function(self, other)
     return self.id == other.id
 end
 objectMT.__gc = function(self)
-    self.callback = nil
+    self._callbk = nil
     self:stopTracking()
     for _,v in ipairs(self:monitoredRegions()) do self:removeMonitoredRegion(v.identifier) end
     -- yeah, internal gc will get these, but it takes two passes to get both, so lets just kill both at once
@@ -482,7 +482,7 @@ objectMT.callback = function(self, ...)
     if args.n == 1 then
         local fn = args[1]
         if type(fn) == "function" or type(fn) == "nil" then
-            self.callback = fn
+            self._callbk = fn
         else
             error("expeected a function or nil, found " .. type(fn), 2)
         end

--- a/extensions/location/internal.m
+++ b/extensions/location/internal.m
@@ -14,6 +14,8 @@ static HSLocation *location ;
 
 #define get_objectFromUserdata(objType, L, idx, tag) (objType*)*((void**)luaL_checkudata(L, idx, tag))
 
+static NSMutableSet *backgroundCallbacks ;
+
 #pragma mark - Support Functions and Classes
 
 @interface HSLocation : NSObject <CLLocationManagerDelegate>
@@ -49,89 +51,83 @@ static HSLocation *location ;
 }
 
 - (void)locationManager:(__unused CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
-    if (callbackRef != LUA_NOREF) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (callbackRef != LUA_NOREF) {
             LuaSkin *skin = [LuaSkin shared] ;
             _lua_stackguard_entry(skin.L);
             [skin pushLuaRef:refTable ref:callbackRef] ;
-            [skin pushNSObject:self] ;
             [skin pushNSObject:@"didUpdateLocations"] ;
             [skin pushNSObject:locations] ;
-            [skin protectedCallAndError:@"hs.location:didUpdateLocations callback" nargs:3 nresults:0];
+            [skin protectedCallAndError:@"hs.location:didUpdateLocations callback" nargs:2 nresults:0];
             _lua_stackguard_exit(skin.L);
-        }) ;
-    }
+        }
+    }) ;
 }
 
 - (void)locationManager:(__unused CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
-    if (callbackRef != LUA_NOREF) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (callbackRef != LUA_NOREF) {
             LuaSkin *skin = [LuaSkin shared] ;
             _lua_stackguard_entry(skin.L);
             [skin pushLuaRef:refTable ref:callbackRef] ;
-            [skin pushNSObject:self] ;
             [skin pushNSObject:@"didEnterRegion"] ;
             [skin pushNSObject:region] ;
-            [skin protectedCallAndError:@"hs.location:didEnterRegion callback" nargs:3 nresults:0];
+            [skin protectedCallAndError:@"hs.location:didEnterRegion callback" nargs:2 nresults:0];
             _lua_stackguard_exit(skin.L);
-        }) ;
-    }
+        }
+    }) ;
 }
 
 - (void)locationManager:(__unused CLLocationManager *)manager didExitRegion:(CLRegion *)region {
-    if (callbackRef != LUA_NOREF) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (callbackRef != LUA_NOREF) {
             LuaSkin *skin = [LuaSkin shared] ;
             _lua_stackguard_entry(skin.L);
             [skin pushLuaRef:refTable ref:callbackRef] ;
-            [skin pushNSObject:self] ;
             [skin pushNSObject:@"didExitRegion"] ;
             [skin pushNSObject:region] ;
-            [skin protectedCallAndError:@"hs.location:didExitRegion callback" nargs:3 nresults:0];
+            [skin protectedCallAndError:@"hs.location:didExitRegion callback" nargs:2 nresults:0];
             _lua_stackguard_exit(skin.L);
-        }) ;
-    }
+        }
+    }) ;
 }
 
 - (void)locationManager:(__unused CLLocationManager *)manager didFailWithError:(NSError *)error {
-    if (callbackRef != LUA_NOREF) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (callbackRef != LUA_NOREF) {
             LuaSkin *skin = [LuaSkin shared] ;
             _lua_stackguard_entry(skin.L);
             [skin pushLuaRef:refTable ref:callbackRef] ;
-            [skin pushNSObject:self] ;
             [skin pushNSObject:@"didFailWithError"] ;
             [skin pushNSObject:error.localizedDescription] ;
-            [skin protectedCallAndError:@"hs.location:didFailWithError callback" nargs:3 nresults:0];
+            [skin protectedCallAndError:@"hs.location:didFailWithError callback" nargs:2 nresults:0];
             _lua_stackguard_exit(skin.L);
-        }) ;
-    }
+        }
+    }) ;
 }
 
 - (void)locationManager:(__unused CLLocationManager *)manager monitoringDidFailForRegion:(CLRegion *)region
                                                                       withError:(NSError *)error {
-    if (callbackRef != LUA_NOREF) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (callbackRef != LUA_NOREF) {
             LuaSkin *skin = [LuaSkin shared] ;
             _lua_stackguard_entry(skin.L);
             [skin pushLuaRef:refTable ref:callbackRef] ;
-            [skin pushNSObject:self] ;
             [skin pushNSObject:@"monitoringDidFailForRegion"] ;
             [skin pushNSObject:region] ;
             [skin pushNSObject:error.localizedDescription] ;
-            [skin protectedCallAndError:@"hs.location:monitoringDidFailForRegion callback" nargs:4 nresults:0];
+            [skin protectedCallAndError:@"hs.location:monitoringDidFailForRegion callback" nargs:3 nresults:0];
             _lua_stackguard_exit(skin.L);
-        }) ;
-    }
+        }
+    }) ;
 }
 
 - (void)locationManager:(__unused CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    if (callbackRef != LUA_NOREF) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (callbackRef != LUA_NOREF) {
             LuaSkin *skin = [LuaSkin shared] ;
             _lua_stackguard_entry(skin.L);
             [skin pushLuaRef:refTable ref:callbackRef] ;
-            [skin pushNSObject:self] ;
             [skin pushNSObject:@"didChangeAuthorizationStatus"] ;
 
 // according to the CLLocationManager.h file, kCLAuthorizationStatusAuthorizedWhenInUse is
@@ -149,25 +145,24 @@ static HSLocation *location ;
             }
 #pragma clang diagnostic pop
 
-            [skin protectedCallAndError:@"hs.location:didChangeAuthorizationStatus callback" nargs:3 nresults:0];
+            [skin protectedCallAndError:@"hs.location:didChangeAuthorizationStatus callback" nargs:2 nresults:0];
             _lua_stackguard_exit(skin.L);
-        }) ;
-    }
+        }
+    }) ;
 }
 
 - (void)locationManager:(__unused CLLocationManager *)manager didStartMonitoringForRegion:(CLRegion *)region {
-    if (callbackRef != LUA_NOREF) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (callbackRef != LUA_NOREF) {
             LuaSkin *skin = [LuaSkin shared] ;
             _lua_stackguard_entry(skin.L);
             [skin pushLuaRef:refTable ref:callbackRef] ;
-            [skin pushNSObject:self] ;
             [skin pushNSObject:@"didStartMonitoringForRegion"] ;
             [skin pushNSObject:region] ;
-            [skin protectedCallAndError:@"hs.location:didStartMonitoringForRegion" nargs:3 nresults:0];
+            [skin protectedCallAndError:@"hs.location:didStartMonitoringForRegion" nargs:2 nresults:0];
             _lua_stackguard_exit(skin.L);
-        }) ;
-    }
+        }
+    }) ;
 }
 
 @end
@@ -575,17 +570,21 @@ static int clgeocoder_lookupLocation(lua_State *L) {
     CLLocation *theLocation = [skin luaObjectAtIndex:1 toClass:"CLLocation"] ;
     lua_pushvalue(L, 2) ;
     int fnRef = [skin luaRef:refTable] ;
+    [backgroundCallbacks addObject:@(fnRef)] ;
 
     CLGeocoder *geoItem = [[CLGeocoder alloc] init] ;
     [geoItem reverseGeocodeLocation:theLocation completionHandler:^(NSArray *placemark, NSError *error) {
-        LuaSkin   *_skin = [LuaSkin shared] ;
-//         if (error) [_skin logInfo:[NSString stringWithFormat:@"%s:lookupLocation completion error:%@", GEOCODE_UD_TAG, error.localizedDescription]] ;
-        lua_State *_L    = [_skin L] ;
-        [_skin pushLuaRef:refTable ref:fnRef] ;
-        lua_pushboolean(_L, (error == NULL)) ;
-        [_skin pushNSObject:(error ? error.localizedDescription : placemark)] ;
-        [_skin protectedCallAndError:@"hs.location.geocode:lookupLocation callback" nargs:2 nresults:0];
-        [_skin luaUnref:refTable ref:fnRef] ;
+        if ([backgroundCallbacks containsObject:@(fnRef)]) {
+            LuaSkin   *_skin = [LuaSkin shared] ;
+    //         if (error) [_skin logInfo:[NSString stringWithFormat:@"%s:lookupLocation completion error:%@", GEOCODE_UD_TAG, error.localizedDescription]] ;
+            lua_State *_L    = [_skin L] ;
+            [_skin pushLuaRef:refTable ref:fnRef] ;
+            lua_pushboolean(_L, (error == NULL)) ;
+            [_skin pushNSObject:(error ? error.localizedDescription : placemark)] ;
+            [_skin protectedCallAndError:@"hs.location.geocode:lookupLocation callback" nargs:2 nresults:0];
+            [_skin luaUnref:refTable ref:fnRef] ;
+            [backgroundCallbacks removeObject:@(fnRef)] ;
+        }
     }] ;
     [skin pushNSObject:geoItem] ;
     return 1 ;
@@ -613,17 +612,21 @@ static int clgeocoder_lookupAddress(lua_State *L) {
     NSString *searchString = [skin toNSObjectAtIndex:1] ;
     lua_pushvalue(L, 2) ;
     int fnRef = [skin luaRef:refTable] ;
+    [backgroundCallbacks addObject:@(fnRef)] ;
 
     CLGeocoder *geoItem = [[CLGeocoder alloc] init] ;
     [geoItem geocodeAddressString:searchString completionHandler:^(NSArray *placemark, NSError *error) {
-        LuaSkin   *_skin = [LuaSkin shared] ;
-//         if (error) [_skin logInfo:[NSString stringWithFormat:@"%s:lookupAddress completion error:%@", GEOCODE_UD_TAG, error.localizedDescription]] ;
-        lua_State *_L    = [_skin L] ;
-        [_skin pushLuaRef:refTable ref:fnRef] ;
-        lua_pushboolean(_L, (error == NULL)) ;
-        [_skin pushNSObject:(error ? error.localizedDescription : placemark)] ;
-        [_skin protectedCallAndError:@"hs.location.geocode:lookupAddress callback" nargs:2 nresults:0];
-        [_skin luaUnref:refTable ref:fnRef] ;
+        if ([backgroundCallbacks containsObject:@(fnRef)]) {
+            LuaSkin   *_skin = [LuaSkin shared] ;
+    //         if (error) [_skin logInfo:[NSString stringWithFormat:@"%s:lookupAddress completion error:%@", GEOCODE_UD_TAG, error.localizedDescription]] ;
+            lua_State *_L    = [_skin L] ;
+            [_skin pushLuaRef:refTable ref:fnRef] ;
+            lua_pushboolean(_L, (error == NULL)) ;
+            [_skin pushNSObject:(error ? error.localizedDescription : placemark)] ;
+            [_skin protectedCallAndError:@"hs.location.geocode:lookupAddress callback" nargs:2 nresults:0];
+            [_skin luaUnref:refTable ref:fnRef] ;
+            [backgroundCallbacks removeObject:@(fnRef)] ;
+        }
     }] ;
     [skin pushNSObject:geoItem] ;
     return 1 ;
@@ -661,17 +664,21 @@ static int clgeocoder_lookupAddressNear(lua_State *L) {
         lua_pushvalue(L, 3) ;
     }
     int fnRef = [skin luaRef:refTable] ;
+    [backgroundCallbacks addObject:@(fnRef)] ;
 
     CLGeocoder *geoItem = [[CLGeocoder alloc] init] ;
     [geoItem geocodeAddressString:searchString inRegion:theRegion completionHandler:^(NSArray *placemark, NSError *error) {
-        LuaSkin   *_skin = [LuaSkin shared] ;
-//         if (error) [_skin logInfo:[NSString stringWithFormat:@"%s:lookupAddressNear completion error:%@", GEOCODE_UD_TAG, error.localizedDescription]] ;
-        lua_State *_L    = [_skin L] ;
-        [_skin pushLuaRef:refTable ref:fnRef] ;
-        lua_pushboolean(_L, (error == NULL)) ;
-        [_skin pushNSObject:(error ? error.localizedDescription : placemark)] ;
-        [_skin protectedCallAndError:@"hs.location.geocode:lookupAddressNear callback" nargs:2 nresults:0];
-        [_skin luaUnref:refTable ref:fnRef] ;
+        if ([backgroundCallbacks containsObject:@(fnRef)]) {
+            LuaSkin   *_skin = [LuaSkin shared] ;
+    //         if (error) [_skin logInfo:[NSString stringWithFormat:@"%s:lookupAddressNear completion error:%@", GEOCODE_UD_TAG, error.localizedDescription]] ;
+            lua_State *_L    = [_skin L] ;
+            [_skin pushLuaRef:refTable ref:fnRef] ;
+            lua_pushboolean(_L, (error == NULL)) ;
+            [_skin pushNSObject:(error ? error.localizedDescription : placemark)] ;
+            [_skin protectedCallAndError:@"hs.location.geocode:lookupAddressNear callback" nargs:2 nresults:0];
+            [_skin luaUnref:refTable ref:fnRef] ;
+            [backgroundCallbacks removeObject:@(fnRef)] ;
+        }
     }] ;
     [skin pushNSObject:geoItem] ;
     return 1 ;
@@ -902,8 +909,14 @@ static int clgeocoder_gc(lua_State* L) {
 }
 
 static int meta_gc(lua_State* __unused L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [backgroundCallbacks enumerateObjectsUsingBlock:^(NSNumber *ref, __unused BOOL *stop) {
+        [skin luaUnref:refTable ref:ref.intValue] ;
+    }] ;
+    [backgroundCallbacks removeAllObjects] ;
+
     // make sure we don't get a last-minute callback during teardown
-    callbackRef = [[LuaSkin shared] luaUnref:refTable ref:callbackRef] ;
+    callbackRef = [skin luaUnref:refTable ref:callbackRef] ;
     if (location) {
         if (location.manager) {
             location.manager.delegate = nil ;
@@ -991,5 +1004,6 @@ int luaopen_hs_location_internal(lua_State *L) {
 
     [skin registerPushNSHelper:pushCLPlacemark            forClass:"CLPlacemark"] ;
 
+    backgroundCallbacks = [NSMutableSet set] ;
     return 1;
 }

--- a/extensions/network/configurationinternal.m
+++ b/extensions/network/configurationinternal.m
@@ -23,18 +23,20 @@ static void doDynamicStoreCallback(__unused SCDynamicStoreRef store, CFArrayRef 
     if (thePtr->callbackRef != LUA_NOREF) {
         NSArray *nsChangedKeys = [(__bridge NSArray *)changedKeys copy];
         dispatch_async(dispatch_get_main_queue(), ^{
-            LuaSkin   *skin = [LuaSkin shared] ;
-            lua_State *L    = [skin L] ;
-            _lua_stackguard_entry(L);
-            [skin pushLuaRef:refTable ref:thePtr->callbackRef] ;
-            [skin pushLuaRef:refTable ref:thePtr->selfRef] ;
-            if (changedKeys) {
-                [skin pushNSObject:nsChangedKeys] ;
-            } else {
-                lua_pushnil(L) ;
+            if (thePtr->callbackRef != LUA_NOREF) {
+                LuaSkin   *skin = [LuaSkin shared] ;
+                lua_State *L    = [skin L] ;
+                _lua_stackguard_entry(L);
+                [skin pushLuaRef:refTable ref:thePtr->callbackRef] ;
+                [skin pushLuaRef:refTable ref:thePtr->selfRef] ;
+                if (changedKeys) {
+                    [skin pushNSObject:nsChangedKeys] ;
+                } else {
+                    lua_pushnil(L) ;
+                }
+                [skin protectedCallAndError:@"hs.network.configuration callback" nargs:2 nresults:0];
+                _lua_stackguard_exit(L);
             }
-            [skin protectedCallAndError:@"hs.network.configuration callback" nargs:2 nresults:0];
-            _lua_stackguard_exit(L);
         }) ;
     }
 }

--- a/extensions/network/reachabilityinternal.m
+++ b/extensions/network/reachabilityinternal.m
@@ -37,20 +37,18 @@ static int pushSCNetworkReachability(lua_State *L, SCNetworkReachabilityRef theR
 
 static void doReachabilityCallback(__unused SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info) {
     reachability_t *theRef = (reachability_t *)info ;
-    if (theRef->callbackRef != LUA_NOREF) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (theRef->callbackRef != LUA_NOREF) {
-                LuaSkin   *skin = [LuaSkin shared] ;
-                lua_State *L    = [skin L] ;
-                _lua_stackguard_entry(L);
-                [skin pushLuaRef:refTable ref:theRef->callbackRef] ;
-                [skin pushLuaRef:refTable ref:theRef->selfRef] ;
-                lua_pushinteger(L, (lua_Integer)flags) ;
-                [skin protectedCallAndError:@"hs.network.reachability" nargs:2 nresults:0];
-                _lua_stackguard_exit(L);
-            }
-        }) ;
-    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ((theRef->callbackRef != LUA_NOREF) && (theRef->selfRef != LUA_NOREF)) {
+            LuaSkin   *skin = [LuaSkin shared] ;
+            lua_State *L    = [skin L] ;
+            _lua_stackguard_entry(L);
+            [skin pushLuaRef:refTable ref:theRef->callbackRef] ;
+            [skin pushLuaRef:refTable ref:theRef->selfRef] ;
+            lua_pushinteger(L, (lua_Integer)flags) ;
+            [skin protectedCallAndError:@"hs.network.reachability" nargs:2 nresults:0];
+            _lua_stackguard_exit(L);
+        }
+    }) ;
 }
 
 static NSString *statusString(SCNetworkReachabilityFlags flags) {

--- a/extensions/network/reachabilityinternal.m
+++ b/extensions/network/reachabilityinternal.m
@@ -39,14 +39,16 @@ static void doReachabilityCallback(__unused SCNetworkReachabilityRef target, SCN
     reachability_t *theRef = (reachability_t *)info ;
     if (theRef->callbackRef != LUA_NOREF) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            LuaSkin   *skin = [LuaSkin shared] ;
-            lua_State *L    = [skin L] ;
-            _lua_stackguard_entry(L);
-            [skin pushLuaRef:refTable ref:theRef->callbackRef] ;
-            [skin pushLuaRef:refTable ref:theRef->selfRef] ;
-            lua_pushinteger(L, (lua_Integer)flags) ;
-            [skin protectedCallAndError:@"hs.network.reachability" nargs:2 nresults:0];
-            _lua_stackguard_exit(L);
+            if (theRef->callbackRef != LUA_NOREF) {
+                LuaSkin   *skin = [LuaSkin shared] ;
+                lua_State *L    = [skin L] ;
+                _lua_stackguard_entry(L);
+                [skin pushLuaRef:refTable ref:theRef->callbackRef] ;
+                [skin pushLuaRef:refTable ref:theRef->selfRef] ;
+                lua_pushinteger(L, (lua_Integer)flags) ;
+                [skin protectedCallAndError:@"hs.network.reachability" nargs:2 nresults:0];
+                _lua_stackguard_exit(L);
+            }
         }) ;
     }
 }

--- a/extensions/noises/internal.m
+++ b/extensions/noises/internal.m
@@ -66,6 +66,7 @@ void AudioInputCallback(void * inUserData,  // Custom audio metadata
 - (Listener*)initPlugins {
   self = [super init];
   if (self) {
+    self.fn = LUA_NOREF ;
     recordState.recording = false;
     detectors = detectors_new();
   }
@@ -161,13 +162,15 @@ void AudioInputCallback(void * inUserData,  // Custom audio metadata
 }
 
 - (void)runCallbackWithEvent: (NSNumber*)evNumber {
-  LuaSkin *skin = [LuaSkin shared];
-  lua_State* L = self.L;
-  _lua_stackguard_entry(L);
-  [skin pushLuaRef:refTable ref:self.fn];
-  lua_pushinteger(L, [evNumber intValue]);
-  [skin protectedCallAndError:@"hs.noises callback" nargs:1 nresults:0];
-  _lua_stackguard_exit(L);
+  if (self.fn != LUA_NOREF) {
+      LuaSkin *skin = [LuaSkin shared];
+      lua_State* L = self.L;
+      _lua_stackguard_entry(L);
+      [skin pushLuaRef:refTable ref:self.fn];
+      lua_pushinteger(L, [evNumber intValue]);
+      [skin protectedCallAndError:@"hs.noises callback" nargs:1 nresults:0];
+      _lua_stackguard_exit(L);
+  }
 }
 @end
 

--- a/extensions/screen/watcher.m
+++ b/extensions/screen/watcher.m
@@ -26,6 +26,16 @@ static int refTable;
 @end
 
 @implementation MJScreenWatcher
+
+- (instancetype)init {
+    self = [super init] ;
+    if (self) {
+        _fn            = LUA_NOREF ;
+        _includeActive = NO ;
+    }
+    return self ;
+}
+
 - (void) _screensChanged:(id)note {
     [self performSelectorOnMainThread:@selector(screensChanged:)
                                         withObject:note
@@ -33,21 +43,23 @@ static int refTable;
 }
 
 - (void) screensChanged:(NSNotification*)note {
-    LuaSkin *skin = [LuaSkin shared];
-    lua_State *L = skin.L;
-    _lua_stackguard_entry(skin.L);
-    int argCount = _includeActive ? 1 : 0;
+    if (self.fn != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared];
+        lua_State *L = skin.L;
+        _lua_stackguard_entry(skin.L);
+        int argCount = _includeActive ? 1 : 0;
 
-    [skin pushLuaRef:refTable ref:self.fn];
-    if (_includeActive) {
-        if ([note.name isEqualToString:@"NSWorkspaceActiveDisplayDidChangeNotification"]) {
-            lua_pushboolean(L, YES);
-        } else {
-            lua_pushnil(L);
+        [skin pushLuaRef:refTable ref:self.fn];
+        if (_includeActive) {
+            if ([note.name isEqualToString:@"NSWorkspaceActiveDisplayDidChangeNotification"]) {
+                lua_pushboolean(L, YES);
+            } else {
+                lua_pushnil(L);
+            }
         }
+        [skin protectedCallAndError:@"hs.screen.watcher callback" nargs:argCount nresults:0];
+        _lua_stackguard_exit(skin.L);
     }
-    [skin protectedCallAndError:@"hs.screen.watcher callback" nargs:argCount nresults:0];
-    _lua_stackguard_exit(skin.L);
 }
 @end
 

--- a/extensions/socket/udp.m
+++ b/extensions/socket/udp.m
@@ -19,36 +19,42 @@ static const char *USERDATA_TAG = "hs.socket.udp";
 // Lua callbacks
 static void connectCallback(HSAsyncUdpSocket *asyncUdpSocket) {
     mainThreadDispatch(
-        LuaSkin *skin = [LuaSkin shared];
-        _lua_stackguard_entry(skin.L);
-        [skin pushLuaRef:refTable ref:asyncUdpSocket.connectCallback];
-        asyncUdpSocket.connectCallback = [skin luaUnref:refTable ref:asyncUdpSocket.connectCallback];
-        [skin protectedCallAndError:@"hs.socket.udp:connect" nargs:0 nresults:0];
-        _lua_stackguard_exit(skin.L);
+        if (asyncUdpSocket.connectCallback != LUA_NOREF) {
+            LuaSkin *skin = [LuaSkin shared];
+            _lua_stackguard_entry(skin.L);
+            [skin pushLuaRef:refTable ref:asyncUdpSocket.connectCallback];
+            asyncUdpSocket.connectCallback = [skin luaUnref:refTable ref:asyncUdpSocket.connectCallback];
+            [skin protectedCallAndError:@"hs.socket.udp:connect" nargs:0 nresults:0];
+            _lua_stackguard_exit(skin.L);
+        }
     );
 }
 
 static void writeCallback(HSAsyncUdpSocket *asyncUdpSocket, long tag) {
     mainThreadDispatch(
-        LuaSkin *skin = [LuaSkin shared];
-        _lua_stackguard_entry(skin.L);
-        [skin pushLuaRef:refTable ref:asyncUdpSocket.writeCallback];
-        [skin pushNSObject: @(tag)];
-        asyncUdpSocket.writeCallback = [skin luaUnref:refTable ref:asyncUdpSocket.writeCallback];
-        [skin protectedCallAndError:@"hs.socket.udp:write callback" nargs:1 nresults:0];
-        _lua_stackguard_exit(skin.L);
+        if (asyncUdpSocket.writeCallback != LUA_NOREF) {
+            LuaSkin *skin = [LuaSkin shared];
+            _lua_stackguard_entry(skin.L);
+            [skin pushLuaRef:refTable ref:asyncUdpSocket.writeCallback];
+            [skin pushNSObject: @(tag)];
+            asyncUdpSocket.writeCallback = [skin luaUnref:refTable ref:asyncUdpSocket.writeCallback];
+            [skin protectedCallAndError:@"hs.socket.udp:write callback" nargs:1 nresults:0];
+            _lua_stackguard_exit(skin.L);
+        }
     );
 }
 
 static void readCallback(HSAsyncUdpSocket *asyncUdpSocket, NSData *data, NSData *address) {
     mainThreadDispatch(
-        LuaSkin *skin = [LuaSkin shared];
-        _lua_stackguard_entry(skin.L);
-        [skin pushLuaRef:refTable ref:asyncUdpSocket.readCallback];
-        [skin pushNSObject: [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]];
-        [skin pushNSObject: address];
-        [skin protectedCallAndError:@"hs.socket.udp:read callback" nargs:2 nresults:0];
-        _lua_stackguard_exit(skin.L);
+        if (asyncUdpSocket.readCallback != LUA_NOREF) {
+            LuaSkin *skin = [LuaSkin shared];
+            _lua_stackguard_entry(skin.L);
+            [skin pushLuaRef:refTable ref:asyncUdpSocket.readCallback];
+            [skin pushNSObject: [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]];
+            [skin pushNSObject: address];
+            [skin protectedCallAndError:@"hs.socket.udp:read callback" nargs:2 nresults:0];
+            _lua_stackguard_exit(skin.L);
+        }
     );
 }
 

--- a/extensions/spaces/watcher.m
+++ b/extensions/spaces/watcher.m
@@ -33,14 +33,16 @@ typedef struct _spacewatcher_t {
 
 // Call the lua callback function.
 - (void)callback:(NSDictionary* __unused)dict withSpace:(int)space {
-    LuaSkin *skin = [LuaSkin shared];
-    lua_State *L = skin.L;
-    _lua_stackguard_entry(L);
+    if (self.object->fn != LUA_NOREF) {
+        LuaSkin *skin = [LuaSkin shared];
+        lua_State *L = skin.L;
+        _lua_stackguard_entry(L);
 
-    [skin pushLuaRef:refTable ref:self.object->fn];
-    lua_pushinteger(L, space);
-    [skin protectedCallAndError:@"hs.spaces.watcher callback" nargs:1 nresults:0];
-    _lua_stackguard_exit(L);
+        [skin pushLuaRef:refTable ref:self.object->fn];
+        lua_pushinteger(L, space);
+        [skin protectedCallAndError:@"hs.spaces.watcher callback" nargs:1 nresults:0];
+        _lua_stackguard_exit(L);
+    }
 }
 
 - (void)spaceChanged:(NSNotification*)notification {

--- a/extensions/webview/datastore.m
+++ b/extensions/webview/datastore.m
@@ -11,6 +11,8 @@
 /// The datastore for a webview contains various types of data including cookies, disk and memory caches, and persistent data such as WebSQL, IndexedDB databases, and local storage.  You can use methods in this module to selectively or completely purge the common datastore (used by all Hammerspoon `hs.webview` instances that do not use a non-persistent datastore).
 static int refTable = LUA_NOREF;
 
+static NSMutableSet *backgroundCallbacks ;
+
 #pragma mark - Support Functions and Classes
 
 #pragma mark - Module Functions
@@ -132,13 +134,14 @@ static int datastore_fetchRecords(lua_State *L) {
     LuaSkin *skin = [LuaSkin shared] ;
     [skin checkArgs:LS_TUSERDATA, USERDATA_DS_TAG,
                     LS_TSTRING | LS_TTABLE | LS_TFUNCTION,
-                    LS_TFUNCTION, LS_TBREAK] ;
+                    LS_TFUNCTION | LS_TOPTIONAL, LS_TBREAK] ;
 
     WKWebsiteDataStore *dataStore = [skin toNSObjectAtIndex:1] ;
     NSArray            *dataTypes = [[WKWebsiteDataStore allWebsiteDataTypes] allObjects] ;
 
     lua_pushvalue(L, lua_gettop(L)) ;
     int fnRef = [skin luaRef:refTable] ;
+    [backgroundCallbacks addObject:@(fnRef)] ;
 
     if (lua_type(L, 2) == LUA_TSTRING) {
         dataTypes = [NSArray arrayWithObject:[skin toNSObjectAtIndex:2]] ;
@@ -165,10 +168,14 @@ static int datastore_fetchRecords(lua_State *L) {
 
     [dataStore fetchDataRecordsOfTypes:typeSet completionHandler:^(NSArray *records){
         dispatch_async(dispatch_get_main_queue(), ^{
-            [skin pushLuaRef:refTable ref:fnRef] ;
-            [skin pushNSObject:records] ;
-            [skin protectedCallAndError:@"hs.webview.datastore:fetchRecords callback" nargs:1 nresults:0];
-            [skin luaUnref:refTable ref:fnRef] ;
+            if ([backgroundCallbacks containsObject:@(fnRef)]) {
+                LuaSkin *_skin = [LuaSkin shared] ;
+                [_skin pushLuaRef:refTable ref:fnRef] ;
+                [_skin pushNSObject:records] ;
+                [_skin protectedCallAndError:@"hs.webview.datastore:fetchRecords callback" nargs:1 nresults:0];
+                [_skin luaUnref:refTable ref:fnRef] ;
+                [backgroundCallbacks removeObject:@(fnRef)] ;
+            }
         }) ;
     }] ;
 
@@ -247,6 +254,7 @@ static int datastore_removeRecords(lua_State *L) {
     if (lua_type(L, 4) == LUA_TFUNCTION) {
         lua_pushvalue(L, 4) ;
         fnRef = [skin luaRef:refTable] ;
+        [backgroundCallbacks addObject:@(fnRef)] ;
     }
 
     [dataStore fetchDataRecordsOfTypes:typeSet completionHandler:^(NSArray *records){
@@ -261,10 +269,12 @@ static int datastore_removeRecords(lua_State *L) {
 
         [dataStore removeDataOfTypes:typeSet forDataRecords:targets completionHandler:^{
             dispatch_async(dispatch_get_main_queue(), ^{
-                if (fnRef != LUA_NOREF) {
-                    [skin pushLuaRef:refTable ref:fnRef] ;
-                    [skin protectedCallAndError:@"hs.webview.datastore:removeRecordsFor callback" nargs:0 nresults:0];
-                    [skin luaUnref:refTable ref:fnRef] ;
+                if (fnRef != LUA_NOREF && [backgroundCallbacks containsObject:@(fnRef)]) {
+                    LuaSkin *_skin = [LuaSkin shared] ;
+                    [_skin pushLuaRef:refTable ref:fnRef] ;
+                    [_skin protectedCallAndError:@"hs.webview.datastore:removeRecordsFor callback" nargs:0 nresults:0];
+                    [_skin luaUnref:refTable ref:fnRef] ;
+                    [backgroundCallbacks removeObject:@(fnRef)] ;
                 }
             }) ;
         }] ;
@@ -348,15 +358,18 @@ static int datastore_removeDataFrom(lua_State *L) {
     if (lua_type(L, 4) == LUA_TFUNCTION) {
         lua_pushvalue(L, 4) ;
         fnRef = [skin luaRef:refTable] ;
+        [backgroundCallbacks addObject:@(fnRef)] ;
     }
 
 
     [dataStore removeDataOfTypes:typeSet modifiedSince:theDate completionHandler:^{
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (fnRef != LUA_NOREF) {
-                [skin pushLuaRef:refTable ref:fnRef] ;
-                [skin protectedCallAndError:@"hs.webview.datastore:removeRecordsAfter callback" nargs:0 nresults:0];
-                [skin luaUnref:refTable ref:fnRef] ;
+            if (fnRef != LUA_NOREF && [backgroundCallbacks containsObject:@(fnRef)]) {
+                LuaSkin *_skin = [LuaSkin shared] ;
+                [_skin pushLuaRef:refTable ref:fnRef] ;
+                [_skin protectedCallAndError:@"hs.webview.datastore:removeRecordsAfter callback" nargs:0 nresults:0];
+                [_skin luaUnref:refTable ref:fnRef] ;
+                [backgroundCallbacks removeObject:@(fnRef)] ;
             }
         }) ;
     }] ;
@@ -460,9 +473,14 @@ static int userdata_gc(lua_State* L) {
     return 0 ;
 }
 
-// static int meta_gc(lua_State* __unused L) {
-//     return 0 ;
-// }
+static int meta_gc(lua_State* __unused L) {
+    LuaSkin *skin = [LuaSkin shared] ;
+    [backgroundCallbacks enumerateObjectsUsingBlock:^(NSNumber *ref, __unused BOOL *stop) {
+        [skin luaUnref:refTable ref:ref.intValue] ;
+    }] ;
+    [backgroundCallbacks removeAllObjects] ;
+    return 0;
+}
 
 // Metatable for userdata objects
 static const luaL_Reg userdata_metaLib[] = {
@@ -487,11 +505,11 @@ static luaL_Reg moduleLib[] = {
     {NULL,               NULL}
 };
 
-// // Metatable for module, if needed
-// static const luaL_Reg module_metaLib[] = {
-//     {"__gc", meta_gc},
-//     {NULL,   NULL}
-// };
+// Metatable for module, if needed
+static const luaL_Reg module_metaLib[] = {
+    {"__gc", meta_gc},
+    {NULL,   NULL}
+};
 
 // NOTE: ** Make sure to change luaopen_..._internal **
 int luaopen_hs_webview_datastore(lua_State* L) {
@@ -503,7 +521,7 @@ int luaopen_hs_webview_datastore(lua_State* L) {
     } else {
         refTable = [skin registerLibraryWithObject:USERDATA_DS_TAG
                                          functions:moduleLib
-                                     metaFunctions:nil    // or module_metaLib
+                                     metaFunctions:module_metaLib
                                    objectFunctions:userdata_metaLib];
 
         [skin registerPushNSHelper:pushWKWebsiteDataStore         forClass:"WKWebsiteDataStore"];
@@ -512,5 +530,6 @@ int luaopen_hs_webview_datastore(lua_State* L) {
         [skin registerLuaObjectHelper:toWKWebsiteDataStoreFromLua forClass:"WKWebsiteDataStore"
                                                  withUserdataMapping:USERDATA_DS_TAG];
     }
+    backgroundCallbacks = [NSMutableSet set] ;
     return 1;
 }

--- a/extensions/webview/internal.m
+++ b/extensions/webview/internal.m
@@ -1175,12 +1175,14 @@ static int webview_reload(lua_State *L) {
 
     if (theView.loading) [theView stopLoading] ;
     while (theView.loading) {}
+    BOOL validate = (lua_type(L, 2) == LUA_TBOOLEAN) ? (BOOL)lua_toboolean(L, 2) : NO ;
+
     dispatch_async(dispatch_get_main_queue(), ^{
         WKNavigation *navID ;
-        if (lua_type(L, 2) == LUA_TBOOLEAN && lua_toboolean(L, 2))
-            navID = [theView reload] ;
-        else
+        if (validate)
             navID = [theView reloadFromOrigin] ;
+        else
+            navID = [theView reload] ;
         theView.trackingID = navID ;
     }) ;
     lua_pushvalue(L, 1) ;

--- a/extensions/wifi/watcher.m
+++ b/extensions/wifi/watcher.m
@@ -172,8 +172,8 @@ static HSWifiWatcherManager *manager ;
     }
     [_watchers enumerateObjectsUsingBlock:^(HSWifiWatcher *aWatcher, __unused BOOL *stop) {
         if ([aWatcher.watchingFor containsObject:message]) {
-            if (aWatcher.callbackRef != LUA_NOREF) {
-                dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (aWatcher.callbackRef != LUA_NOREF) {
                     LuaSkin *skin = [LuaSkin shared] ;
                     _lua_stackguard_entry(skin.L);
                     [skin pushLuaRef:refTable ref:aWatcher.callbackRef] ;
@@ -188,8 +188,8 @@ static HSWifiWatcherManager *manager ;
                     }
                     [skin protectedCallAndError:[NSString stringWithFormat:@"hs.wifi.watcher callback for %@", message] nargs:(2 + (int)count) nresults:0];
                     _lua_stackguard_exit(skin.L);
-                }) ;
-            }
+                }
+            }) ;
         }
     }] ;
 }


### PR DESCRIPTION
May change title later, as I suspect I'll add more as I do the changes for proper coroutine support; however, as that's going onto a separate branch for the purposes of testing before formally releasing it into the wild, I figured some of other bugs I'm finding along the way should probably be applied to master in the mean time...

Currently:

* `hs.webview.toolbar` checked for valid fn ref before dispatch, but not within, so could crash if callback disappeared (e.g. __gc)
* `hs.webview.reload` checked lua stack within dispatch for parameter *after* stack purged, so `validate` parameter was being ignored; in addition, the logic was inverted from the docs

