### PR TITLE
[READY] Fixed bug in hs.fs.urlFromPath()

### DIFF
--- a/extensions/fs/internal.m
+++ b/extensions/fs/internal.m
@@ -1112,7 +1112,8 @@ static int fs_urlFromPath(lua_State *L) {
         return 1;
     }
     
-    NSURL *fileURL = [[NSURL alloc] initFileURLWithPath:[NSString stringWithFormat:@"%s", absolutePath]];
+    NSString *urlPath = [[filePath stringByStandardizingPath] stringByResolvingSymlinksInPath];
+    NSURL *fileURL = [[NSURL alloc] initFileURLWithPath:urlPath];
 
     [skin pushNSObject:fileURL.absoluteString] ;
     free(absolutePath);


### PR DESCRIPTION
Some paths with non-alphanumeric characters (such as single quotation marks) could break this function - it would return a URL string, but the result wouldn’t be valid for `hs.pasteboard.writeObjects({url=path})` for example. I assume it’s because of the `UTF8String`.