### PR TITLE
[REVIEW] Add argument to CLI to abort

### DIFF
--- a/extensions/ipc/cli/hs.m
+++ b/extensions/ipc/cli/hs.m
@@ -461,6 +461,7 @@ int main()
         BOOL           interactive = !readStdIn && (BOOL)isatty(STDOUT_FILENO) ;
         BOOL           useColors   = interactive ;
         BOOL           autoLaunch  = NO ;
+        BOOL           exitIfNoHS  = NO ;
         NSString       *portName   = defaultPortName ;
         NSString       *fileName   = nil ;
 
@@ -487,7 +488,11 @@ int main()
                 readStdIn   = YES ;
                 if (!seenColors) useColors = NO ;
             } else if ([args[idx] isEqualToString:@"-A"]) {
+                exitIfNoHS = NO ;
                 autoLaunch = YES ;
+            } else if ([args[idx] isEqualToString:@"-a"]) {
+                exitIfNoHS = YES ;
+                autoLaunch = NO ;
             } else if ([args[idx] isEqualToString:@"-n"]) {
                 useColors = NO ;
             } else if ([args[idx] isEqualToString:@"-N"]) {
@@ -553,6 +558,7 @@ int main()
 
         NSArray *ra = [NSRunningApplication runningApplicationsWithBundleIdentifier:(__bridge NSString *)hammerspoonBundle] ;
         if (ra.count == 0) {
+            if (exitIfNoHS) exit(EX_TEMPFAIL) ;
             BOOL launchHS = autoLaunch ;
             if (!autoLaunch) {
                 NSAlert *alert = [[NSAlert alloc] init] ;

--- a/extensions/ipc/cli/hs.man
+++ b/extensions/ipc/cli/hs.man
@@ -6,7 +6,7 @@
 .Nd Command line interface to Hammerspoon.app
 .Sh SYNOPSIS
 .Nm
-.Op Fl A
+.Op Fl A | Fl a
 .Op Fl c Ar code Op Fl c Ar ...
 .Op Fl C | Fl P
 .Op Fl i | Fl s
@@ -33,6 +33,8 @@ are implied unless stdin or stdout are redirected (i.e. not a tty).
 Autolaunch Hammerspoon if it is not already running. By default,
 .Nm
 prompts the user for confirmation.
+.It Fl a
+If Hammerspoon is not currently running, exit with EX_TEMPFAIL rather than prompt the user.
 .It Fl c Ar code
 Executes the specified code. May be specified more than once and the commands will be executed in the order given. Disables
 .Fl i
@@ -127,6 +129,10 @@ A Hammerspoon or Lua error occured when attempting to execute code in a non-inte
 There was an error reading from stdin or
 .Pa /path/file
 \&.
+.It EX_TEMPFAIL (75)
+Hammerspoon is not running and
+.Fl a
+was specified to prevent autolaunch or prompting the user.
 .It EX_UNAVAILABLE (69)
 Hammerspoon is not running, the
 .Pa hs.ipc


### PR DESCRIPTION
Adds `-a` argument to command line tool `hs` which causes the command to abort rather than prompt or autolaunch if Hammerspoon is not currently running.

Will close #2569 
