### PR TITLE
[READY] Skip hs.window Snapshots & Size tests in Travis

### DIFF
--- a/Hammerspoon Tests/HSwindow.m
+++ b/Hammerspoon Tests/HSwindow.m
@@ -44,6 +44,7 @@
 }
 
 - (void)testSnapshots {
+    SKIP_IN_TRAVIS() // Added by @latenitefilms
     RUN_LUA_TEST()
 }
 
@@ -60,6 +61,7 @@
 }
 
 - (void)testSize {
+    SKIP_IN_TRAVIS() // Added by @latenitefilms
     RUN_LUA_TEST()
 }
 


### PR DESCRIPTION
- These tests run fine locally on my machine but fail in Travis.
- I’m on a MacBook Pro (15-inch, 2017) running macOS Mojave 10.14.6.