### PR TITLE
add caveat in timer extension

### DIFF
--- a/extensions/timer/init.lua
+++ b/extensions/timer/init.lua
@@ -1,6 +1,10 @@
 --- === hs.timer ===
 ---
 --- Execute functions with various timing rules
+---
+--- **NOTE**: timers use NSTimer internally, which will be paused when computers sleep.
+--- Especially, repeating timers won't be triggered at the specificed time when there are sleeps in between.
+--- The workaround is to prevent system from sleeping, configured in Energy Saver in System Preferences.
 
 local module = require("hs.timer.internal")
 local log=require'hs.logger'.new('timer',3)


### PR DESCRIPTION
The issue was raised in #1942 
Before a better fix (I'm thinking to recalculate fire date when waking up), it's good to let users know.