### PR TITLE
[READY] LuaSkin object wrapper fix

### DIFF
--- a/LuaSkin/LuaSkin/luaskin.m
+++ b/LuaSkin/LuaSkin/luaskin.m
@@ -230,7 +230,11 @@ static int obj_ud_newindex(lua_State *L) {
             NSObject *key = [skin toNSObjectAtIndex:2] ;
             NSObject *value = [skin toNSObjectAtIndex:3 withOptions:LS_NSDescribeUnknownTypes] ;
             if (key) {
-                [(NSMutableDictionary *)obj setObject:value forKey:(id <NSCopying>)key] ;
+                if (value) {
+                    [(NSMutableDictionary *)obj setObject:value forKey:(id <NSCopying>)key] ;
+                } else {
+                    [(NSMutableDictionary *)obj removeObjectForKey:(id <NSCopying>)key] ;
+                }
                 if (arrayAutoConversion) {
                     NSUInteger totalKeys = [(NSMutableDictionary *)obj count] ;
                     NSUInteger count     = 0 ;


### PR DESCRIPTION
Object wrapper can properly clear entries in NSDictionary now

Need to find good place/way to document its use and the `ls` functions in general, so holding off for the moment -- at present only `hs.doc` uses this, and it uses it in read-only mode so bug would never occur.

Planning to use this in future `hs.hash` updates, so giving it a review first.