### PR TITLE
[REVIEW] Updates to hs.plist for binary data

### DIFF
--- a/extensions/plist/internal.m
+++ b/extensions/plist/internal.m
@@ -20,22 +20,30 @@ static int plist_read(lua_State *L) {
     return 1;
 }
 
-/// hs.plist.readString(value) -> table | nil
+/// hs.plist.readString(value, [binary]) -> table | nil
 /// Function
 /// Interpretes a property list file within a string into a table.
 ///
 /// Parameters:
-///  * value - The contents of the property list as a string
+///  * value  - The contents of the property list as a string
+///  * binary - an optional boolean, specifying whether the value should be treated as raw binary (true) or as an UTF8 encoded string (false). If you do not provide this argument, the function will attempt to auto-detect the type.
 ///
 /// Returns:
 ///  * The contents of the property list as a Lua table or `nil` if an error occurs
 static int plist_readString(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
-    [skin checkArgs:LS_TSTRING, LS_TBREAK];
+    [skin checkArgs:LS_TSTRING, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK];
 
     NSString *source = [skin toNSObjectAtIndex:1];
+    BOOL binary = (lua_gettop(L) > 1) ? (BOOL)(lua_toboolean(L, 2)) : [source hasPrefix:@"bplist"] ;
 
-    NSData *plistData = [source dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *plistData ;
+    if (binary) {
+        plistData = [skin toNSObjectAtIndex:1 withOptions:LS_NSLuaStringAsDataOnly] ;
+    } else {
+        plistData = [source dataUsingEncoding:NSUTF8StringEncoding];
+    }
+
     NSError *error;
     NSPropertyListFormat format;
     NSDictionary* plist = [NSPropertyListSerialization propertyListWithData:plistData options:NSPropertyListImmutable format:&format error:&error];
@@ -49,6 +57,44 @@ static int plist_readString(lua_State *L) {
     [skin pushNSObject:plist];
 
     return 1;
+}
+
+/// hs.plist.writeString(data, [binary]) -> string | nil
+/// Function
+/// Interpretes a property list file within a string into a table.
+///
+/// Parameters:
+///  * data - A Lua table containing the data to write into a plist string
+///  * binary - an optional boolean, default false, specifying that the resulting string should be encoded as a binary plist.
+///
+/// Returns:
+///  * A string representing the data as a plist or nil if there was a problem with the date or serialization.
+static int plist_writeString(lua_State *L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TTABLE, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK];
+
+    id data = [skin toNSObjectAtIndex:1 withOptions:LS_NSPreserveLuaStringExactly];
+    BOOL binary = (lua_gettop(L) > 1) ? (BOOL)(lua_toboolean(L, 2)) : NO ;
+
+    if (![NSPropertyListSerialization propertyList:data isValidForFormat:(binary ? NSPropertyListBinaryFormat_v1_0 : NSPropertyListXMLFormat_v1_0)]) {
+        [skin logError:@"hs.plist.writeString: data supplied is not in a suitable format to serialize as a plist"];
+        lua_pushboolean(L, false);
+        return 1;
+    }
+
+    NSError *error;
+    NSData *output = [NSPropertyListSerialization dataWithPropertyList: data
+                                                                format: (binary ? NSPropertyListBinaryFormat_v1_0 : NSPropertyListXMLFormat_v1_0)
+                                                               options: 0
+                                                                 error: &error];
+    if (output == nil) {
+        [skin logError:[NSString stringWithFormat:@"hs.plist.writeString: error serializing to plist representation: %@", error.localizedDescription]];
+        lua_pushnil(L) ;
+        return 1;
+    } else {
+        [skin pushNSObject:output] ;
+    }
+    return 1 ;
 }
 
 /// hs.plist.write(filepath, data[, binary]) -> boolean
@@ -75,7 +121,7 @@ static int plist_write(lua_State *L) {
     [skin checkArgs:LS_TSTRING, LS_TTABLE, LS_TBOOLEAN|LS_TOPTIONAL, LS_TBREAK];
 
     NSString *filePath = [[skin toNSObjectAtIndex:1] stringByExpandingTildeInPath];
-    id data = [skin toNSObjectAtIndex:2];
+    id data = [skin toNSObjectAtIndex:2 withOptions:LS_NSPreserveLuaStringExactly];
     BOOL binary = NO;
 
     if (lua_type(L, 3) == LUA_TBOOLEAN) {
@@ -115,6 +161,7 @@ static int plist_write(lua_State *L) {
 static const luaL_Reg plistlib[] = {
     {"read", plist_read},
     {"readString", plist_readString},
+    {"writeString", plist_writeString},
     {"write", plist_write},
     {NULL, NULL}
 };


### PR DESCRIPTION
* allow hs.plist.readString to work with binary data
* add hs.plist.writeString
* hs.plist.write treats binary strings as NSData now

@latenitefilms I think this was one of your additions, so I'd like you to make sure it doesn't break anything for you.

Example with these changes:

~~~lua
> a = hs.fs.xattr.get("~/Downloads/Instructable PDFs/Plywood-DML-Speakers.pdf", "com.apple.metadata:kMDItemWhereFroms")

> a
bplist00�_Qhttps://content.instructables.com/pdfs/E4E/RUX1/KHXF420K/Plywood-DML-Speakers.pdf_Zhttps://www.instructables.com/Plywood-DML-Speakers/?utm_source=newsletter&utm_medium=email_∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅�

> hs.inspect(hs.plist.readString(a, true)) -- specify as binary
{ "https://content.instructables.com/pdfs/E4E/RUX1/KHXF420K/Plywood-DML-Speakers.pdf", "https://www.instructables.com/Plywood-DML-Speakers/?utm_source=newsletter&utm_medium=email" }

> hs.inspect(hs.plist.readString(a, false)) -- specify as string
14:33:46 ERROR:   LuaSkin: hs.plist.readString(): Error Domain=NSCocoaErrorDomain Code=3840 "Unexpected character b at line 1" UserInfo={NSDebugDescription=Unexpected character b at line 1, kCFPropertyListOldStyleParsingError=Error Domain=NSCocoaErrorDomain Code=3840 "Expected ';' or '=' after key at line 1" UserInfo={NSDebugDescription=Expected ';' or '=' after key at line 1}}
nil

> hs.inspect(hs.plist.readString(a)) -- attempt to autodetect
{ "https://content.instructables.com/pdfs/E4E/RUX1/KHXF420K/Plywood-DML-Speakers.pdf", "https://www.instructables.com/Plywood-DML-Speakers/?utm_source=newsletter&utm_medium=email" }

> b = hs.plist.readString(a)

> c = hs.plist.writeString(b)

> c
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<array>
	<string>https://content.instructables.com/pdfs/E4E/RUX1/KHXF420K/Plywood-DML-Speakers.pdf</string>
	<string>https://www.instructables.com/Plywood-DML-Speakers/?utm_source=newsletter&amp;utm_medium=email</string>
</array>
</plist>

> d = hs.plist.writeString(b, true)

> d
bplist00�_Qhttps://content.instructables.com/pdfs/E4E/RUX1/KHXF420K/Plywood-DML-Speakers.pdf_Zhttps://www.instructables.com/Plywood-DML-Speakers/?utm_source=newsletter&utm_medium=email_∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅∅�

> a == d
true
~~~