### PR TITLE
Use standard subrole for canvas window

### DIFF
--- a/extensions/canvas/internal.m
+++ b/extensions/canvas/internal.m
@@ -901,7 +901,7 @@ static int userdata_gc(lua_State* L) ;
             return _subroleOverride ;
         }
     } else {
-        return [[super accessibilitySubrole] stringByAppendingString:@".Hammerspoon"] ;
+        return [super accessibilitySubrole] ;
     }
 }
 


### PR DESCRIPTION
I looked through the codebase but I could not find a good reason for having a non-standard subrole for canvas windows.

This would help yabai in [filtering out AXUnknown windows](https://github.com/koekeishiya/yabai/pull/636) and in [drawing a window stack indicator](https://github.com/AdamWagner/stackline/pull/14#issue-462606696) that only reacts to non-canvas windows