### PR TITLE
Updated www.hammerspoon.org URLs to use HTTPS

### DIFF
--- a/Hammerspoon/Hammerspoon-Info.plist
+++ b/Hammerspoon/Hammerspoon-Info.plist
@@ -278,7 +278,7 @@
 			<key>UTTypeIdentifier</key>
 			<string>org.hammerspoon.Hammerspoon.Spoon</string>
 			<key>UTTypeReferenceURL</key>
-			<string>http://www.hammerspoon.org/</string>
+			<string>https://www.hammerspoon.org/</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>

--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -53,7 +53,7 @@ void MJLuaSetupLogHandler(void(^blk)(NSString* str)) {
 ///
 /// Notes:
 ///  * If at all possible, please do allow Hammerspoon to upload crash reports to us, it helps a great deal in keeping Hammerspoon stable
-///  * Our Privacy Policy can be found here: [http://www.hammerspoon.org/privacy.html](http://www.hammerspoon.org/privacy.html)
+///  * Our Privacy Policy can be found here: [https://www.hammerspoon.org/privacy.html](https://www.hammerspoon.org/privacy.html)
 static int core_uploadCrashData(lua_State* L) {
     if (lua_isboolean(L, 1)) { HSSetUploadCrashData(lua_toboolean(L, 1)); }
     lua_pushboolean(L, HSUploadCrashData()) ;

--- a/Hammerspoon/MJPreferencesWindowController.m
+++ b/Hammerspoon/MJPreferencesWindowController.m
@@ -200,7 +200,7 @@ void PreferencesDarkModeSetEnabled(BOOL enabled) {
 }
 
 - (IBAction) privacyPolicyClicked:(id)sender {
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"http://www.hammerspoon.org/privacy"]];
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://www.hammerspoon.org/privacy"]];
 }
 
 - (void) dockMenuProblemAlertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo {

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ What gives Hammerspoon its power is a set of extensions that expose specific pie
 ### Manually
  * Download the [latest release](https://github.com/Hammerspoon/hammerspoon/releases/latest)
  * Drag `Hammerspoon.app` from your `Downloads` folder to `Applications`
- 
+
 ### Homebrew
   * `brew cask install hammerspoon`
 
 ## What next?
 
 Out of the box, Hammerspoon does nothing - you will need to create `~/.hammerspoon/init.lua` and fill it with useful code. There are several resources which can help you:
- * [Getting Started Guide](http://www.hammerspoon.org/go/)
- * [API docs](http://www.hammerspoon.org/docs/)
- * [FAQ](http://www.hammerspoon.org/faq/)
+ * [Getting Started Guide](https://www.hammerspoon.org/go/)
+ * [API docs](https://www.hammerspoon.org/docs/)
+ * [FAQ](https://www.hammerspoon.org/faq/)
  * [Sample Configurations](https://github.com/Hammerspoon/hammerspoon/wiki/Sample-Configurations) supplied by various users
  * [Contribution Guide](https://github.com/Hammerspoon/hammerspoon/blob/master/CONTRIBUTING.md) for developers looking to get involved
  * An IRC channel for general chat/support/development (#hammerspoon on Freenode) with [searchable archives](https://botbot.me/freenode/hammerspoon/)

--- a/SPOONS.md
+++ b/SPOONS.md
@@ -35,7 +35,7 @@ This is possible because of two things:
 
 ## Where do I get Spoons from?
 
-The official repository of Spoons is [http://www.hammerspoon.org/Spoons](http://www.hammerspoon.org/Spoons) (the source for which can be found at [https://github.com/Hammerspoon/Spoons](https://github.com/Hammerspoon/Spoons)), but authors may choose to distribute them separately from their own sites.
+The official repository of Spoons is [https://www.hammerspoon.org/Spoons](https://www.hammerspoon.org/Spoons) (the source for which can be found at [https://github.com/Hammerspoon/Spoons](https://github.com/Hammerspoon/Spoons)), but authors may choose to distribute them separately from their own sites.
 
 ## How do I install a Spoon?
 
@@ -164,7 +164,7 @@ By convention in Hammerspoon, methods tend to return the object they belong to (
 #### Generating
 
 Several tools are able to operate on the docstrings used by Hammerspoon and Spoons. In the simplest case, each Spoon should include a `docs.json` file which is little more than the various docstrings collected together.
-This file can be generated using the Hammerspoon command line tool (see [http://www.hammerspoon.org/docs/hs.ipc.html#cliInstall](http://www.hammerspoon.org/docs/hs.ipc.html#cliInstall)):
+This file can be generated using the Hammerspoon command line tool (see [https://www.hammerspoon.org/docs/hs.ipc.html#cliInstall](https://www.hammerspoon.org/docs/hs.ipc.html#cliInstall)):
 
 ```bash
 cd /path/too/your/Spoon

--- a/extensions/_coresetup/init.lua
+++ b/extensions/_coresetup/init.lua
@@ -623,7 +623,7 @@ coroutine.applicationYield = hs.coroutineApplicationYield
   if not hasinitfile then
     local notify = require("hs.notify")
     local printf = hs.printf
-    notify.register("__noinitfile", function() os.execute("open http://www.hammerspoon.org/go/") end)
+    notify.register("__noinitfile", function() os.execute("open https://www.hammerspoon.org/go/") end)
     notify.show("Hammerspoon", "No config file found", "Click here for the Getting Started Guide", "__noinitfile")
     printf("-- Can't find %s; create it and reload your config.", prettypath)
     return hs.completionsForInputString, runstring

--- a/extensions/doc/hsdocs/index.md
+++ b/extensions/doc/hsdocs/index.md
@@ -2,11 +2,11 @@
 
 Resource                 | Link
 -------------------------|---------------------------------------------------
-Website                   | http://www.hammerspoon.org/
+Website                   | https://www.hammerspoon.org/
 GitHub page               | https://github.com/Hammerspoon/hammerspoon
-Getting Started Guide     | http://www.hammerspoon.org/go/
+Getting Started Guide     | https://www.hammerspoon.org/go/
 Spoon Plugin Documentation| https://github.com/Hammerspoon/hammerspoon/blob/master/SPOONS.md
-Official Spoon repository | http://www.hammerspoon.org/Spoons
+Official Spoon repository | https://www.hammerspoon.org/Spoons
 IRC channel               | irc://chat.freenode.net/#hammerspoon
 Mailing list              | https://groups.google.com/forum/#!forum/hammerspoon/
-LuaSkin API docs          | http://www.hammerspoon.org/docs/LuaSkin/
+LuaSkin API docs          | https://www.hammerspoon.org/docs/LuaSkin/

--- a/extensions/doc/hsdocs/init.lua
+++ b/extensions/doc/hsdocs/init.lua
@@ -11,7 +11,7 @@
 ---  * Documentation for the LuaSkin Objective-C Framework
 ---  * Lua Reference documentation
 ---
---- The intent of this sub-module is to provide as close a rendering of the same documentation available at the Hammerspoon Github site and Dash documentation as possible in a manner suitable for run-time modification so module developers can test out documentation additions without requiring a complete recompilation of the Hammerspoon source.  As always, the most current and official documentation can be found at http://www.hammerspoon.org and in the official Hammerspoon Dash docset.
+--- The intent of this sub-module is to provide as close a rendering of the same documentation available at the Hammerspoon Github site and Dash documentation as possible in a manner suitable for run-time modification so module developers can test out documentation additions without requiring a complete recompilation of the Hammerspoon source.  As always, the most current and official documentation can be found at https://www.hammerspoon.org and in the official Hammerspoon Dash docset.
 
 local module  = {}
 -- private variables and methods -----------------------------------------

--- a/extensions/spoons/init.lua
+++ b/extensions/spoons/init.lua
@@ -2,7 +2,7 @@
 ---
 --- Utility and management functions for Spoons
 --- Spoons are Lua plugins for Hammerspoon.
---- See http://www.hammerspoon.org/Spoons/ for more information
+--- See https://www.hammerspoon.org/Spoons/ for more information
 
 if _G["spoon"] == nil then
   _G["spoon"] = {}

--- a/scripts/docs/bin/build_docs.py
+++ b/scripts/docs/bin/build_docs.py
@@ -36,21 +36,21 @@ TYPE_DESC = {
         "Deprecated": "API features which will be removed in an future "
                       "release"}
 LINKS = [
-        {"name": "Website", "url": "http://www.hammerspoon.org/"},
+        {"name": "Website", "url": "https://www.hammerspoon.org/"},
         {"name": "GitHub page",
          "url": "https://github.com/Hammerspoon/hammerspoon"},
         {"name": "Getting Started Guide",
-         "url": "http://www.hammerspoon.org/go/"},
+         "url": "https://www.hammerspoon.org/go/"},
         {"name": "Spoon Plugin Documentation",
          "url": "https://github.com/Hammerspoon/hammerspoon/blob/master/SPOONS.md"},
         {"name": "Official Spoon repository",
-         "url": "http://www.hammerspoon.org/Spoons"},
+         "url": "https://www.hammerspoon.org/Spoons"},
         {"name": "IRC channel",
          "url": "irc://chat.freenode.net/#hammerspoon"},
         {"name": "Mailing list",
          "url": "https://groups.google.com/forum/#!forum/hammerspoon/"},
         {"name": "LuaSkin API docs",
-         "url": "http://www.hammerspoon.org/docs/LuaSkin/"}
+         "url": "https://www.hammerspoon.org/docs/LuaSkin/"}
         ]
 
 ARGUMENTS = None

--- a/scripts/librelease.sh
+++ b/scripts/librelease.sh
@@ -452,7 +452,7 @@ function release_submit_dash_docs() {
       "archive": "Hammerspoon.tgz",
       "author": {
           "name": "Hammerspoon Team",
-          "link": "http://www.hammerspoon.org/"
+          "link": "https://www.hammerspoon.org/"
       },
       "aliases": [],
 
@@ -476,7 +476,7 @@ function release_update_appcast() {
         <item>
             <title>Version ${VERSION}</title>
             <sparkle:releaseNotesLink>
-                http://www.hammerspoon.org/releasenotes/${VERSION}.html
+                https://www.hammerspoon.org/releasenotes/${VERSION}.html
             </sparkle:releaseNotesLink>
             <pubDate>$(date +"%a, %e %b %Y %H:%M:%S %z")</pubDate>
             <enclosure url=\"https://github.com/Hammerspoon/hammerspoon/releases/download/${VERSION}/Hammerspoon-${VERSION}.zip\"
@@ -500,7 +500,7 @@ function release_tweet() {
   local CURRENT
   CURRENT=$(t accounts | grep -B1 active | head -1)
   t set active hammerspoon1
-  t update "Just released ${VERSION} - http://www.hammerspoon.org/releasenotes/"
+  t update "Just released ${VERSION} - https://www.hammerspoon.org/releasenotes/"
   t set active "$CURRENT"
 }
 


### PR DESCRIPTION
While navigating Hammerspoon documentation, I noticed I often ended up on non-TLS web pages. This is a bummer, since www.hammerspoon.org is set up just fine for HTTPS. This pull request tries to address that, updating Hammerspoon links where it seemed safe to do so.

A couple things to note:
- Hammerspoon's SSL cert is for [www.hammerspoon.org](https://www.hammerspoon.org), not [hammerspoon.org](https://hammerspoon.org). CertBot will happily issue certificates with Subject Alternative Names that work for multiple domains at once; this is recommended.
- I didn't update the URL in the rtf, due to principle of minimum possible changes and the existing link being to http://hammerspoon.org (the HTTPS version is not covered by the current LetsEncrypt certificate).
- HTTP links can also be mitigated by server config; redirect from HTTP to HTTPS and [add a HSTS header](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) to teach clients to always visit HTTPS.