### PR TITLE
[REVIEW] CI tests that annoy me

### DIFF
--- a/Hammerspoon Tests/HSapplication.m
+++ b/Hammerspoon Tests/HSapplication.m
@@ -29,6 +29,7 @@
 }
 
 - (void)testInitWithPid {
+    SKIP_IN_GITHUB_ACTIONS() // Added by @asmagill
     RUN_LUA_TEST()
 }
 

--- a/extensions/application/test_application.lua
+++ b/extensions/application/test_application.lua
@@ -13,7 +13,7 @@ function testInitWithPid()
   for _,app in pairs(apps) do
     local pidApp = hs.application.applicationForPID(app:pid())
     if pidApp == nil then
-      assertIsEqual(app:name(), nil)
+      assertIsEqual(app:name(), nil) -- works in XCode now, but still not in GithubActions
     end
     assertIsEqual(app:name(), pidApp:name())
   end

--- a/extensions/application/test_application.lua
+++ b/extensions/application/test_application.lua
@@ -13,7 +13,7 @@ function testInitWithPid()
   for _,app in pairs(apps) do
     local pidApp = hs.application.applicationForPID(app:pid())
     if pidApp == nil then
-      assertIsEqual(app:name(), "nil")
+      assertIsEqual(app:name(), nil)
     end
     assertIsEqual(app:name(), pidApp:name())
   end


### PR DESCRIPTION
Well... it passed on my fork at least once...

@cmsj some tweaks to the tests for you to review...

The main offender I've seen consistently (I've seen a few others, but they seem to be sporadic, so not sure if they should be skipped or not) is hs.application's testInitWithPid... to get it to run in XCode, I had to remove some quotes around a "nil", but that wasn't sufficient for GithubActions... I think runningApplicationWithProcessIdentifier: may be restricted in the actions because there were a lot of breadcrumbs about it being nil in the test output on the summary page... so unless you have a better work around, I just skipped it and this last run passed... let's see what it does now that I'm making it a formal pull request.