### PR TITLE
Allow overriding log handler in hs.logger. Add option to log to file.

### DIFF
--- a/extensions/logger/init.lua
+++ b/extensions/logger/init.lua
@@ -208,12 +208,14 @@ end
 ---    However, this will log only to the file, leaving the console empty. If you want
 ---    to log to both file and console, you can create a new log handler that calls
 ---    both the file log handler and hs.logger.defaultLogHandler
----    
+--- Example:
+--- ```lua
 ---    local fileHandler = hs.logger.createFileLogHandler('path/example.log')
 ---    hs.logger.logHandler(function(log)
 ---      fileHandler(log)
 ---      hs.logger.defaultLogHandler(log)
 ---    end)
+--- ```
 logger.createFileLogHandler = function(filePath)
   local file = assert(io.open(filePath,'a'))
   file:setvbuf("line")


### PR DESCRIPTION
PR for #1684

Allow overriding log handler in hs.logger with `hs.logger.logHandler()`.
User can use `hs.logger.createFileLogHandler(path)` to create a log handler that logs to a file at the provided path.
Refactor the current handling to the constant logger.defaultLogHandler and use it as the default value for logHandler.

Some example code (also in the function documentation):
```
local fileHandler = hs.logger.createFileLogHandler('path/example.log')
hs.logger.logHandler(function(log)
   fileHandler(log)
   hs.logger.defaultLogHandler(log)
end)
```