### PR TITLE
adding hs.pasteboard.callbackWhenChanged per Google group conversation

### DIFF
--- a/extensions/pasteboard/init.lua
+++ b/extensions/pasteboard/init.lua
@@ -108,7 +108,7 @@ module.callbackWhenChanged = function(...)
     local longTask
     longTask = coroutine.wrap(function(start, count)
         while (timer.secondsSinceEpoch() - start < timeout) and (module.changeCount(name) == count) do
-              coroutine.applicationYield()
+              coroutine.applicationYield() -- luacheck: ignore
         end
         callback(module.changeCount(name) ~= count)
         longTask = nil -- referncing here makes it an upvalue, so it won't be collected

--- a/extensions/pasteboard/init.lua
+++ b/extensions/pasteboard/init.lua
@@ -7,6 +7,8 @@
 local module = require("hs.pasteboard.internal")
 module.watcher = require("hs.pasteboard.watcher")
 
+local timer = require("hs.timer")
+
 -- make sure the convertors for types we can recognize are loaded
 require("hs.image")
 require("hs.sound")
@@ -57,6 +59,61 @@ module.writeAllData = function (...)
     ok = ok and module.writeDataForUTI(name, uti, data, true)
   end
   return ok
+end
+
+--- hs.pasteboard.callbackWhenChanged([name], [timeout], callback) -> None
+--- Function
+--- Invokes callback when the specified pasteoard has changed or the timeout is reached.
+---
+--- Parameters:
+---  * `name`     - an optional string indicating the pasteboard name.  If nil or not present, defaults to the system pasteboard.
+---  * `timeout`  - an optional number, default 2.0, specifying the time in seconds that this function should wait for a change to the specified pasteboard before timing out.
+---  * `callback` - a required callback function that will be invoked when either the specified pasteboard contents have changed or the timeout has been reached. The function should expect one boolean argument, true if the pasteboard contents have changed or false if timeout has been reached.
+---
+--- Returns:
+---  * None
+---
+--- Notes:
+---  * This function can be used to capture the results of a copy operation issued programatically with `hs.application:selectMenuItem` or `hs.eventtap.keyStroke` without resorting to creating your own timers:
+---
+---  ~~~
+---      hs.eventtap.keyStroke({"cmd"}, "c", 0) -- or whatever method you want to trigger the copy
+---      hs.pasteboard.callbackWhenChanged(5, function(state)
+---          if state then
+---              local contents = hs.pasteboard.getContents()
+---              -- do what you want with contents
+---          else
+---              error("copy timeout") -- or whatever fallback you want when it timesout
+---          end
+---      end)
+--- ~~~
+module.callbackWhenChanged = function(...)
+    local name, timeout, callback = nil, 2.0, nil
+    for _, v in ipairs({...}) do
+        if type(v) == "number" then
+            timeout = v
+        elseif type(v) == "nil" or type(v) == "string" then
+            name = v
+        elseif type(v) == "function" or (getmetatable(v) or {}).__call then
+            callback = v
+        end
+    end
+    assert(type(name) == "nil" or type(name) == "string", "pasteboard must be a string or nil")
+    assert(type(timeout) == "number", "timeout must be a number")
+    assert(
+        type(callback) == "function" or (getmetatable(callback) or {}).__call,
+        "callback must be a function"
+    )
+
+    local longTask
+    longTask = coroutine.wrap(function(start, count)
+        while (timer.secondsSinceEpoch() - start < timeout) and (module.changeCount(name) == count) do
+              coroutine.applicationYield()
+        end
+        callback(module.changeCount(name) ~= count)
+        longTask = nil -- referncing here makes it an upvalue, so it won't be collected
+    end)
+    longTask(timer.secondsSinceEpoch(), module.changeCount(name))
 end
 
 return module


### PR DESCRIPTION
Example usage:

~~~lua
local pasteboard = require("hs.pasteboard")
local inspect    = require("hs.inspect")

local doSomethingWithClipboardContents
doSomethingWithClipboardContents = function(state)
    if state then
        local value = pasteboard.getContents()
        if not value then
            value = inspect(pasteboard.contentTypes())
        end
        print(value)
    end
    -- since this is a one-shot, we need to restart ourself
    pasteboard.callbackWhenChanged(math.huge, doSomethingWithClipboardContents)
end
pasteboard.callbackWhenChanged(math.huge, doSomethingWithClipboardContents)
~~~

Interestingly, I think now we could actually implement the watcher entirely in Lua... not that I want to, since it's already in place.