### PR TITLE
[READY] Removed unnecessary error messages when callback functions not defined 

### DIFF
--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -877,7 +877,12 @@ void callAccessibilityStateCallback(void) {
     lua_getglobal(L, "hs");
     lua_getfield(L, -1, "accessibilityStateCallback");
 
-    [skin protectedCallAndError:@"hs.callAccessibilityStateCallback" nargs:0 nresults:0];
+    if (lua_type(L, -1) == LUA_TNIL) {
+        // There is no callback set, so just pop the callback and carry on
+        lua_pop(L, 1);
+    } else {
+        [skin protectedCallAndError:@"hs.callAccessibilityStateCallback" nargs:0 nresults:0];
+    }
 
     // Pop the hs global off the stack
     lua_pop(L, 1);
@@ -893,8 +898,13 @@ void textDroppedToDockIcon(NSString *pboardString) {
     lua_getglobal(L, "hs");
     lua_getfield(L, -1, "textDroppedToDockIconCallback");
 
-    [skin pushNSObject:pboardString];
-    [skin protectedCallAndError:@"hs.textDroppedToDockIconCallback" nargs:1 nresults:0];
+    if (lua_type(L, -1) == LUA_TNIL) {
+        // There is no callback set, so just pop the callback and carry on
+        lua_pop(L, 1);
+    } else {
+        [skin pushNSObject:pboardString];
+        [skin protectedCallAndError:@"hs.textDroppedToDockIconCallback" nargs:1 nresults:0];
+    }
 
     // Pop the hs global off the stack
     lua_pop(L, 1);
@@ -910,8 +920,13 @@ void fileDroppedToDockIcon(NSString *filePath) {
     lua_getglobal(L, "hs");
     lua_getfield(L, -1, "fileDroppedToDockIconCallback");
 
-    [skin pushNSObject:filePath];
-    [skin protectedCallAndError:@"hs.fileDroppedToDockIconCallback" nargs:1 nresults:0];
+    if (lua_type(L, -1) == LUA_TNIL) {
+        // There is no callback set, so just pop the callback and carry on
+        lua_pop(L, 1);
+    } else {
+        [skin pushNSObject:filePath];
+        [skin protectedCallAndError:@"hs.fileDroppedToDockIconCallback" nargs:1 nresults:0];
+    }
 
     // Pop the hs global off the stack
     lua_pop(L, 1);


### PR DESCRIPTION
- `hs.accessibilityStateCallback`, `hs.textDroppedToDockIconCallback` and `hs.fileDroppedToDockIconCallback` no longer generate an error if there’s no callback defined.
- Closes #2500