### PR TITLE
create invalidCallback for hs.chooser

### DIFF
--- a/extensions/chooser/HSChooser.h
+++ b/extensions/chooser/HSChooser.h
@@ -53,6 +53,7 @@
 @property(nonatomic) int queryChangedCallbackRef;
 @property(nonatomic) int completionCallbackRef;
 @property(nonatomic) int rightClickCallbackRef;
+@property(nonatomic) int invalidCallbackRef;
 
 // A pointer to the hs.chooser module's references table
 @property(nonatomic) int *refTable;

--- a/extensions/chooser/internal.m
+++ b/extensions/chooser/internal.m
@@ -123,6 +123,7 @@ static int chooserIsVisible(lua_State *L) {
 ///  * Each choice may also optionally contain the following keys:
 ///   * subText - A string or hs.styledtext object that will be shown underneath the main text of the choice
 ///   * image - An `hs.image` image object that will be displayed next to the choice
+///   * valid - A boolean that defaults to `true`, if set to `false` selecting the choice will invoke the `invalidCallback` method instead of dismissing the chooser
 ///  * Any other keys/values in each choice table will be retained by the chooser and returned to the completion callback when a choice is made. This is useful for storing UUIDs or other non-user-facing information, however, it is important to note that you should not store userdata objects in the table - it is run through internal conversion functions, so only basic Lua types should be stored.
 ///  * If a function is given, it will be called once, when the chooser window is displayed. The results are then cached until this method is called again, or `hs.chooser:refreshChoicesCallback()` is called.
 ///  * If you're using a hs.styledtext object for text or subText choices, make sure you specify a color, otherwise your text could appear transparent depending on the bgDark setting.

--- a/extensions/chooser/internal.m
+++ b/extensions/chooser/internal.m
@@ -413,6 +413,35 @@ static int chooserRightClickCallback(lua_State *L) {
     return 1;
 }
 
+/// hs.chooser:invalidCallback([fn]) -> hs.chooser object
+/// Method
+/// Sets/clears a callback for invalid choices
+///
+/// Parameters:
+///  * fn - An optional function that will be called whenever the user select an choice set as invalid. If this parameter is omitted, the existing callback will be removed.
+///
+/// Returns:
+///  * The `hs.chooser` object
+///
+/// Notes:
+///   * The callback may accept one argument, it will be a table containing whatever information you supplied for the item the user chose.
+///   * To display a context menu, see `hs.menubar`, specifically the `:popupMenu()` method
+static int chooserInvalidCallback(lua_State *L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION|LS_TOPTIONAL, LS_TBREAK];
+
+    HSChooser *chooser = [skin toNSObjectAtIndex:1];
+
+    chooser.invalidCallbackRef = [skin luaUnref:refTable ref:chooser.invalidCallbackRef];
+
+    if (lua_type(L, 2) == LUA_TFUNCTION) {
+        chooser.invalidCallbackRef = [skin luaRef:refTable atIndex:2];
+    }
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
 /// hs.chooser:delete()
 /// Method
 /// Deletes a chooser
@@ -818,6 +847,7 @@ static int userdata_gc(lua_State* L) {
             chooser.queryChangedCallbackRef = [skin luaUnref:refTable ref:chooser.queryChangedCallbackRef];
             chooser.completionCallbackRef = [skin luaUnref:refTable ref:chooser.completionCallbackRef];
             chooser.rightClickCallbackRef = [skin luaUnref:refTable ref:chooser.rightClickCallbackRef];
+            chooser.invalidCallbackRef = [skin luaUnref:refTable ref:chooser.invalidCallbackRef];
             chooser.isObservingThemeChanges = NO;  // Stop observing for interface theme changes.
 
             NSWindow *theWindow = chooser.window ;
@@ -855,6 +885,7 @@ static const luaL_Reg userdataLib[] = {
     {"delete", chooserDelete},
     {"refreshChoicesCallback", chooserRefreshChoicesCallback},
     {"rightClickCallback", chooserRightClickCallback},
+    {"invalidCallback", chooserInvalidCallback},
     {"selectedRow", chooserSelectedRow},
     {"selectedRowContents", chooserSelectedRowContents},
     {"select", chooserSelect},


### PR DESCRIPTION
Create an `invalidCallback` method for `hs.chooser`.

Similar to the the valid property of Alfred's script filter items. [alfred.com#script-filter](https://www.alfredapp.com/help/workflows/inputs/script-filter/json/)

This add an optional `valid` property to `hs.chooser` choices that default to `true`, if set to false when the choice is selected the `invalidCallback` will be invoked instead of the `completionCallback` and the chooser interface will stay instead of hiding.

This allows for example multi-step workflows with the Seal Spoon and can be used as an alternative to Alfred.

Example use case for an App manager:
* Fuzzy search the name of a running application
  - All choices have `valid` propriety set to `false`
* The user press enter
  - The `invalidCallback` method is invoked
  - Autocomplete the name of the selected app
  - Change to choices related to the app
    * All choices have `valid` propriety set to `true`
    * All choices have a custom function
* The user press enter
  - The `completionCallback` is invoked
  - The choice custom function is invoked

