### PR TITLE
make HSuicore coroutine friendly

### DIFF
--- a/Hammerspoon/HSuicore.h
+++ b/Hammerspoon/HSuicore.h
@@ -11,11 +11,11 @@
 @property (nonatomic, getter=isHidden, setter=setHidden:) BOOL hidden;
 
 // Simplest class methods that just return an application
-+(HSapplication *)frontmostApplication;
++(HSapplication *)frontmostApplicationWithState:(lua_State *)L;
 
 // Class methods that return an application matching a criteria
-+(HSapplication *)applicationForPID:(pid_t)pid;
-+(HSapplication *)applicationForNSRunningApplication:(NSRunningApplication *)app;
++(HSapplication *)applicationForPID:(pid_t)pid withState:(lua_State *)L;
++(HSapplication *)applicationForNSRunningApplication:(NSRunningApplication *)app withState:(lua_State *)L;
 
 // Class methods that return application metadata based on an argument
 +(NSString *)nameForBundleID:(NSString *)bundleID;
@@ -24,8 +24,8 @@
 +(NSDictionary *)infoForBundlePath:(NSString *)bundlePath;
 
 // Class methods that return arrays of applications
-+(NSArray<HSapplication *>*)runningApplications;
-+(NSArray<HSapplication *>*)applicationsForBundleID:(NSString *)bundleID;
++(NSArray<HSapplication *>*)runningApplicationsWithState:(lua_State *)L;
++(NSArray<HSapplication *>*)applicationsForBundleID:(NSString *)bundleID withState:(lua_State *)L;
 
 // Class methods that launch applications
 +(BOOL)launchByName:(NSString *)name;
@@ -36,8 +36,8 @@
 -(BOOL)isHidden;
 
 // Initialisers
--(HSapplication *)initWithPid:(pid_t)pid;
--(HSapplication *)initWithNSRunningApplication:(NSRunningApplication *)app;
+-(HSapplication *)initWithPid:(pid_t)pid withState:(lua_State *)L;
+-(HSapplication *)initWithNSRunningApplication:(NSRunningApplication *)app withState:(lua_State *)L;
 
 // Destructor
 -(void)dealloc;
@@ -48,7 +48,7 @@
 -(id)focusedWindow;
 -(BOOL)activate:(BOOL)allWindows;
 -(BOOL)isResponsive;
--(BOOL)isRunning;
+-(BOOL)isRunningWithState:(lua_State *)L;
 -(BOOL)setFrontmost:(BOOL)allWindows;
 -(BOOL)isFrontmost;
 -(NSString *)title;
@@ -99,7 +99,7 @@
 -(HSuielementWatcher *)initWithElement:(HSuielement *)element callbackRef:(int)callbackRef userdataRef:(int)userdataRef;
 -(void)dealloc;
 
--(void)start:(NSArray <NSString *>*)events;
+-(void)start:(NSArray <NSString *>*)events withState:(lua_State *)L;
 -(void)stop;
 @end
 

--- a/extensions/application/internal.m
+++ b/extensions/application/internal.m
@@ -30,7 +30,7 @@ static int application_gc(lua_State* L) {
 static int application_frontmostapplication(lua_State* L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TBREAK];
-    [skin pushNSObject:[HSapplication frontmostApplication]];
+    [skin pushNSObject:[HSapplication frontmostApplicationWithState:L]];
     return 1;
 }
 
@@ -46,7 +46,7 @@ static int application_frontmostapplication(lua_State* L) {
 static int application_runningapplications(lua_State* L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TBREAK];
-    NSArray *apps = [HSapplication runningApplications];
+    NSArray *apps = [HSapplication runningApplicationsWithState:L];
     [skin pushNSObject:apps];
     return 1;
 }
@@ -64,7 +64,7 @@ static int application_applicationforpid(lua_State* L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TNUMBER, LS_TBREAK];
     pid_t pid = (pid_t)lua_tointeger(L, 1);
-    [skin pushNSObject:[HSapplication applicationForPID:pid]];
+    [skin pushNSObject:[HSapplication applicationForPID:pid withState:L]];
     return 1;
 }
 
@@ -80,7 +80,7 @@ static int application_applicationforpid(lua_State* L) {
 static int application_applicationsForBundleID(lua_State* L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TSTRING, LS_TBREAK];
-    [skin pushNSObject:[HSapplication applicationsForBundleID:[skin toNSObjectAtIndex:1]]];
+    [skin pushNSObject:[HSapplication applicationsForBundleID:[skin toNSObjectAtIndex:1] withState:L]];
     return 1;
 }
 
@@ -332,7 +332,7 @@ static int application_isRunning(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
     HSapplication *app = [skin toNSObjectAtIndex:1];
-    lua_pushboolean(L, [app isRunning]);
+    lua_pushboolean(L, [app isRunningWithState:L]);
     return 1;
 }
 

--- a/extensions/application/watcher.m
+++ b/extensions/application/watcher.m
@@ -103,7 +103,7 @@ typedef enum _event_t {
 
     lua_pushinteger(L, event); // Parameter 2: the event type
 
-    HSapplication *application = [HSapplication applicationForNSRunningApplication:app];
+    HSapplication *application = [HSapplication applicationForNSRunningApplication:app withState:L];
     [skin pushNSObject:application];
 
     [skin protectedCallAndError:@"hs.application.watcher callback" nargs:3 nresults:0];

--- a/extensions/uielement/watcher.m
+++ b/extensions/uielement/watcher.m
@@ -38,7 +38,7 @@ static int watcher_new(lua_State* L) {
     if (lua_type(L, 3) != LUA_TNONE) {
         userdataRef = [skin luaRef:refTable atIndex:3];
     }
-    
+
     // FIXME move reftable to an argument for newWatcher
     HSuielementWatcher *watcher = [element newWatcher:callbackRef withUserdata:userdataRef];
     watcher.refTable = refTable;
@@ -50,7 +50,7 @@ static int watcher_start(lua_State* L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TTABLE, LS_TBREAK];
     HSuielementWatcher *watcher = [skin toNSObjectAtIndex:1];
-    [watcher start:[skin toNSObjectAtIndex:2]];
+    [watcher start:[skin toNSObjectAtIndex:2] withState:L];
     lua_pushvalue(L, 1);
     return 1;
 }

--- a/extensions/window/internal.m
+++ b/extensions/window/internal.m
@@ -446,7 +446,7 @@ static int window_application(lua_State* L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
     HSwindow *win = [skin toNSObjectAtIndex:1];
-    HSapplication *app = [[HSapplication alloc] initWithPid:win.pid];
+    HSapplication *app = [[HSapplication alloc] initWithPid:win.pid withState:L];
     [skin pushNSObject:app];
     return 1;
 }


### PR DESCRIPTION
Because HSuicore methods are called from module functions, they have to be state aware to be coroutine safe.

Should fix at least some of #2339