### PR TITLE
Update CocoaAsyncSocket from 7.6.3 to 7.6.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ project 'Hammerspoon', 'Profile' => :debug
 target 'Hammerspoon' do
 pod 'ASCIImage', '1.0.0'
 pod 'CocoaLumberjack', '3.5.3'
-pod 'CocoaAsyncSocket', '7.6.3'
+pod 'CocoaAsyncSocket', '7.6.4'
 pod 'CocoaHTTPServer', '2.3'
 pod 'PocketSocket/Client', '1.0.1'
 pod 'Crashlytics', '3.14.0'


### PR DESCRIPTION
Release notes can be found [here](https://github.com/robbiehanson/CocoaAsyncSocket/releases/tag/7.6.4).