### PR TITLE
hs.window.filter fixes

### DIFF
--- a/extensions/uielement/watcher.m
+++ b/extensions/uielement/watcher.m
@@ -158,6 +158,8 @@ static int userdata_gc(lua_State* L) {
             watcher = nil;
         }
     }
+    lua_pushnil(L) ;
+    lua_setmetatable(L, 1) ;
     return 0;
 }
 

--- a/extensions/window/filter.lua
+++ b/extensions/window/filter.lua
@@ -1387,7 +1387,7 @@ appWindowEvent=function(win,event,_,appname,retry)
     end
     if apps[appname].windows[id] then return log.df('%s (%d) already registered',appname,id) end
     local watcher=win:newWatcher(windowEvent,appname)
-    if not watcher._element.pid then
+    if not watcher:pid() then
       log.wf('%s: %s has no watcher pid',appname,role or (win.role and win:role()))
       if retry>MAX_RETRIES then log.df('%s: %s has no watcher pid',appname,win.subrole and win:subrole() or (win.role and win:role()) or 'window')
       else
@@ -1412,7 +1412,7 @@ local function startAppWatcher(app,appname)
   local watcher = app:newWatcher(appWindowEvent,appname)
   watcher:start({uiwatcher.windowCreated,uiwatcher.focusedWindowChanged})
   App.new(app,appname,watcher)
-  if not watcher._element.pid then
+  if not watcher:pid() then
     log.wf('No accessibility access to app %s (no watcher pid)',(appname or '[???]'))
   end
 end
@@ -1428,7 +1428,7 @@ local function startAppWatcher(app,appname,retry,nologging)
   if retry>1 and not pendingApps[appname] then return end --given up before anything could even happen
 
   local watcher = app:newWatcher(appWindowEvent,appname)
-  if watcher._element.pid then
+  if watcher:pid() then
     pendingApps[appname]=nil --done
     watcher:start({uiwatcher.windowCreated,uiwatcher.focusedWindowChanged})
     App.new(app,appname,watcher)


### PR DESCRIPTION
May address #2474 and linked issues.

1. Previous `hs.uielement.watcher` was a table and `hs.window.filter` checked for pid by accessing table directly instead of through methods. New `hs.uielement.watcher` is a userdata, so you methods required.

2. `hs.uielement.watcher` objects were not having metatable removed during garbage collection, resulting in Hammerspoon crash during reload if `hs.window.filter` used anywhere. Metatable is now removed during garbage collection.

@cmsj, I'm not entirely happy about #2 because all it really does is push back the error into lua space (which a reload can survive). Somehow we've got a userdata (perhaps in a queued callback) that still "exists" even though its ref count has reached 0, which is the real issue. Thoughts on how to try and narrow down the search to a better solution?