### PR TITLE
Safari 14 kludge for accessing Tabs

### DIFF
--- a/Hammerspoon/HSuicore.m
+++ b/Hammerspoon/HSuicore.m
@@ -518,6 +518,28 @@ static AXUIElementRef get_window_tabs(AXUIElementRef win) {
         }
     }
 
+    // Safari 14 puts them into an AXGroup, not an AXTabsGroup
+    if (tabs == NULL) {
+        for (CFIndex i = 0; i < count; ++i) {
+            AXUIElementRef child = CFArrayGetValueAtIndex(children, i);
+            if(AXUIElementCopyAttributeValue(child, kAXRoleAttribute, &typeRef) != noErr) goto cleanup;
+            CFStringRef role = (CFStringRef)typeRef;
+            BOOL correctRole = kCFCompareEqualTo == CFStringCompare(role, kAXGroupRole, 0);
+            CFRelease(role);
+            if (correctRole) {
+                CFArrayRef attributeNames = NULL ;
+                if (AXUIElementCopyAttributeNames(child, &attributeNames) != noErr) goto cleanup ;
+                if (CFArrayContainsValue(attributeNames, CFRangeMake(0, CFArrayGetCount(attributeNames)), kAXTabsAttribute)) {
+                    tabs = child;
+                    CFRetain(tabs);
+                    CFRelease(attributeNames) ;
+                    break;
+                }
+                CFRelease(attributeNames) ;
+            }
+        }
+    }
+
 cleanup:
     if (children) CFRelease(children);
 
@@ -743,7 +765,11 @@ cleanup:
     CFIndex count = CFArrayGetCount(children);
 
     CFIndex i = index;
-    if(i >= count || i < 0) i = count - 1;
+    if(i > count || i <= 0) {
+        i = count - 1;
+    } else {
+        i = i - 1 ; // adjust because lua style indexes start at 1
+    }
     tab = CFArrayGetValueAtIndex(children, i);
 
     if (AXUIElementPerformAction(tab, kAXPressAction) != noErr) goto cleanup;

--- a/extensions/window/internal.m
+++ b/extensions/window/internal.m
@@ -349,7 +349,7 @@ static int window__close(lua_State* L) {
 ///  * true if the tab was successfully pressed, or false if there was a problem
 static int window_focustab(lua_State* L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
-    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TINTEGER, LS_TBREAK];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TNUMBER | LS_TINTEGER, LS_TBREAK];
     HSwindow *win = [skin toNSObjectAtIndex:1];
     int tabIndex = (int)lua_tointeger(L, 2);
     lua_pushboolean(L, [win focusTab:tabIndex]);
@@ -633,7 +633,7 @@ static int window_uielement_isApplication(lua_State *L) {
     HSapplication *app = [skin toNSObjectAtIndex:1];
     HSuielement *uiElement = app.uiElement;
     lua_pushboolean(L, [uiElement.role isEqualToString:@"AXApplication"]);
-    
+
     return 1;
 }
 
@@ -644,7 +644,7 @@ static int window_uielement_isWindow(lua_State *L) {
     HSapplication *app = [skin toNSObjectAtIndex:1];
     HSuielement *uiElement = app.uiElement;
     lua_pushboolean(L, uiElement.isWindow);
-    
+
     return 1;
 }
 
@@ -655,7 +655,7 @@ static int window_uielement_role(lua_State *L) {
     HSapplication *app = [skin toNSObjectAtIndex:1];
     HSuielement *uiElement = app.uiElement;
     [skin pushNSObject:uiElement.role];
-    
+
     return 1;
 }
 
@@ -666,7 +666,7 @@ static int window_uielement_selectedText(lua_State *L) {
     HSapplication *app = [skin toNSObjectAtIndex:1];
     HSuielement *uiElement = app.uiElement;
     [skin pushNSObject:uiElement.selectedText];
-    
+
     return 1;
 }
 


### PR DESCRIPTION
Safari 14 no longer keeps tabs in AXTabGroup element; rather in a regular AXGroup. This searches both.

Also fixes off by 1 for `hs.window:focusTab(#)`

Should partially address #2527, though not formally tested locally yet.