### PR TITLE
Fix typo

### DIFF
--- a/SPOONS.md
+++ b/SPOONS.md
@@ -217,7 +217,7 @@ There is, however, a simple way to discover the true path of your Spoon on the f
 
 ```lua
 -- Get path to Spoon's init.lua script
-obj.spoonPath = hs.spoon.scriptPath()
+obj.spoonPath = hs.spoons.scriptPath()
 ```
 #### Assets
 


### PR DESCRIPTION
External resources on my version of Hammerspoon (0.9.81) are loaded using `hs.spoons.scriptPath()` and not `hs.spoon.scriptPath()`