### PR TITLE
[REVIEW] Updated hs.sqlite3 from 0.9.4 to 0.9.5

### DIFF
--- a/extensions/sqlite3/init.lua
+++ b/extensions/sqlite3/init.lua
@@ -3,7 +3,7 @@
 --- Interact with SQLite databases
 ---
 --- Notes:
----  * This module is LSQLite 0.9.4 as found at http://lua.sqlite.org/index.cgi/index
+---  * This module is LSQLite 0.9.5 as found at http://lua.sqlite.org/index.cgi/index
 ---  * It is unmodified apart from removing `db:load_extension()` as this feature is not available in Apple's libsqlite3.dylib
 ---  * For API documentation please see [http://lua.sqlite.org](http://lua.sqlite.org)
 return require("hs.sqlite3.lsqlite3")

--- a/extensions/sqlite3/lsqlite3.c
+++ b/extensions/sqlite3/lsqlite3.c
@@ -1,4 +1,4 @@
-// HAMMERSPOON NOTE: This file has been modified from the original 0.9.4 release. Be careful when updating it
+// HAMMERSPOON NOTE: This file has been modified from the original 0.9.5 release. Be careful when updating it.
 
 /************************************************************************
 * lsqlite3                                                              *
@@ -1182,10 +1182,7 @@ static int collwrapper(scc *co,int l1,const void *p1,
     lua_rawgeti(L,LUA_REGISTRYINDEX,co->ref);
     lua_pushlstring(L,p1,l1);
     lua_pushlstring(L,p2,l2);
-    if (lua_pcall(L,2,1,0)==0) {
-        double d=lua_tonumber(L,-1);
-        res=(int)d;
-    }
+	if (lua_pcall(L,2,1,0)==0) res=(int)lua_tonumber(L,-1);
     lua_pop(L,1);
     return res;
 }
@@ -1323,6 +1320,7 @@ static void db_update_hook_callback(void *user, int op, char const *dbname, char
     sdb *db = (sdb*)user;
     lua_State *L = db->L;
     int top = lua_gettop(L);
+    lua_Number n;
 
     /* setup lua callback call */
     lua_rawgeti(L, LUA_REGISTRYINDEX, db->update_hook_cb);    /* get callback */
@@ -2138,7 +2136,7 @@ static int lsqlite_newindex(lua_State *L) {
 
 #ifndef LSQLITE_VERSION
 /* should be defined in rockspec, but just in case... */
-#define LSQLITE_VERSION "0.9.4"
+#define LSQLITE_VERSION "0.9.5"
 #endif
 
 /* Version number of this library


### PR DESCRIPTION
I manually compared the changes from [0.9.5](http://lua.sqlite.org/index.cgi/zip/lsqlite3_fsl09y.zip?uuid=fsl_9y) to the code in `hs.sqlite3` (0.9.4), and made the required changes.

Definitely worth checking @cmsj and/or @asmagill - although there's only a couple of minor changes, so should be pretty easy to review.