### PR TITLE
[WIP] Fix hs.window.filter 0.9.81

### DIFF
--- a/extensions/window/filter.lua
+++ b/extensions/window/filter.lua
@@ -2303,10 +2303,10 @@ end
 
 for _,dir in ipairs{'East','North','West','South'}do
   WF['windowsTo'..dir]=function(self,win,...)
-    return window['windowsTo'..dir](win,self:getWindows(),...)
+    return win['windowsTo'..dir](win,self:getWindows(),...)
   end
   WF['focusWindow'..dir]=function(self,win,...)
-    if window['focusWindow'..dir](win,self:getWindows(),...) then self.log.i('focused window '..dir:lower()) end
+    if win['focusWindow'..dir](win,self:getWindows(),...) then self.log.i('focused window '..dir:lower()) end
   end
   windowfilter['focus'..dir]=function()local d=makeDefaultCurrentSpace():keepActive()d['focusWindow'..dir](d,nil,nil,true)end
 end


### PR DESCRIPTION
Initial push should fix #2488 latest where hs.window methods were being treated as functions

Hoping to figure out #2524 as well, but so far no ideas... it seems like a timing thing -- the app watcher for the new app seems to stop checking for windows in the app after getting initial `activated` event and doesn't start again until the next `activated` event, so if the window is created *after* we receive the first `activated` event, it isn't seen until a forced recheck.

Any thoughts or help on #2524 greatly appreciated -- I am at the limit of my minimal understanding of that module.