### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ What gives Hammerspoon its power is a set of extensions that expose specific pie
  * Drag `Hammerspoon.app` from your `Downloads` folder to `Applications`
 
 ### Homebrew
-  * `brew cask install hammerspoon`
+  * `brew install --cask hammerspoon`
 
 ## What next?
 


### PR DESCRIPTION
Fix error when installing using latest Homebrew in macOS. Just fix README.md.

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103056459-55d5d500-45e0-11eb-8231-2ee903efb2ef.png)
