### PR TITLE
allow inverting custom subrole logic for canvas windows

### DIFF
--- a/extensions/drawing/canvasWrapper.lua
+++ b/extensions/drawing/canvasWrapper.lua
@@ -12,9 +12,9 @@ local drawingMT    = {}
 
 local newDrawing = function(...)
     local result = canvas.new(...)
-    if result then
-        result:_accessibilitySubrole("hammerspoonDrawing")
-    end
+--     if result then
+--         result:_accessibilitySubrole("hammerspoonDrawing")
+--     end
     return result
 end
 


### PR DESCRIPTION
Alternative to #2427 

With this pull, adding `hs.canvas.useCustomAccessibilitySubrole(false)` to your Hammerspoon `init.lua` file will ensure that all canvas objects use default Apple standard subroles by default. This should conform to what third-party accessibility enabled tools expect but may cause issues with `hs.window.filter` and other modules that can optionally use it (`hs.window.layout`, `hs.window.switcher`, etc.)