### PR TITLE
[READY] Migrate away from @encode

### DIFF
--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -1251,16 +1251,30 @@ nextarg:
     NSValue    *value    = obj;
     const char *objCType = [value objCType];
 
+    // @encode is a compiler directive that can give different results depending upon the
+    // architecture, so lets compare apples to apples:
+    static dispatch_once_t onceToken;
+    static const char *pointEncoding ;
+    static const char *sizeEncoding ;
+    static const char *rectEncoding ;
+    static const char *rangeEncoding ;
+    dispatch_once(&onceToken, ^{
+        pointEncoding = [[NSValue valueWithPoint:NSZeroPoint] objCType] ;
+        sizeEncoding  = [[NSValue valueWithSize:NSZeroSize] objCType] ;
+        rectEncoding  = [[NSValue valueWithRect:NSZeroRect] objCType] ;
+        rangeEncoding = [[NSValue valueWithRange:NSMakeRange(0,1)] objCType] ;
+    });
+
     // Ensure our Lua stack is large enough for the number of items being pushed
     [self growStack:3 withMessage:"pushNSValue"];
 
-    if (strcmp(objCType, @encode(NSPoint))==0) {
+    if (strcmp(objCType, pointEncoding)==0) {
         [self pushNSPoint:[value pointValue]] ;
-    } else if (strcmp(objCType, @encode(NSSize))==0) {
+    } else if (strcmp(objCType, sizeEncoding)==0) {
         [self  pushNSSize:[value sizeValue]] ;
-    } else if (strcmp(objCType, @encode(NSRect))==0) {
+    } else if (strcmp(objCType, rectEncoding)==0) {
         [self  pushNSRect:[value rectValue]] ;
-    } else if (strcmp(objCType, @encode(NSRange))==0) {
+    } else if (strcmp(objCType, rangeEncoding)==0) {
         NSRange holder = [value rangeValue] ;
         lua_newtable(self.L) ;
         lua_pushinteger(self.L, (lua_Integer)holder.location) ; lua_setfield(self.L, -2, "location") ;

--- a/extensions/canvas/internal.m
+++ b/extensions/canvas/internal.m
@@ -48,7 +48,8 @@ static NSDictionary *defineLanguageDictionary() {
         @"absolutePosition" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),  // @encode may change depending upon architecture, so use the
+                                                    // same value we check against in isValueValidForDictionary
             @"nullable"    : @(YES),
             @"default"     : @(YES),
             @"optionalFor" : VISIBLE,
@@ -56,7 +57,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"absoluteSize" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(YES),
             @"optionalFor" : VISIBLE,
@@ -64,7 +65,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"antialias" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(YES),
             @"optionalFor" : VISIBLE,
@@ -72,7 +73,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"arcRadii" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(YES),
             @"optionalFor" : @[ @"arc", @"ellipticalArc" ],
@@ -80,7 +81,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"arcClockwise" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(YES),
             @"optionalFor" : @[ @"arc", @"ellipticalArc" ],
@@ -88,7 +89,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"clipToPath" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(NO),
             @"optionalFor" : CLOSED,
@@ -124,7 +125,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"closed" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(NO),
             @"default"     : @(NO),
             @"requiredFor" : @[ @"segments" ],
@@ -258,7 +259,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"flattenPath" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(NO),
             @"optionalFor" : PRIMITIVES,
@@ -325,7 +326,8 @@ static NSDictionary *defineLanguageDictionary() {
         },
         @"imageAnimationFrame" : @ {
             @"class"       : @[ [NSNumber class] ],
-            @"objCType"    : @(@encode(lua_Integer)),
+            @"objCType"    : @([@((lua_Integer)1) objCType]), // @encode may change depending upon architecture, so use the
+                                                              // same value we check against in isValueValidForDictionary
             @"luaClass"    : @"integer",
             @"nullable"    : @(YES),
             @"default"     : @(0),
@@ -334,7 +336,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"imageAnimates" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(NO),
             @"default"     : @(NO),
             @"requiredFor" : @[ @"image" ],
@@ -371,7 +373,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"reversePath" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(NO),
             @"optionalFor" : PRIMITIVES,
@@ -503,7 +505,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"trackMouseByBounds" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(NO),
             @"optionalFor" : VISIBLE,
@@ -511,7 +513,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"trackMouseEnterExit" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(NO),
             @"optionalFor" : VISIBLE,
@@ -519,7 +521,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"trackMouseDown" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(NO),
             @"optionalFor" : VISIBLE,
@@ -527,7 +529,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"trackMouseUp" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(NO),
             @"optionalFor" : VISIBLE,
@@ -535,7 +537,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"trackMouseMove" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(NO),
             @"optionalFor" : VISIBLE,
@@ -581,7 +583,7 @@ static NSDictionary *defineLanguageDictionary() {
         @"withShadow" : @{
             @"class"       : @[ [NSNumber class] ],
             @"luaClass"    : @"boolean",
-            @"objCType"    : @(@encode(BOOL)),
+            @"objCType"    : @([@(YES) objCType]),
             @"nullable"    : @(YES),
             @"default"     : @(NO),
             @"optionalFor" : PRIMITIVES,


### PR DESCRIPTION
It's a compiler directive that is architecture specific and causes issues (at least with BOOL) in universal builds when comparing against [NSNumber objCType]

While fixing the `BOOL` issue should address #2602 specifically, it's probably best to move away from it entirely just to be safe... compare like to like instead of two things that are *mostly* the same (i.e. `@encode` and `[NSNumber objCType]`.

I need to consider a way to specifically test the structure converters in LuaSkin (point, rect, etc.) as they aren't used often (they're mostly useful when such items are entries in an NSDictionary or NSArray -- for methods we create, it's usually more flexible to use the table provided and craft the specific structure we require ourselves).

@cmsj, since you use it with a c style structure in LuaSkinTests I *think* you should be safe -- from a little googling, most of the problems people have with @encode are with objective-c specific types and structures.

*edit: made 2nd to last paragraph clearer*