### PR TITLE
[WIP] Updated hs.fs to use LuaFileSystem 1.8.0 take 2

### DIFF
--- a/extensions/fs/init.lua
+++ b/extensions/fs/init.lua
@@ -2,9 +2,7 @@
 ---
 --- Access/inspect the filesystem
 ---
---- Home: http://keplerproject.github.io/luafilesystem/
----
---- This module is produced by the Kepler Project under the name "Lua File System"
+--- This module is partial superset of LuaFileSystem 1.8.0 (http://keplerproject.github.io/luafilesystem/). It has been modified to remove functions which do not apply to macOS filesystems and additional functions providing macOS specific filesystem information have been added.
 
 local module = require("hs.fs.internal")
 module.volume = require("hs.fs.volume")
@@ -117,6 +115,35 @@ end tell
         return state
     else
         error(raw.NSLocalizedDescription, 2)
+    end
+end
+
+-- easier to wrap here than adjust in internal.m since we have a more macOS way to resolve
+-- symlinks
+local hs_fs_symlinkAttributes = module.symlinkAttributes
+--- hs.fs.symlinkAttributes (filepath [, aname]) -> table or string or nil,error
+--- Function
+--- Gets the attributes of a symbolic link
+---
+--- Parameters:
+---  * filepath - A string containing the path of a link to inspect
+---  * aName - An optional attribute name. If this value is specified, only the attribute requested, is returned
+---
+--- Returns:
+---  * A table or string if the values could be found, otherwise nil and an error string.
+---
+--- Notes:
+---  * The return values for this function are identical to those provided by `hs.fs.attributes()` with the following addition: the attribute name "target" is added and specifies a string containing the absolute path that the symlink points to.
+module.symlinkAttributes = function(...)
+    local args = table.pack(...)
+    if args[2] == "target" then
+        return module.pathToAbsolute(args[1])
+    else
+        local ans = table.pack(hs_fs_symlinkAttributes(...))
+        if ans.n == 1 and type(ans[1]) == "table" then
+            ans[1].target = module.pathToAbsolute(args[1])
+        end
+        return table.unpack(ans)
     end
 end
 

--- a/extensions/fs/internal.m
+++ b/extensions/fs/internal.m
@@ -514,18 +514,9 @@ static int dir_iter_factory (lua_State *L) {
 
     // Lua 5.4: use __close to close dir if you break the iterator
     // SOURCE: https://github.com/keplerproject/luafilesystem/commit/842505b6a33d0b0e2445568ea42f2adbf3c4eb77
-    #if LUA_VERSION_NUM >= 504
         lua_pushnil(L);
-        lua_pushvalue(L, -2);
-        // ASM: this *is* what 1.8.0 says, but why? Return stack is generatorFn
-        //                                                          dirObj
-        //                                                          nil
-        //                                                          dirObj
-        // and its use as an iterator only cares about the first two
+        lua_pushvalue(L, -2); // forces "to-be-closed" when used with `for`
         return 4;
-    #else
-        return 2;
-    #endif
 }
 
 

--- a/extensions/fs/lfs.h
+++ b/extensions/fs/lfs.h
@@ -1,24 +1,6 @@
-/*
-** LuaFileSystem
-** Copyright Kepler Project 2003 (http://www.keplerproject.org/luafilesystem)
-**
-** $Id: lfs.h,v 1.5 2008/02/19 20:08:23 mascarenhas Exp $
-*/
+#pragma once
 
-/* Define 'chdir' for systems that do not implement it */
-#ifdef NO_CHDIR
-#define chdir(p)	(-1)
-#define chdir_error	"Function 'chdir' not provided by system"
-#else
-#define chdir_error	strerror(errno)
-#endif
-
-#ifdef _WIN32
-#define chdir(p) (_chdir(p))
-#define getcwd(d, s) (_getcwd(d, s))
-#define rmdir(p) (_rmdir(p))
-#define fileno(f) (_fileno(f))
-#endif
+// This file is probably  no longer necessary
 
 #ifdef __cplusplus
 extern "C" {

--- a/extensions/fs/test_fs.lua
+++ b/extensions/fs/test_fs.lua
@@ -93,7 +93,7 @@ function testAttributes()
 
   local status, err = hs.fs.attributes(dirname, "bad_attribute_name")
   assertIsNil(status)
-  assertIsEqual("invalid attribute name", err)
+  assertIsEqual("invalid attribute name 'bad_attribute_name'", err)
 
   if hs.socket then
     local sockname, socket = "sock", nil

--- a/extensions/fs/test_fs.lua
+++ b/extensions/fs/test_fs.lua
@@ -229,8 +229,8 @@ function testDirWalker()
   iterfn, dirobj = hs.fs.dir(dirname)
   dirobj:close()
 
-  local status, err = hs.fs.dir("some_non_existent_dir")
-  assertIsNil(status)
+  local status, err = pcall(hs.fs.dir, "some_non_existent_dir")
+  assertFalse(status)
   assertIsEqual("cannot open", err:match("cannot open"))
 
   return success()


### PR DESCRIPTION
Should supersede #2511 

Update includes #2511 and:
* fixed missing `blocks` and `blksize` from `hs.fs.attributes` and `hs.fs.symlinkAttributes`
* added `target` attribute to `hs.fs.symlinkAttributes`
* modified some error messages to match format used in lfs 1.8.0
* updated `hs.fs.currentDir` to match lfs 1.8.0
* fixed `check_file` helper to properly use `luaL_stream` (as per lfs 1.8.0)

I do have a question about `hs.fs.dir` though... the example given in the docs is as follows:

~~~lua
       local iterFn, dirObj = hs.fs.dir("/Users/Guest/Documents")
       if iterFn then
          for file in iterFn, dirObj do
             print(file)
          end
       else
          print(string.format("The following error occurred: %s", dirObj))
       end
~~~

This is in the style required for 5.1, but since 5.2, you can also do:

~~~lua
for file in hs.fs.dir(path) do
    print(file)
end
~~~

Updating the comment is easy, but there's a catch... you'll no longer be able to check if the first argument is `nil` and then decide what to do with the error... you'll get this instead:

~~~
[string "for file in hs.fs.dir("~booger") do print(fil..."]:1: attempt to call a nil value
stack traceback:
   ...
~~~

With the stock `lfs`, they actually throw an error at that point (in fact they throw them at a number of places where we return `nil, errMsg`) and I tend to think, even with the other changes in how `hs.fs` handles errors vs stock `lfs` that we should too for this generator function -- it's more in line with what I think 5.2+ programmers expect from a generator function -- an error that says what's actually wrong (such as `cannot open /Users/amagill/.config/hammerspoon/~l: No such file or directory` instead of `attempt to call a nil value`.

Thoughts?