### PR TITLE
properly track id when closing windows in window.filter

### DIFF
--- a/extensions/window/filter.lua
+++ b/extensions/window/filter.lua
@@ -1341,14 +1341,8 @@ function App:destroyed()
   apps[self.name]=nil
 end
 
-local function windowEvent(win,event,_,appname)
-  local id=win and win.id and win:id()
+local function windowEvent(win,event,_,appname,id)
   local app=apps[appname]
-  if not id and app then
-    for _,v in pairs(app.windows) do
-      if v.window==win then id=v.id break end
-    end
-  end
   log.vf('%s (%s) <= %s (window event)',appname,id or '?',event)
   if not id then return log.df('%s: %s cannot be processed',appname,event) end
   if not app then return log.df('app %s is not registered!',appname) end
@@ -1386,7 +1380,9 @@ appWindowEvent=function(win,event,_,appname,retry)
       return
     end
     if apps[appname].windows[id] then return log.df('%s (%d) already registered',appname,id) end
-    local watcher=win:newWatcher(windowEvent,appname)
+    local watcher=win:newWatcher(function(win,event,_,appname)
+      windowEvent(win,event,_,appname,id)
+    end, appname)
     if not watcher:pid() then
       log.wf('%s: %s has no watcher pid',appname,role or (win.role and win:role()))
       if retry>MAX_RETRIES then log.df('%s: %s has no watcher pid',appname,win.subrole and win:subrole() or (win.role and win:role()) or 'window')

--- a/extensions/window/filter.lua
+++ b/extensions/window/filter.lua
@@ -1341,7 +1341,7 @@ function App:destroyed()
   apps[self.name]=nil
 end
 
-local function windowEvent(win,event,_,appname,id)
+local function windowEvent(event,appname,id)
   local app=apps[appname]
   log.vf('%s (%s) <= %s (window event)',appname,id or '?',event)
   if not id then return log.df('%s: %s cannot be processed',appname,event) end
@@ -1380,8 +1380,8 @@ appWindowEvent=function(win,event,_,appname,retry)
       return
     end
     if apps[appname].windows[id] then return log.df('%s (%d) already registered',appname,id) end
-    local watcher=win:newWatcher(function(win,event,_,appname)
-      windowEvent(win,event,_,appname,id)
+    local watcher=win:newWatcher(function(_,watcherEvent)
+      windowEvent(watcherEvent,appname,id)
     end, appname)
     if not watcher:pid() then
       log.wf('%s: %s has no watcher pid',appname,role or (win.role and win:role()))


### PR DESCRIPTION
I noticed a regression after updating to `0.9.79` and `0.9.80` where  `window.filter` doesn't track closing windows properly anymore (with for example `hs.window.filter.windowNotVisible`). The `id` was missing, and couldn't be retrieved using the `for` loop which I removed, and instead I'm passing the `id` when creating a watcher. I've been testing this with my `hhtwm` which relies on this heavily for past couple of hours, and I didn't notice any issues so far.