### PR TITLE
Use key name as alert message when binding hotkeys for Spoons

### DIFF
--- a/SPOONS.md
+++ b/SPOONS.md
@@ -120,13 +120,13 @@ If your Spoon provides some kind of background activity, e.g. timers, watchers, 
 #### Hotkeys
 
 If your Spoon provides actions that a user can map to hotkeys, you should expose a `:bindHotKeys()` method. The method should accept a single parameter, which is a table.
-The keys of the table should be strings that describe the action performed by the hotkeys, and the values of the table should be tables containing modifiers and keynames/keycodes.
+The keys of the table should be strings that describe the action performed by the hotkeys, and the values of the table should be tables containing modifiers and keynames/keycodes and, optionally, a message to be displayed via `hs.alert()` when the hotkey has been triggered.
 
 For example, if the user wants to map two of your actions, `show` and `hide`, they would pass in:
 
 ```lua
   {
-    show={{"cmd", "alt"}, "s"},
+    show={{"cmd", "alt"}, "s", message="Show"},
     hide={{"cmd", "alt"}, "h"}
   }
 ```

--- a/extensions/spoons/init.lua
+++ b/extensions/spoons/init.lua
@@ -126,7 +126,7 @@ end
 ---
 --- Parameters:
 ---  * def - table containing name-to-function definitions for the hotkeys supported by the Spoon. Each key is a hotkey name, and its value must be a function that will be called when the hotkey is invoked.
----  * map - table containing name-to-hotkey definitions, as supported by [bindHotkeys in the Spoon API](https://github.com/Hammerspoon/hammerspoon/blob/master/SPOONS.md#hotkeys). Not all the entries in `def` must be bound, but if any keys in `map` don't have a definition, an error will be produced.
+---  * map - table containing name-to-hotkey definitions and an optional message to be displayed via `hs.alert()` when the hotkey has been triggered, as supported by [bindHotkeys in the Spoon API](https://github.com/Hammerspoon/hammerspoon/blob/master/SPOONS.md#hotkeys). Not all the entries in `def` must be bound, but if any keys in `map` don't have a definition, an error will be produced.
 ---
 --- Returns:
 ---  * None
@@ -138,7 +138,7 @@ function module.bindHotkeysToSpec(def,map)
          if module._keys[keypath] then
             module._keys[keypath]:delete()
          end
-         module._keys[keypath]=hotkey.bindSpec(key, def[name])
+         module._keys[keypath]=hotkey.bindSpec(key, key["message"], def[name])
       else
          log.ef("Error: Hotkey requested for undefined action '%s'", name)
       end


### PR DESCRIPTION
I wanted to remove the need to rewrite the body of `hs.spoons.bindHotKeysToSpec` for each new Spoon if I wanted to include the hotkey name as an alert message.

I thought about adding a new optional name-to-message map to the function but decided making the smaller change introduced less risk and would also encourage Spoon authors to use thoughtful and descriptive naming for their hotkey names.

If a user does not want to show the alert for hotkeys as per current behaviour when using  `hs.spoons.bindHotKeysToSpec` then they can simply set the `hs.hotkey.alertDuration` to 0.