### PR TITLE
Rewrite hs.notify to remove memory leaks

### DIFF
--- a/extensions/notify/internal.m
+++ b/extensions/notify/internal.m
@@ -1,30 +1,35 @@
 @import Cocoa ;
 @import LuaSkin ;
 
-// #define DEBUGGING
+#import "MJUserNotificationManager.h"
 
-#define USERDATA_TAG    "hs.notify"
-static int refTable = LUA_NOREF ;
+#define DEBUGGING
 
-// NOTE: Hammerspoon's internal notification delegate (from MJUserNotificationManager.h and MJUserNotificationUser.m)
+// NSUserNotification and it's relations are deprecated but we're not ready to switch quite yet...
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 
-@interface MJUserNotificationManager : NSObject
-+ (MJUserNotificationManager*) sharedManager;
-- (void) sendNotification:(NSString*)title handler:(dispatch_block_t)handler;
-@end
+static const char * const USERDATA_TAG = "hs.notify" ;
+static int refTable = LUA_NOREF;
 
-@interface MJUserNotificationManager () <NSUserNotificationCenterDelegate>
-@property NSMutableDictionary* callbacks;
-@end
+// changes made to userInfo dictionary in userNotificationCenter:didDeliverNotification: are not
+// kept (is notification object a copy?) so we can't update delivered if it's in that particular
+// dictionary... track it in here instead, keyed to unique id added when created (see new).
+static NSMutableDictionary *ourNotificationSpecifics ;
 
-// NOTE: Our internals and replacement delegate
+#define KEY_LOCKED        @"locked"
+#define KEY_ID            @"gus"
+#define KEY_WITHDRAWAFTER @"withdrawAfter"
+#define KEY_FNTAG         @"fntag"
+#define KEY_ALWAYSPRESENT @"alwaysPresent"
+#define KEY_AUTOWITHDRAW  @"autoWithdraw"
+#define KEY_SELFREFCOUNT  @"selfRefCount"
+#define KEY_DELIVERED     @"delivered"
 
-@interface ourNotificationManager : NSObject
-+ (ourNotificationManager*) sharedManager;
-@end
+static id <NSUserNotificationCenterDelegate>    old_delegate ;
 
-@interface ourNotificationManager () <NSUserNotificationCenterDelegate>
-@end
+#define get_objectFromUserdata(objType, L, idx, tag) (objType*)*((void**)luaL_checkudata(L, idx, tag))
 
 // Private API for setting notification identity image http://stackoverflow.com/questions/19797841
 @interface NSUserNotification (NSUserNotificationPrivate)
@@ -33,179 +38,142 @@ static int refTable = LUA_NOREF ;
 @property BOOL _alwaysShowAlternateActionMenu; // See: https://stackoverflow.com/questions/33631218/show-nsusernotification-additionalactions-on-click
 @end
 
-static id <NSUserNotificationCenterDelegate>    old_delegate ;
+#pragma mark - Support Functions and Classes
 
-typedef struct _notification_t {
-    BOOL    locked ;      // flag to indicate if changes should no longer be allowed (it's been sent)
-    BOOL    delivered ;   // flag to indicate if notification has been delivered to the User Notification Center
-    void*   note ;        // user notification object itself
-    void*   gus ;         // globally unique identifier for use when verifying/recreating userdata
-    int     withdrawAfter; // Number of seconds after which to auto-withdraw the notification
-} notification_t ;
+@interface HSModuleNotificationManager : NSObject <NSUserNotificationCenterDelegate>
++ (HSModuleNotificationManager*) sharedManager;
+@end
 
-@implementation ourNotificationManager
+@implementation HSModuleNotificationManager
 
 + (instancetype) sharedManager {
-    static ourNotificationManager* sharedManager;
-    static dispatch_once_t onceToken;
+    static HSModuleNotificationManager *sharedManager ;
+    static dispatch_once_t onceToken ;
     dispatch_once(&onceToken, ^{
-        sharedManager = [[ourNotificationManager alloc] init];
-    });
-    return sharedManager;
-}
-
-// Checks to see if userdata exists and is appropriate type at location referenced in userInfo
-// dictionary and creates it if it doesn't exist -- this is necessary for notifications which
-// are delivered or activated after Hammerspoon has been reloaded.
-//
-// Need to add unique identifier in notification_t and userInfo dict to verify correct matchup
-// after reload.
-
-- (notification_t *)getOrCreateUserdata:(NSUserNotification *)notification {
-    LuaSkin *skin = [LuaSkin sharedWithState:NULL];
-    NSMutableDictionary *noteInfoDict = [notification.userInfo mutableCopy];
-    BOOL rebuild = NO ;
-
-    int myHandle = [[noteInfoDict valueForKey:@"userdata"] intValue] ;
-    notification_t *thisNote = NULL ;
-
-    [skin pushLuaRef:refTable ref:myHandle];
-
-    if (lua_type(skin.L, -1) == LUA_TUSERDATA && luaL_testudata(skin.L, -1, USERDATA_TAG)) {
-        thisNote = lua_touserdata(skin.L, -1);
-        if ([[noteInfoDict valueForKey:@"gus"] isEqualToString:(__bridge NSString *)thisNote->gus]) {
-
-            // Because the notification object changes behind the scenes, we need to clear the userdata's
-            // cached version and replace it with the current one at the end.
-            NSUserNotification *tmpHolder = (__bridge_transfer NSUserNotification *) thisNote->note ;
-            tmpHolder = nil ;
-        } else {
-            rebuild = YES ;
-        }
-    } else {
-        rebuild = YES ;
-    }
-
-    if (rebuild) {
-        [skin logBreadcrumb:@"hs.notify: creating new userdata for orphaned notification"] ;
-    // If notification userdata does not exist, then we've been reloaded
-    // and the reference is bad.  Make a new one.
-        thisNote = lua_newuserdata(skin.L, sizeof(notification_t)) ;
-        memset(thisNote, 0, sizeof(notification_t)) ;
-        luaL_getmetatable(skin.L, USERDATA_TAG);
-        lua_setmetatable(skin.L, -2);
-    // this function is only called for an orphaned notification, so it's safe to assume it's
-    // either being delivered or activated right now (i.e. previously delivered)
-        thisNote->delivered = YES;
-        thisNote->locked    = YES ;
-        thisNote->gus       = (__bridge_retained void *)[noteInfoDict valueForKey:@"gus"] ;
-
-        [noteInfoDict setValue:[NSNumber numberWithInt:[skin luaRef:refTable]]
-                        forKey:@"userdata"];
-        notification.userInfo = noteInfoDict ;
-    }
-
-    lua_pop(skin.L, 1) ;  // Clear the stack of our userdata, retrieved or new
-
-    thisNote->note = (__bridge_retained void *) notification;
-    return thisNote ;
+        sharedManager = [[HSModuleNotificationManager alloc] init] ;
+    }) ;
+    return sharedManager ;
 }
 
 // Notification delivered to Notification Center
-- (void)userNotificationCenter:(NSUserNotificationCenter *)center
-        didDeliverNotification:(NSUserNotification *)notification {
+- (void)userNotificationCenter:(NSUserNotificationCenter *)center didDeliverNotification:(NSUserNotification *)notification {
+//     [LuaSkin logInfo:[NSString stringWithFormat:@"%s in didDeliverNotification %@", USERDATA_TAG, notification.userInfo]] ;
 
-    // NSlog(@"in didDeliverNotification") ;
+    // if it's ours, we've copied the necessary info into the userInfo dictionary...
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    if (gus) {
+        // however we *might* need to recreate the local record so we can update KEY_DELIVERED
+        NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+        if (!userInfo) {
+            ourNotificationSpecifics[gus] = [notification.userInfo mutableCopy] ;
+            userInfo = ourNotificationSpecifics[gus] ;
+        }
+        userInfo[KEY_DELIVERED] = @(YES) ;
 
-    NSString *fnTag = [notification.userInfo valueForKey:@"tag"] ;
+        NSNumber       *NSwithdrawAfter = userInfo[KEY_WITHDRAWAFTER] ;
+        NSTimeInterval withdrawAfter    = NSwithdrawAfter ? NSwithdrawAfter.doubleValue : 0.0 ;
 
-    notification_t *thisNote = [self getOrCreateUserdata:notification] ;  // necessary in case of reload
-
-    if (fnTag) {
-        thisNote->delivered = YES ;
-    } // not one of ours, and MJUserNotificationManager doesn't use this, so do nothing else
-
-    if (thisNote->withdrawAfter > 0) {
-        [center performSelector:@selector(removeDeliveredNotification:) withObject:notification afterDelay:(NSTimeInterval)thisNote->withdrawAfter];
-    }
+        if (withdrawAfter > 0) {
+            [center performSelector:@selector(removeDeliveredNotification:)
+                         withObject:notification
+                         afterDelay:withdrawAfter];
+        }
+    } // else not one of ours, and MJUserNotificationManager doesn't use this, so do nothing else
 }
 
 // User clicked on notification...
-- (void)userNotificationCenter:(NSUserNotificationCenter *)center
-       didActivateNotification:(NSUserNotification *)notification {
+- (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification {
+//     [LuaSkin logInfo:[NSString stringWithFormat:@"%s in didActivateNotification %@", USERDATA_TAG, notification.userInfo]] ;
 
-    // NSLog(@"in didActivateNotification") ;
+    // if it's ours, we've copied the necessary info into the userInfo dictionary...
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    if (gus) {
+        // however we *might* need to recreate the local record so we can update KEY_DELIVERED
+        NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+        if (!userInfo) {
+            ourNotificationSpecifics[gus] = [notification.userInfo mutableCopy] ;
+            userInfo = ourNotificationSpecifics[gus] ;
+        }
+        userInfo[KEY_DELIVERED] = @(YES) ; // just in case its a holdover from before a reload/relaunch
 
-        NSString *fnTag = [notification.userInfo valueForKey:@"tag"] ;
+        LuaSkin   *skin = [LuaSkin sharedWithState:NULL];
+        lua_State *L    = skin.L ;
 
-        if (fnTag) {
-            LuaSkin *skin = [LuaSkin sharedWithState:NULL];
-            _lua_stackguard_entry(skin.L);
+        _lua_stackguard_entry(L);
+        if (![skin requireModule:"hs.notify"]) {
+            [skin logError:[NSString stringWithFormat:@"%s:_didActivateNotification - unable to load tag handler: %s", USERDATA_TAG, lua_tostring(L, -1)]] ;
+            lua_pop(L, 1) ; // remove error message
+            _lua_stackguard_exit(L);
+            return;
+        }
+        lua_getfield(L, -1, "_tag_handler") ; // now we know the function hs.notify._tag_handler is on the stack...
+        [skin pushNSObject:userInfo[KEY_FNTAG]] ;
+        [skin pushNSObject:notification] ;
 
-        // maybe a little more overhead than just assuming its there and putting logic in init.lua to
-        // make sure hs.notify is in the right place, but this is more portable and doesn't rely on
-        // assumptions.  And luaL_requiref requires knowing the open function name...
-            lua_getglobal(skin.L, "require") ;
-            lua_pushstring(skin.L, "hs.notify") ;
-            if (![skin protectedCallAndTraceback:1 nresults:1]) {
-                const char *errorMsg = lua_tostring(skin.L, -1);
-                [skin logError:[NSString stringWithFormat:@"Unable to require('hs.notify'): %s", errorMsg]];
-                lua_pop(skin.L, 1) ; // remove error message
-                _lua_stackguard_exit(skin.L);
-                return;
-            }
-            lua_getfield(skin.L, -1, "_tag_handler") ;
-        // now we know the function hs.notify._tag_handler is on the stack...
+        if ([skin protectedCallAndError:[NSString stringWithFormat:@"%s callback", USERDATA_TAG] nargs:2 nresults:0] == NO) {
+            lua_pop(L, 1); // pop the hs.notify module
+            _lua_stackguard_exit(L);
+            return;
+        }
+        lua_pop(L, 1); // pop the hs.notify module
 
-            lua_pushstring(skin.L, [fnTag UTF8String]) ;
+        NSNumber *NSshouldWithdraw = userInfo[KEY_AUTOWITHDRAW] ;
+        BOOL shouldWithdraw = NSshouldWithdraw ? NSshouldWithdraw.boolValue : YES ;
+        if (notification.deliveryRepeatInterval != nil) shouldWithdraw = YES ;
 
-            notification_t __unused *thisNote = [self getOrCreateUserdata:notification] ; // necessary in case of reload
-            [skin pushLuaRef:refTable ref:[[notification.userInfo valueForKey:@"userdata"] intValue]];
-
-    // NSLog(@"invoking callback handler") ;
-
-            if ([skin protectedCallAndError:@"hs.notify callback" nargs:2 nresults:0] == NO) {
-                lua_pop(skin.L, 1); // pop the hs.notify module
-                _lua_stackguard_exit(skin.L);
-                return;
-            }
-            lua_pop(skin.L, 1); // pop the hs.notify module
-
-            BOOL shouldWithdraw = [[notification.userInfo valueForKey:@"autoWithdraw"] boolValue] ;
-            if (notification.deliveryRepeatInterval != nil) shouldWithdraw = YES ;
-
-            if (shouldWithdraw) {
-                [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification:notification];
-                [[NSUserNotificationCenter defaultUserNotificationCenter] removeScheduledNotification:notification];
-            }
-            _lua_stackguard_exit(skin.L);
-        } else {
-    // NSLog(@"hs.notify passing off to original handler") ;
-            if ([old_delegate respondsToSelector:@selector(userNotificationCenter:didActivateNotification:)]) {
-                [old_delegate userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:notification];
-            }
+        if (shouldWithdraw) {
+            [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification:notification];
+            [[NSUserNotificationCenter defaultUserNotificationCenter] removeScheduledNotification:notification];
+        }
+        _lua_stackguard_exit(skin.L);
+    } else {
+        [LuaSkin logInfo:[NSString stringWithFormat:@"%s passing off to original handler", USERDATA_TAG]] ;
+        if ([old_delegate respondsToSelector:@selector(userNotificationCenter:didActivateNotification:)]) {
+            [old_delegate userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:notification];
         }
     }
+}
 
 // Should notification show, even if we're the foremost application?
-- (BOOL)userNotificationCenter:(NSUserNotificationCenter __unused *)center
-     shouldPresentNotification:(NSUserNotification *)notification {
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter __unused *)center shouldPresentNotification:(NSUserNotification *)notification {
+//     [LuaSkin logInfo:[NSString stringWithFormat:@"%s in shouldPresentNotification %@", USERDATA_TAG, notification.userInfo]] ;
 
-    // NSLog(@"in shouldPresentNotification") ;
-
-        NSNumber *shouldPresent = [notification.userInfo valueForKey:@"alwaysPresent"] ;
-        if (shouldPresent != nil) {
-            notification_t __unused *thisNote = [self getOrCreateUserdata:notification] ; // necessary in case of reload
-            return (BOOL)[shouldPresent boolValue] ;
-        } else // MJNotificationManager just returns YES, so this is simpler.
-            return YES ;
+    // if it's ours, we've copied the necessary info into the userInfo dictionary...
+    NSNumber *shouldPresent = notification.userInfo[KEY_ALWAYSPRESENT] ;
+    if (shouldPresent != nil) {
+        return (BOOL)(shouldPresent.boolValue) ;
+    } else { // MJNotificationManager just returns YES, so this is simpler.
+        return YES ;
     }
+}
 
 @end
 
-// NOTE: hs.notify functions that interface with Lua
+static void notification_delegate_setup() {
+    // Get and store old (core app) delegate.  If it hasn't been setup yet, do so.
+    old_delegate = [[NSUserNotificationCenter defaultUserNotificationCenter] delegate];
+    if (!old_delegate) {
+        [MJUserNotificationManager sharedManager];
+        old_delegate = [[NSUserNotificationCenter defaultUserNotificationCenter] delegate];
+    }
+    // Create our delegate
+    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:[HSModuleNotificationManager sharedManager]];
+}
 
-static int notification_withdraw_all(lua_State* __unused L) {
+static NSDate* date_from_string(NSString* dateString) {
+    // rfc3339 (Internet Date/Time) formated date.  More or less.
+    NSDateFormatter *rfc3339DateFormatter = [[NSDateFormatter alloc] init];
+    NSLocale *enUSPOSIXLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    [rfc3339DateFormatter setLocale:enUSPOSIXLocale];
+    [rfc3339DateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"];
+    [rfc3339DateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+
+    NSDate *date = [rfc3339DateFormatter dateFromString:dateString];
+    return date;
+}
+
+#pragma mark - Module Functions
+
 /// hs.notify.withdrawAll()
 /// Function
 /// Withdraw all delivered notifications from Hammerspoon
@@ -218,11 +186,13 @@ static int notification_withdraw_all(lua_State* __unused L) {
 ///
 /// Notes:
 ///  * This will withdraw all notifications for Hammerspoon, including those not sent by this module or that linger from a previous load of Hammerspoon.
+static int notification_withdraw_all(lua_State* L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    [skin checkArgs:LS_TBREAK] ;
     [[NSUserNotificationCenter defaultUserNotificationCenter] removeAllDeliveredNotifications];
     return 0;
 }
 
-static int notification_withdraw_allScheduled(lua_State* __unused L) {
 /// hs.notify.withdrawAllScheduled()
 /// Function
 /// Withdraw all scheduled notifications from Hammerspoon
@@ -232,6 +202,9 @@ static int notification_withdraw_allScheduled(lua_State* __unused L) {
 ///
 /// Returns:
 ///  * None
+static int notification_withdraw_allScheduled(lua_State* L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    [skin checkArgs:LS_TBREAK] ;
     ([NSUserNotificationCenter defaultUserNotificationCenter]).scheduledNotifications = @[];
     return 0;
 }
@@ -269,7 +242,15 @@ static int notification_withdraw_allScheduled(lua_State* __unused L) {
 static int notification_deliveredNotifications(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L] ;
     [skin checkArgs:LS_TBREAK] ;
-    [skin pushNSObject:[[NSUserNotificationCenter defaultUserNotificationCenter] deliveredNotifications]] ;
+    NSArray *deliveredNotifications = [[NSUserNotificationCenter defaultUserNotificationCenter] deliveredNotifications] ;
+
+    [skin pushNSObject:deliveredNotifications] ;
+    // just in case pushNSUserNotification had to recreate our entries in ourNotificationSpecifics
+    for (NSUserNotification *notification in deliveredNotifications) {
+        NSString *gus = notification.userInfo[KEY_ID] ;
+        NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+        userInfo[KEY_DELIVERED] = @(YES) ;
+    }
     return 1 ;
 }
 
@@ -294,48 +275,38 @@ static int notification_scheduledNotifications(lua_State *L) {
     return 1 ;
 }
 
-static int notification_new(lua_State* L) {
 // NOTE: THIS FUNCTION IS WRAPPED IN init.lua
 // hs.notify._new(fntag) -> notificationObject
 // Constructor
 // Returns a new notification object with the specified information and the assigned callback function.
+static int notification_new(lua_State* L) {
     LuaSkin *skin  = [LuaSkin sharedWithState:L];
-    NSString *myID = [[NSProcessInfo processInfo] globallyUniqueString] ;
+    [skin checkArgs:LS_TSTRING, LS_TBREAK] ;
+    NSString *gus = [[NSProcessInfo processInfo] globallyUniqueString] ;
 
-    NSMutableDictionary *noteInfoDict = [@{
-                              @"autoWithdraw": @(YES),
-                              @"alwaysPresent":@(YES),
-                              @"gus":          myID,
-//                            @"tag":          see below,
-//                            @"userdata":     see below,
-    } mutableCopy];
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{
+        KEY_LOCKED        : @(NO),
+        KEY_ID            : gus,
+        KEY_WITHDRAWAFTER : @(0.0),
+        KEY_FNTAG         : [skin toNSObjectAtIndex:1],
+        KEY_ALWAYSPRESENT : @(YES),
+        KEY_AUTOWITHDRAW  : @(YES),
+        KEY_SELFREFCOUNT  : @(0),
+        KEY_DELIVERED     : @(NO)
+    }] ;
 
-    notification_t* notification = lua_newuserdata(L, sizeof(notification_t)) ;
-    memset(notification, 0, sizeof(notification_t)) ;
+    ourNotificationSpecifics[gus] = userInfo ;
 
-    [noteInfoDict setValue:[NSString stringWithUTF8String:luaL_checkstring(L, 1)]
-                     forKey:@"tag"] ;
-    lua_pushvalue(L, -1) ;
-    [noteInfoDict setValue:[NSNumber numberWithInt:[skin luaRef:refTable]]
-                     forKey:@"userdata"];
+    NSUserNotification* notification = [[NSUserNotification alloc] init];
+    notification.userInfo            = @{ KEY_ID : gus } ;
+    notification.hasActionButton     = NO;
 
-    NSUserNotification* note = [[NSUserNotification alloc] init];
-    note.userInfo            = noteInfoDict ;
-    note.hasActionButton     = NO;
-
-    notification->delivered = NO ;
-    notification->locked    = NO ;
-
-    notification->note = (__bridge_retained void *)note;
-    notification->gus  = (__bridge_retained void *)myID;
-
-    luaL_getmetatable(L, USERDATA_TAG);
-    lua_setmetatable(L, -2);
-
+    [skin pushNSObject:notification] ;
     return 1;
 }
 
-static int notification_send(lua_State* L) {
+#pragma mark - Module Methods
+
 /// hs.notify:send() -> notificationObject
 /// Method
 /// Delivers the notification immediately to the users Notification Center.
@@ -350,26 +321,22 @@ static int notification_send(lua_State* L) {
 ///  * See also hs.notify:schedule()
 ///  * If a notification has been modified, then this will resend it.
 ///  * You can invoke this multiple times if you wish to repeat the same notification.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    notification->locked = YES ;
-    lua_settop(L,1);
-    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:(__bridge NSUserNotification*)notification->note];
-    return 1;
+static int notification_send(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    userInfo[KEY_DELIVERED] = @(NO) ;
+    userInfo[KEY_LOCKED] = @(YES) ;
+    notification.userInfo = [userInfo copy] ;
+
+    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification] ;
+    lua_pushvalue(L, 1) ;
+    return 1 ;
 }
 
-static NSDate* date_from_string(NSString* dateString) {
-    // rfc3339 (Internet Date/Time) formated date.  More or less.
-    NSDateFormatter *rfc3339DateFormatter = [[NSDateFormatter alloc] init];
-    NSLocale *enUSPOSIXLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
-    [rfc3339DateFormatter setLocale:enUSPOSIXLocale];
-    [rfc3339DateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"];
-    [rfc3339DateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
-
-    NSDate *date = [rfc3339DateFormatter dateFromString:dateString];
-    return date;
-}
-
-static int notification_scheduleNotification(lua_State* L) {
 /// hs.notify:schedule(date) -> notificationObject
 /// Method
 /// Schedules a notification for delivery in the future.
@@ -383,28 +350,31 @@ static int notification_scheduleNotification(lua_State* L) {
 /// Notes:
 ///  * See also hs.notify:send()
 ///  * hs.settings.dateFormat specifies a lua format string which can be used with `os.date()` to properly present the date and time as a string for use with this method.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+static int notification_scheduleNotification(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TNUMBER, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
     NSDate* myDate = lua_isnumber(L, 2) ? [[NSDate alloc] initWithTimeIntervalSince1970:(NSTimeInterval) lua_tonumber(L,2)] :
                      lua_isstring(L, 2) ? date_from_string([NSString stringWithUTF8String:lua_tostring(L, 2)]) : nil ;
     if (myDate) {
-        ((__bridge NSUserNotification *) notification->note).deliveryDate = myDate ;
+        notification.deliveryDate = myDate ;
     } else {
-        return luaL_error(L, "-- hs.notify:schedule: improper date specified: must be a number (# of seconds since 1970-01-01 00:00:00Z) or string in the format of 'YYYY-MM-DD[T]HH:MM:SS[Z]' (rfc3339)") ;
+        return luaL_error(L, "-- %s:schedule: improper date specified: must be a number (# of seconds since 1970-01-01 00:00:00Z) or string in the format of 'YYYY-MM-DD[T]HH:MM:SS[Z]' (rfc3339)", USERDATA_TAG) ;
     }
 
-    notification->locked    = YES ;
-    [[NSUserNotificationCenter defaultUserNotificationCenter] scheduleNotification:(__bridge NSUserNotification*)notification->note];
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    userInfo[KEY_DELIVERED] = @(NO) ;
+    userInfo[KEY_LOCKED] = @(YES) ;
+    notification.userInfo = [userInfo copy] ;
 
+    [[NSUserNotificationCenter defaultUserNotificationCenter] scheduleNotification:notification] ;
     lua_settop(L,1);
     return 1;
 }
 
-// Too easy to create runaway repeaters that persist through reboots.  Default Hammerspoon delegate and this one would stop it if
-// activated (user clicks on it) but only if Hammerspoon is available and running.  Also possible to "recapture" userdata in a callback
-// by swapping it out after a reload of Hammerspoon and using that to withdraw, but that's more complex then I want to describe in
-// the core docs.  Better to put this into an external module so only those who really want it have to deal with the possible messes.
+// Too easy to create runaway repeaters that persist through reboots.
 //
-// static int notification_deliveryRepeatInterval(lua_State* L) {
 // /// hs.notify:repeatInterval([seconds]) -> notificationObject | current-setting
 // /// Method
 // /// Get or set the repeat interval for a notification which is to be scheduled.
@@ -420,31 +390,9 @@ static int notification_scheduleNotification(lua_State* L) {
 // ///  * A repeating notification will autoWithdraw when activated. Setting this to anything but 0 will cause the notification to ignore `hs.notify:autoWithdraw()`.
 // ///  * The interval must be at least 60 seconds (1 minute).
 // ///  * Specify an interval of 0 if the notification should not repeat.
-//     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-//     if (lua_isnone(L, 2)) {
-//         NSDateComponents *interval = ((__bridge NSUserNotification *) notification->note).deliveryRepeatInterval ;
-//         lua_pushinteger(L, interval.second) ;
-//    } else if (!notification->locked) {
-//         luaL_checktype(L, 2, LUA_TNUMBER) ;
-//         lua_Integer seconds = lua_tointeger(L, 2) ;
-//         if (seconds == 0) {
-//             ((__bridge NSUserNotification *) notification->note).deliveryRepeatInterval = nil ;
-//         } else if (seconds < 60) {
-//             return luaL_error(L, "notification repeat interval must be 60 seconds or greater") ;
-//         } else {
-//             NSDateComponents *interval = [[NSDateComponents alloc] init];
-//             [interval setSecond:seconds];
-//             ((__bridge NSUserNotification *) notification->note).deliveryRepeatInterval = interval ;
-//         }
-//         notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-//         lua_settop(L, 1) ;
-//     } else {
-//         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
-//     }
-//     return 1;
+// static int notification_deliveryRepeatInterval(lua_State* L) {
 // }
 
-static int notification_withdraw(lua_State* L) {
 /// hs.notify:withdraw() -> notificationObject
 /// Method
 /// Withdraws a delivered notification from the Notification Center.
@@ -454,16 +402,31 @@ static int notification_withdraw(lua_State* L) {
 ///
 /// Returns:
 ///  * The notification object
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification: (__bridge NSUserNotification*)notification->note];
-    [[NSUserNotificationCenter defaultUserNotificationCenter] removeScheduledNotification: (__bridge NSUserNotification*)notification->note];
-    notification->locked    = NO ;
+///  * This method allows you to unlock a dispatched notification so that it can be modified and resent.
+static int notification_withdraw(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
 
-    lua_settop(L, 1) ;
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (isLocked.boolValue == YES) {
+        [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification:notification];
+        [[NSUserNotificationCenter defaultUserNotificationCenter] removeScheduledNotification:notification];
+
+        userInfo[KEY_DELIVERED] = @(NO) ;
+        userInfo[KEY_LOCKED] = @(NO) ;
+        notification.userInfo = @{ KEY_ID : gus } ;
+    } else {
+        return luaL_error(L, "notification has not yet been dispatched and cannot be withdrawn") ;
+    }
+
+    lua_pushvalue(L, 1) ;
     return 1;
 }
 
-static int notification_title(lua_State* L) {
 /// hs.notify:title([titleText]) -> notificationObject | current-setting
 /// Method
 /// Get or set the title of a notification
@@ -473,24 +436,30 @@ static int notification_title(lua_State* L) {
 ///
 /// Returns:
 ///  * The notification object, if titleText is present; otherwise the current setting.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+static int notification_title(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TNIL | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
     if (lua_isnone(L,2)) {
-        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).title UTF8String]);
-    } else if (!notification->locked) {
+        [skin pushNSObject:notification.title] ;
+    } else if (isLocked.boolValue == NO) {
         if (lua_isnil(L,2)) {
-            ((__bridge NSUserNotification *) notification->note).title = @"";
+            notification.title = @"";
         } else {
-            ((__bridge NSUserNotification *) notification->note).title = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
+            notification.title = [skin toNSObjectAtIndex:2] ;
         }
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
 
-static int notification_subtitle(lua_State* L) {
 /// hs.notify:subTitle([subtitleText]) -> notificationObject | current-setting
 /// Method
 /// Get or set the subtitle of a notification
@@ -500,24 +469,30 @@ static int notification_subtitle(lua_State* L) {
 ///
 /// Returns:
 ///  * The notification object, if subtitleText is present; otherwise the current setting.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).subtitle UTF8String]);
-    } else if (!notification->locked) {
+static int notification_subtitle(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TNIL | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        [skin pushNSObject:notification.subtitle] ;
+    } else if (isLocked.boolValue == NO) {
         if (lua_isnil(L,2)) {
-            ((__bridge NSUserNotification *) notification->note).subtitle = nil;
+            notification.subtitle = nil ;
         } else {
-            ((__bridge NSUserNotification *) notification->note).subtitle = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
+            notification.subtitle = [skin toNSObjectAtIndex:2] ;
         }
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
 
-static int notification_informativeText(lua_State* L) {
 /// hs.notify:informativeText([informativeText]) -> notificationObject | current-setting
 /// Method
 /// Get or set the informative text of a notification
@@ -527,24 +502,30 @@ static int notification_informativeText(lua_State* L) {
 ///
 /// Returns:
 ///  * The notification object, if informativeText is present; otherwise the current setting.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).informativeText UTF8String]);
-    } else if (!notification->locked) {
+static int notification_informativeText(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TNIL | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        [skin pushNSObject:notification.informativeText] ;
+    } else if (isLocked.boolValue == NO) {
         if (lua_isnil(L,2)) {
-            ((__bridge NSUserNotification *) notification->note).informativeText = nil;
+            notification.informativeText = nil ;
         } else {
-            ((__bridge NSUserNotification *) notification->note).informativeText = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
+            notification.informativeText = [skin toNSObjectAtIndex:2] ;
         }
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
 
-static int notification_actionButtonTitle(lua_State* L) {
 /// hs.notify:actionButtonTitle([buttonTitle]) -> notificationObject | current-setting
 /// Method
 /// Get or set the label of a notification's action button
@@ -558,27 +539,30 @@ static int notification_actionButtonTitle(lua_State* L) {
 /// Notes:
 ///  * The affects of this method only apply if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences
 ///  * This value is ignored if [hs.notify:hasReplyButton](#hasReplyButton) is true.
-    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+static int notification_actionButtonTitle(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TNIL | LS_TOPTIONAL, LS_TBREAK] ;
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).actionButtonTitle UTF8String]);
-    } else if (!notification->locked) {
-        NSString *title = lua_isnil(L, 2) ? nil : [skin toNSObjectAtIndex:2] ;
-        if (!title) {
-            ((__bridge NSUserNotification *) notification->note).actionButtonTitle = @"";
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        [skin pushNSObject:notification.actionButtonTitle] ;
+    } else if (isLocked.boolValue == NO) {
+        if (lua_isnil(L,2)) {
+            notification.actionButtonTitle = @"" ;
         } else {
-            ((__bridge NSUserNotification *) notification->note).actionButtonTitle = title ;
+            notification.actionButtonTitle = [skin toNSObjectAtIndex:2] ;
         }
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
 
-static int notification_otherButtonTitle(lua_State* L) {
 /// hs.notify:otherButtonTitle([buttonTitle]) -> notificationObject | current-setting
 /// Method
 /// Get or set the label of a notification's other button
@@ -592,27 +576,30 @@ static int notification_otherButtonTitle(lua_State* L) {
 /// Notes:
 ///  * The affects of this method only apply if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences
 ///  * Due to OSX limitations, it is NOT possible to get a callback for this button.
-    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+static int notification_otherButtonTitle(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TNIL | LS_TOPTIONAL, LS_TBREAK] ;
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).otherButtonTitle UTF8String]);
-    } else if (!notification->locked) {
-        NSString *title = lua_isnil(L, 2) ? nil : [skin toNSObjectAtIndex:2] ;
-        if (!title) {
-            ((__bridge NSUserNotification *) notification->note).otherButtonTitle = @"";
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        [skin pushNSObject:notification.otherButtonTitle] ;
+    } else if (isLocked.boolValue == NO) {
+        if (lua_isnil(L,2)) {
+            notification.otherButtonTitle = @"" ;
         } else {
-            ((__bridge NSUserNotification *) notification->note).otherButtonTitle = title;
+            notification.otherButtonTitle = [skin toNSObjectAtIndex:2] ;
         }
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
 
-static int notification_hasActionButton(lua_State* L) {
 /// hs.notify:hasActionButton([hasButton]) -> notificationObject | current-setting
 /// Method
 /// Get or set the presence of an action button in a notification
@@ -625,20 +612,26 @@ static int notification_hasActionButton(lua_State* L) {
 ///
 /// Notes:
 ///  * The affects of this method only apply if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note).hasActionButton);
-    } else if (!notification->locked) {
-        ((__bridge NSUserNotification *) notification->note).hasActionButton = (BOOL) lua_toboolean(L, 2);
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+static int notification_hasActionButton(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        lua_pushboolean(L, notification.hasActionButton) ;
+    } else if (isLocked.boolValue == NO) {
+        notification.hasActionButton = (BOOL)(lua_toboolean(L, 2)) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
 
-static int notification_alwaysPresent(lua_State* L) {
 /// hs.notify:alwaysPresent([alwaysPresent]) -> notificationObject | current-setting
 /// Method
 /// Get or set whether a notification should be presented even if this overrides Notification Center's decision process.
@@ -652,44 +645,47 @@ static int notification_alwaysPresent(lua_State* L) {
 /// Notes:
 ///  * This does not affect the return value of `hs.notify:presented()` -- that will still reflect the decision of the Notification Center
 ///  * Examples of why the users Notification Center would choose not to display a notification would be if Hammerspoon is the currently focussed application, being attached to a projector, or the user having set Do Not Disturb.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        BOOL alwaysPresent = [(NSNumber *)[((__bridge NSUserNotification *) notification->note).userInfo valueForKey:@"alwaysPresent"] boolValue];
-        lua_pushboolean(L, alwaysPresent);
-    } else if (!notification->locked) {
-        NSMutableDictionary *noteInfoDict = [((__bridge NSUserNotification *) notification->note).userInfo mutableCopy];
-        [noteInfoDict setValue:@((BOOL)lua_toboolean(L, 2)) forKey:@"alwaysPresent"] ;
-        ((__bridge NSUserNotification *) notification->note).userInfo = noteInfoDict ;
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+static int notification_alwaysPresent(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        NSNumber *alwaysPresent = userInfo[KEY_ALWAYSPRESENT] ;
+        lua_pushboolean(L, alwaysPresent.boolValue) ;
+    } else if (isLocked.boolValue == NO) {
+        userInfo[KEY_ALWAYSPRESENT] = lua_toboolean(L, 2) ? @(YES) : @(NO) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
 
-static int notification_release(lua_State* L) {
-/// hs.notify:release() -> notificationObject
-/// Method
-/// This is a no-op included for backwards compatibility.
-///
-/// Parameters:
-///  * None
-///
-/// Returns:
-///  * The notification object
-///
-/// Notes:
-///  * This is no longer required during garbage collection as function tags can be re-established after a reload.
-///  * The proper way to release a notifications callback is to remove its tag from the [hs.notify.registry](#registry) with [hs.notify.unregister](#unregister).
-///  * This is included for backwards compatibility.
+// /// hs.notify:release() -> notificationObject
+// /// Method
+// /// This is a no-op included for backwards compatibility.
+// ///
+// /// Parameters:
+// ///  * None
+// ///
+// /// Returns:
+// ///  * The notification object
+// ///
+// /// Notes:
+// ///  * This is no longer required during garbage collection as function tags can be re-established after a reload.
+// ///  * The proper way to release a notifications callback is to remove its tag from the [hs.notify.registry](#registry) with [hs.notify.unregister](#unregister).
+// ///  * This is included for backwards compatibility.
+// static int notification_release(lua_State* L) {
+//     [LuaSkin logInfo:[NSString stringWithFormat:@"%s:release() is a no-op. If you want to remove a notification's callback, see hs.notify:getFunctionTag().", USERDATA_TAG] ;
+//     lua_pushvalue(L, 1) ;
+//     return 1;
+// }
 
-    [[LuaSkin sharedWithState:L] logInfo:@"hs.notify:release() is a no-op. If you want to remove a notification's callback, see hs.notify:getFunctionTag()."] ;
-    lua_settop(L, 1) ;
-    return 1;
-}
-
-static int notification_getFunctionTag(lua_State* L) {
 /// hs.notify:getFunctionTag() -> functiontag
 /// Method
 /// Return the name of the function tag the notification will call when activated.
@@ -702,15 +698,18 @@ static int notification_getFunctionTag(lua_State* L) {
 ///
 /// Notes:
 ///  * This tag should correspond to a function in [hs.notify.registry](#registry) and can be used to either add a replacement with `hs.notify.register(...)` or remove it with `hs.notify.unregister(...)`
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+static int notification_getFunctionTag(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
 
-    NSString *fnTag = [((__bridge NSUserNotification *) notification->note).userInfo valueForKey:@"tag"] ;
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
 
-    lua_pushstring(L, [fnTag UTF8String]) ;
+    [skin pushNSObject:userInfo[KEY_FNTAG]] ;
     return 1;
 }
 
-static int notification_autoWithdraw(lua_State* L) {
 /// hs.notify:autoWithdraw([shouldWithdraw]) -> notificationObject | current-setting
 /// Method
 /// Get or set whether a notification should automatically withdraw once activated
@@ -724,23 +723,27 @@ static int notification_autoWithdraw(lua_State* L) {
 /// Note:
 ///  * This method has no effect if the user has set Hammerspoon notifications to `Alert` in the Notification Center pane of System Preferences: clicking on either the action or other button will clear the notification automatically.
 ///  * If a notification which was created before your last reload (or restart) of Hammerspoon and is clicked upon before hs.notify has been loaded into memory, this setting will not be honored because the initial application delegate is not aware of this option and is set to automatically withdraw all notifications which are acted upon.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        BOOL autoWithdraw = [(NSNumber *)[((__bridge NSUserNotification *) notification->note).userInfo valueForKey:@"autoWithdraw"] boolValue];
-        lua_pushboolean(L, autoWithdraw);
-    } else if (!notification->locked) {
-        NSMutableDictionary *noteInfoDict = [((__bridge NSUserNotification *) notification->note).userInfo mutableCopy];
-        [noteInfoDict setValue:@((BOOL)lua_toboolean(L, 2)) forKey:@"autoWithdraw"] ;
-        ((__bridge NSUserNotification *) notification->note).userInfo = noteInfoDict ;
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+static int notification_autoWithdraw(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        NSNumber *alwaysPresent = userInfo[KEY_AUTOWITHDRAW] ;
+        lua_pushboolean(L, alwaysPresent.boolValue) ;
+    } else if (isLocked.boolValue == NO) {
+        userInfo[KEY_AUTOWITHDRAW] = lua_toboolean(L, 2) ? @(YES) : @(NO) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
 
-static int notification_soundName(lua_State* L) {
 /// hs.notify:soundName([soundName]) -> notificationObject | current-setting
 /// Method
 /// Get or set the sound for a notification
@@ -757,84 +760,77 @@ static int notification_soundName(lua_State* L) {
 ///   * `/Library/Sounds`
 ///   * `/Network/Sounds`
 ///   * `/System/Library/Sounds`
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        lua_pushstring(L, [((__bridge NSUserNotification *) notification->note).soundName UTF8String]);
-    } else if (!notification->locked) {
+static int notification_soundName(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TNIL | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        [skin pushNSObject:notification.soundName] ;
+    } else if (isLocked.boolValue == NO) {
         if (lua_isnil(L,2)) {
-            ((__bridge NSUserNotification *) notification->note).soundName = nil;
+            notification.soundName = nil ;
         } else {
-            ((__bridge NSUserNotification *) notification->note).soundName = [NSString stringWithUTF8String: luaL_checkstring(L, 2)];
+            notification.soundName = [skin toNSObjectAtIndex:2] ;
         }
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
 
-static int notification_contentImage(lua_State *L) {
 // NOTE: THIS FUNCTION IS WRAPPED IN init.lua
-    NSImage *contentImage;
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
-    if (lua_isnone(L, 2)) {
-        if ([((__bridge NSUserNotification *) notification->note) respondsToSelector:@selector(contentImage)]) {
-            contentImage = ((__bridge NSUserNotification *) notification->note).contentImage ;
-            [skin pushNSObject:contentImage];
-        } else {
-            lua_pushnil(L) ;
-        }
-    } else if (!notification->locked) {
-        if ([((__bridge NSUserNotification *) notification->note) respondsToSelector:@selector(contentImage)]) {
-            contentImage = [skin luaObjectAtIndex:2 toClass:"NSImage"] ;
-            if (!contentImage) {
-                return luaL_error(L, "invalid image specified");
-            } else {
-                contentImage = ((__bridge NSUserNotification *) notification->note).contentImage = contentImage ;
-                notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-                lua_settop(L, 1) ;
-            }
-        } else {
-            [skin logInfo:@"hs.notify:contentImage() is only supported in OS X 10.9 and newer."] ;
-            lua_settop(L, 1) ;
-        }
+static int notification_contentImage(lua_State *L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK | LS_TVARARG] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        [skin pushNSObject:notification.contentImage];
+    } else if (isLocked.boolValue == NO) {
+        [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TUSERDATA, "hs.image", LS_TBREAK] ;
+        notification.contentImage = [skin toNSObjectAtIndex:2] ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
-    return 1 ;
+    return 1;
 }
 
-static int notification_setIdImage(lua_State *L) {
 // NOTE: THIS FUNCTION IS WRAPPED IN init.lua
+static int notification_setIdImage(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TUSERDATA, "hs.image", LS_TBOOLEAN, LS_TBREAK];
-    notification_t *notificationUserdata = luaL_checkudata(L, 1, USERDATA_TAG);
-    BOOL hasBorder = (BOOL)lua_toboolean(L, 3);
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
 
-    NSUserNotification *notification = ((__bridge NSUserNotification *) notificationUserdata->note);
-    if (!([notification respondsToSelector:@selector(set_identityImage:)] &&
-          [notification respondsToSelector:@selector(_identityImageHasBorder)])) {
-        [skin logInfo:@"hs.notify:setIdImage() is not supported. Please file an issue"];
-        lua_settop(L, 1);
-    }
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
 
-    if (!notificationUserdata->locked) {
-        NSImage *idImage = [skin luaObjectAtIndex:2 toClass:"NSImage"];
-        if (!(idImage && idImage.valid)) {
-            return luaL_error(L, "invalid image specified");
-        } else {
+    if (isLocked.boolValue == NO) {
+        NSImage *idImage = [skin toNSObjectAtIndex:2] ;
+        BOOL hasBorder = (BOOL)(lua_toboolean(L, 3)) ;
+
+        if ([notification respondsToSelector:@selector(set_identityImage:)] && [notification respondsToSelector:@selector(_identityImageHasBorder)]) {
             [notification set_identityImage:idImage];
             notification._identityImageHasBorder = hasBorder;
-            notificationUserdata->delivered = NO; // modifying a notification means that it is considered new by the User Notification Center
-            lua_settop(L, 1);
+        } else {
+            [skin logInfo:[NSString stringWithFormat:@"%s:setIdImage() is not supported on this machine or macOS version. Please file an issue", USERDATA_TAG]];
         }
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified");
     }
-
-    return 1;
+    return 1 ;
 }
 
 /// hs.notify:hasReplyButton([state]) -> notificationObject | boolean
@@ -852,14 +848,19 @@ static int notification_setIdImage(lua_State *L) {
 ///  * [hs.notify:hasActionButton](#hasActionButton) must also be true or the "Reply" button will not be displayed.
 ///  * If this is set to true, the action button will be "Reply" even if you have set another one with [hs.notify:actionButtonTitle](#actionButtonTitle).
 static int notification_hasReplyButton(lua_State *L) {
-    [[LuaSkin sharedWithState:L] checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note).hasReplyButton);
-    } else if (!notification->locked) {
-        ((__bridge NSUserNotification *) notification->note).hasReplyButton = (BOOL) lua_toboolean(L, 2);
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        lua_pushboolean(L, notification.hasReplyButton) ;
+    } else if (isLocked.boolValue == NO) {
+        notification.hasReplyButton = (BOOL)(lua_toboolean(L, 2)) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
@@ -881,15 +882,25 @@ static int notification_hasReplyButton(lua_State *L) {
 ///  * [hs.notify:additionalActions](#additionalActions) must also be used for this method to have any effect.
 ///  * **WARNING:** This method uses a private API. It could break at any time. Please file an issue if it does.
 static int notification_alwaysShowAdditionalActions(lua_State *L) {
-    [[LuaSkin sharedWithState:L] checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note)._alwaysShowAlternateActionMenu);
-    } else if (!notification->locked) {
-        ((__bridge NSUserNotification *) notification->note)._alwaysShowAlternateActionMenu = (BOOL) lua_toboolean(L, 2);
-        lua_settop(L, 1) ;
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if ([notification respondsToSelector:@selector(_alwaysShowAlternateActionMenu)]) {
+        if (lua_isnone(L,2)) {
+            lua_pushboolean(L, notification._alwaysShowAlternateActionMenu) ;
+        } else if (isLocked.boolValue == NO) {
+            notification._alwaysShowAlternateActionMenu = (BOOL)(lua_toboolean(L, 2)) ;
+            lua_pushvalue(L, 1) ;
+        } else {
+            return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
+        }
     } else {
-        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
+        [skin logInfo:[NSString stringWithFormat:@"%s:alwaysShowAdditionalActions() is not supported on this machine or macOS version. Please file an issue", USERDATA_TAG]];
     }
     return 1;
 }
@@ -908,16 +919,21 @@ static int notification_alwaysShowAdditionalActions(lua_State *L) {
 ///  * While this setting applies to both Banner and Alert styles of notifications, it is functionally meaningless for Banner styles
 ///  * A value of 0 will disable auto-withdrawal
 static int notification_withdrawAfter(lua_State *L) {
-    LuaSkin *skin = [LuaSkin sharedWithState:L];
-    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TNUMBER | LS_TOPTIONAL, LS_TBREAK];
-    notification_t *notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        lua_pushnumber(L, notification->withdrawAfter);
-    } else if (!notification->locked){
-        notification->withdrawAfter = lua_tonumber(L, 2);
-        lua_settop(L, 1);
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TNUMBER | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        [skin pushNSObject:userInfo[KEY_WITHDRAWAFTER]] ;
+    } else if (isLocked.boolValue == NO) {
+        userInfo[KEY_WITHDRAWAFTER] = [skin toNSObjectAtIndex:2] ;
+        lua_pushvalue(L, 1) ;
     } else {
-        return luaL_error(L, "notification has been dispatched and can no longer be modified");
+        return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
     return 1;
 }
@@ -936,20 +952,23 @@ static int notification_withdrawAfter(lua_State *L) {
 ///  * In macOS 10.13, this text appears so light that it is almost unreadable; so far no workaround has been found.
 ///  * See also [hs.notify:hasReplyButton](#hasReplyButton)
 static int notification_responsePlaceholder(lua_State *L) {
-    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TSTRING | LS_TNIL | LS_TOPTIONAL, LS_TBREAK] ;
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    if (lua_isnone(L, 2)) {
-        [skin pushNSObject:((__bridge NSUserNotification *) notification->note).responsePlaceholder] ;
-    } else if (!notification->locked) {
-        NSString *placeholder = lua_isnil(L, 2) ? nil : [skin toNSObjectAtIndex:2] ;
-        if (!placeholder) {
-            ((__bridge NSUserNotification *) notification->note).responsePlaceholder = @"";
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
+    if (lua_isnone(L,2)) {
+        [skin pushNSObject:notification.responsePlaceholder] ;
+    } else if (isLocked.boolValue == NO) {
+        if (lua_isnil(L,2)) {
+            notification.responsePlaceholder = @"";
         } else {
-            ((__bridge NSUserNotification *) notification->note).responsePlaceholder = placeholder;
+            notification.responsePlaceholder = [skin toNSObjectAtIndex:2] ;
         }
-        notification->delivered = NO ; // modifying a notification means that it is considered new by the User Notification Center
-        lua_settop(L, 1) ;
+        lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
     }
@@ -972,8 +991,9 @@ static int notification_responsePlaceholder(lua_State *L) {
 static int notification_response(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L] ;
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    NSAttributedString *response = ((__bridge NSUserNotification *) notification->note).response ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSAttributedString *response = notification.response ;
     if (response) {
         // since placeholder is a string, and there are no tools to edit within the reply, let's leave it as a string unless someone cares. Remember to local `hs.styledtext` in init.lua if this changes
         [skin pushNSObject:response.string] ;
@@ -1000,9 +1020,14 @@ static int notification_response(lua_State *L) {
 static int notification_additionalActions(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L] ;
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TTABLE | LS_TOPTIONAL, LS_TBREAK] ;
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *isLocked = userInfo[KEY_LOCKED] ;
+
     if (lua_gettop(L) == 1) {
-        NSArray *actions = ((__bridge NSUserNotification *) notification->note).additionalActions ;
+        NSArray *actions = notification.additionalActions ;
         lua_newtable(L) ;
         if (actions) {
             for (NSUserNotificationAction *action in actions) {
@@ -1010,7 +1035,7 @@ static int notification_additionalActions(lua_State *L) {
                 lua_rawseti(L, -2, luaL_len(L, -2) + 1 ) ;
             }
         }
-    } else if (!notification->locked) {
+    } else if (isLocked.boolValue == NO) {
         NSArray *actions = [skin toNSObjectAtIndex:2] ;
         NSMutableArray *newActions = [[NSMutableArray alloc] init] ;
         __block NSString *errorMsg = nil ;
@@ -1027,7 +1052,7 @@ static int notification_additionalActions(lua_State *L) {
             errorMsg = @"expected a table containing an array of strings" ;
         }
         if (errorMsg) return luaL_argerror(L, 2, errorMsg.UTF8String) ;
-        ((__bridge NSUserNotification *) notification->note).additionalActions = newActions ;
+        notification.additionalActions = newActions ;
         lua_pushvalue(L, 1) ;
     } else {
         return luaL_error(L, "notification has been dispatched and can no longer be modified") ;
@@ -1051,8 +1076,9 @@ static int notification_additionalActions(lua_State *L) {
 static int notification_additionalActivationAction(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L] ;
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    NSUserNotificationAction *action = ((__bridge NSUserNotification *) notification->note).additionalActivationAction ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSUserNotificationAction *action = notification.additionalActivationAction ;
     if (action) {
         [skin pushNSObject:action.title] ;
     } else {
@@ -1061,9 +1087,6 @@ static int notification_additionalActivationAction(lua_State *L) {
     return 1 ;
 }
 
-// Get status of a notification
-
-static int notification_presented(lua_State* L) {
 /// hs.notify:presented() -> bool
 /// Method
 /// Returns whether the users Notification Center decided to display the notification
@@ -1076,12 +1099,15 @@ static int notification_presented(lua_State* L) {
 ///
 /// Notes:
 ///  * Examples of why the users Notification Center would choose not to display a notification would be if Hammerspoon is the currently focussed application, being attached to a projector, or the user having set Do Not Disturb.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note).presented);
+static int notification_presented(lua_State* L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    lua_pushboolean(L, notification.presented);
     return 1;
 }
 
-static int notification_delivered(lua_State* L) {
 /// hs.notify:delivered() -> bool
 /// Method
 /// Returns whether the notification has been delivered to the Notification Center
@@ -1091,12 +1117,19 @@ static int notification_delivered(lua_State* L) {
 ///
 /// Returns:
 ///  * A boolean indicating whether the notification has been delivered to the users Notification Center
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    lua_pushboolean(L, notification->delivered);
-    return 1;
+static int notification_delivered(lua_State* L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    NSString *gus = notification.userInfo[KEY_ID] ;
+    NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+    NSNumber *delivered = userInfo[KEY_DELIVERED] ;
+
+    lua_pushboolean(L, delivered.boolValue) ;
+    return 1 ;
 }
 
-// static int notification_remote(lua_State* L) {
 // /// hs.notify:remote() -> bool
 // /// Method
 // /// Returns whether the notification was generated by a push notification (remotely).
@@ -1109,12 +1142,9 @@ static int notification_delivered(lua_State* L) {
 // ///
 // /// Notes:
 // ///  * Currently Hammerspoon only supports locally generated notifications, not push notifications, so this method will always return false.
-//     notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-//     lua_pushboolean(L, ((__bridge NSUserNotification *) notification->note).remote);
-//     return 1;
+// static int notification_remote(lua_State* L) {
 // }
 
-static int notification_activationType(lua_State* L) {
 /// hs.notify:activationType() -> number
 /// Method
 /// Returns how the notification was activated by the user.
@@ -1124,12 +1154,15 @@ static int notification_activationType(lua_State* L) {
 ///
 /// Returns:
 ///  * the integer value corresponding to how the notification was activated by the user.  See the table `hs.notify.activationTypes[]` for more information.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    lua_pushinteger(L, ((__bridge NSUserNotification *) notification->note).activationType);
+static int notification_activationType(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    lua_pushinteger(L, notification.activationType) ;
     return 1;
 }
 
-static int notification_actualDeliveryDate(lua_State* L) {
 /// hs.notify:actualDeliveryDate() -> number
 /// Method
 /// Returns the date and time when a notification was delivered
@@ -1142,10 +1175,34 @@ static int notification_actualDeliveryDate(lua_State* L) {
 ///
 /// Notes:
 ///  * You can turn epoch times into a human readable string or a table of date elements with the `os.date()` function.
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    lua_pushinteger(L, lround([((__bridge NSUserNotification *) notification->note).actualDeliveryDate timeIntervalSince1970]));
+static int notification_actualDeliveryDate(lua_State* L) {
+    LuaSkin *skin  = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    [skin pushNSObject:notification.actualDeliveryDate] ;
     return 1;
 }
+
+#ifdef DEBUGGING
+static int showMyDict(lua_State* L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK] ;
+    NSUserNotification *notification = [skin toNSObjectAtIndex:1] ;
+
+    BOOL fromNotificationItself = (lua_gettop(L) > 1) ? (BOOL)(lua_toboolean(L, 2)) : NO ;
+
+    if (fromNotificationItself) {
+        [skin pushNSObject:notification.userInfo] ;
+    } else {
+        NSString *gus = notification.userInfo[KEY_ID] ;
+        [skin pushNSObject:ourNotificationSpecifics[gus]] ;
+    }
+    return 1 ;
+}
+#endif
+
+#pragma mark - Module Constants
 
 static int notification_activationTypesTable(lua_State *L) {
 /// hs.notify.activationTypes[]
@@ -1160,90 +1217,107 @@ static int notification_activationTypesTable(lua_State *L) {
 /// Notes:
 ///  * Count starts at zero. (implemented in Objective-C)
     lua_newtable(L) ;
-    lua_pushinteger(L, NSUserNotificationActivationTypeNone);
-        lua_setfield(L, -2, "none") ;
-    lua_pushinteger(L, NSUserNotificationActivationTypeContentsClicked);
-        lua_setfield(L, -2, "contentsClicked") ;
-    lua_pushinteger(L, NSUserNotificationActivationTypeActionButtonClicked);
-        lua_setfield(L, -2, "actionButtonClicked") ;
-    lua_pushinteger(L, NSUserNotificationActivationTypeReplied);
-        lua_setfield(L, -2, "replied") ;
-    lua_pushinteger(L, NSUserNotificationActivationTypeAdditionalActionClicked);
-        lua_setfield(L, -2, "additionalActionClicked") ;
-
+    lua_pushinteger(L, NSUserNotificationActivationTypeNone);                    lua_setfield(L, -2, "none") ;
+    lua_pushinteger(L, NSUserNotificationActivationTypeContentsClicked);         lua_setfield(L, -2, "contentsClicked") ;
+    lua_pushinteger(L, NSUserNotificationActivationTypeActionButtonClicked);     lua_setfield(L, -2, "actionButtonClicked") ;
+    lua_pushinteger(L, NSUserNotificationActivationTypeReplied);                 lua_setfield(L, -2, "replied") ;
+    lua_pushinteger(L, NSUserNotificationActivationTypeAdditionalActionClicked); lua_setfield(L, -2, "additionalActionClicked") ;
     return 1 ;
 }
 
-// NOTE: Metamethods and module setup/teardown
-
-static int notification_delegate_setup(lua_State* __unused L) {
-    // Get and store old (core app) delegate.  If it hasn't been setup yet, do so.
-    old_delegate = [[NSUserNotificationCenter defaultUserNotificationCenter] delegate];
-    if (!old_delegate) {
-        [MJUserNotificationManager sharedManager];
-        old_delegate = [[NSUserNotificationCenter defaultUserNotificationCenter] delegate];
-    }
-    // Create our delegate
-    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:[ourNotificationManager sharedManager]];
-    return 0;
-}
-
-#ifdef DEBUGGING
-static int showMyDict(lua_State* L) {
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    [[LuaSkin sharedWithState:L] pushNSObject:((__bridge NSUserNotification *) notification->note).userInfo withOptions:LS_NSDescribeUnknownTypes] ;
-    return 1 ;
-}
-#endif
+#pragma mark - Lua<->NSObject Conversion Functions
+// These must not throw a lua error to ensure LuaSkin can safely be used from Objective-C
+// delegates and blocks.
 
 static int pushNSUserNotification(lua_State *L, id obj) {
     NSUserNotification *value = obj;
-    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
 
-    notification_t *notification = [[ourNotificationManager sharedManager] getOrCreateUserdata:value] ;
-    [skin pushLuaRef:refTable ref:[[((__bridge NSUserNotification *) notification->note).userInfo valueForKey:@"userdata"] intValue]];
+    if (value.userInfo) {
+        NSString *gus = value.userInfo[KEY_ID] ;
+        if (gus) {
+            NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+            if (userInfo) {
+                NSNumber *NSselfRefCount = userInfo[KEY_SELFREFCOUNT] ;
+                userInfo[KEY_SELFREFCOUNT] = @(NSselfRefCount.intValue + 1) ;
+            } else {
+                if (value.userInfo[KEY_DELIVERED]) { // it's a holdover from a reload/relaunch
+                    ourNotificationSpecifics[gus] = [value.userInfo mutableCopy] ;
+                    userInfo = ourNotificationSpecifics[gus] ;
+                    userInfo[KEY_SELFREFCOUNT] = @(1) ;
+                }
+            }
+        } // else not ours -- how does it exist?
+    } // else not ours (probably from core app)
+    void** valuePtr = lua_newuserdata(L, sizeof(NSUserNotification *));
+    *valuePtr = (__bridge_retained void *)value;
+    luaL_getmetatable(L, USERDATA_TAG);
+    lua_setmetatable(L, -2);
     return 1;
 }
 
-static int userdata_eq(lua_State *L) {
+id toNSUserNotificationFromLua(lua_State *L, int idx) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    NSUserNotification *value ;
+    if (luaL_testudata(L, idx, USERDATA_TAG)) {
+        value = get_objectFromUserdata(__bridge NSUserNotification, L, idx, USERDATA_TAG) ;
+    } else {
+        [skin logError:[NSString stringWithFormat:@"expected %s object, found %s", USERDATA_TAG,
+                                                   lua_typename(L, lua_type(L, idx))]] ;
+    }
+    return value ;
+}
+
+#pragma mark - Hammerspoon/Lua Infrastructure
+
+static int userdata_tostring(lua_State* L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    NSUserNotification *obj = [skin luaObjectAtIndex:1 toClass:"NSUserNotification"] ;
+    NSString *title = obj.title ;
+    [skin pushNSObject:[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, title, lua_topointer(L, 1)]] ;
+    return 1 ;
+}
+
+static int userdata_eq(lua_State* L) {
 // can't get here if at least one of us isn't a userdata type, and we only care if both types are ours,
 // so use luaL_testudata before the macro causes a lua error
     if (luaL_testudata(L, 1, USERDATA_TAG) && luaL_testudata(L, 2, USERDATA_TAG)) {
-        notification_t* notification1 = luaL_checkudata(L, 1, USERDATA_TAG);
-        notification_t* notification2 = luaL_checkudata(L, 2, USERDATA_TAG);
-        NSString *gus1 = (__bridge NSString *)notification1->gus ;
-        NSString *gus2 = (__bridge NSString *)notification2->gus ;
-        lua_pushboolean(L, [gus1 isEqualToString:gus2]) ;
+        LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+        NSUserNotification *obj1 = [skin luaObjectAtIndex:1 toClass:"NSUserNotification"] ;
+        NSUserNotification *obj2 = [skin luaObjectAtIndex:2 toClass:"NSUserNotification"] ;
+        lua_pushboolean(L, [obj1 isEqualTo:obj2]) ;
     } else {
         lua_pushboolean(L, NO) ;
     }
     return 1 ;
 }
 
-static int userdata_tostring(lua_State* L) {
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    NSString* title = ((__bridge NSUserNotification *) notification->note).title ;
-
-    lua_pushstring(L, [[NSString stringWithFormat:@"%s: %@ (%p)", USERDATA_TAG, title, lua_topointer(L, 1)] UTF8String]) ;
-
-    return 1 ;
-}
-
 static int userdata_gc(lua_State* L) {
-    notification_t* notification = luaL_checkudata(L, 1, USERDATA_TAG);
-    NSUserNotification *holding = (__bridge_transfer NSUserNotification *) notification->note ;
-    notification->note = nil ; holding = nil ;
+    NSUserNotification *obj = get_objectFromUserdata(__bridge_transfer NSUserNotification, L, 1, USERDATA_TAG) ;
 
-    NSString *myID = (__bridge_transfer NSString *) notification->gus ;
-    myID = nil ; notification->gus = nil ;
+    if (obj.userInfo) {
+        NSString *gus = obj.userInfo[KEY_ID] ;
+        if (gus) { // it's ours
+            NSMutableDictionary *userInfo = ourNotificationSpecifics[gus] ;
+            if (userInfo) { // and we have a record for it
+                NSNumber *NSselfRefCount = userInfo[KEY_SELFREFCOUNT] ;
+                userInfo[KEY_SELFREFCOUNT] = @(NSselfRefCount.intValue - 1) ;
+                if (NSselfRefCount.intValue == 0) ourNotificationSpecifics[gus] = nil ;
+            } // else this shouldn't be possible except *maybe* if meta_gc gets called before userdata one does... unlikely (impossible?)
+        }
+    }
+    obj = nil ;
 
-    return 0;
+    // Remove the Metatable so future use of the variable in Lua won't think its valid
+    lua_pushnil(L) ;
+    lua_setmetatable(L, 1) ;
+    return 0 ;
 }
 
 // Metamethods for the module
 static int meta_gc(lua_State* __unused L) {
     [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:(id <NSUserNotificationCenterDelegate>)old_delegate];
-//     sharedManager = nil;
+    [ourNotificationSpecifics removeAllObjects] ;
+    ourNotificationSpecifics = nil ;
     return 0;
 }
 
@@ -1263,7 +1337,7 @@ static const luaL_Reg userdata_metaLib[] = {
     {"autoWithdraw",                notification_autoWithdraw},
     {"_contentImage",               notification_contentImage},
     {"_setIdImage",                 notification_setIdImage},
-    {"release",                     notification_release},
+//     {"release",                     notification_release},
     {"getFunctionTag",              notification_getFunctionTag},
     {"presented",                   notification_presented},
     {"delivered",                   notification_delivered},
@@ -1311,25 +1385,27 @@ static const luaL_Reg module_metaLib[] = {
 };
 
 int luaopen_hs_notify_internal(lua_State* L) {
-
-    notification_delegate_setup(L);
-
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     refTable = [skin registerLibraryWithObject:USERDATA_TAG
                                      functions:moduleLib
                                  metaFunctions:module_metaLib
                                objectFunctions:userdata_metaLib];
 
-    notification_activationTypesTable(L) ;
-    lua_setfield(L, -2, "activationTypes") ;
+    notification_activationTypesTable(L) ; lua_setfield(L, -2, "activationTypes") ;
 
 /// hs.notify.defaultNotificationSound
 /// Constant
 /// The string representation of the default notification sound. Use `hs.notify:soundName()` or set the `soundName` attribute in `hs:notify.new()`, to this constant, if you want to use the default sound
-    lua_pushstring(L, [NSUserNotificationDefaultSoundName UTF8String]) ;
-    lua_setfield(L, -2, "defaultNotificationSound") ;
+    lua_pushstring(L, [NSUserNotificationDefaultSoundName UTF8String]) ; lua_setfield(L, -2, "defaultNotificationSound") ;
 
-    [skin registerPushNSHelper:pushNSUserNotification forClass:"NSUserNotification"];
+    [skin registerPushNSHelper:pushNSUserNotification         forClass:"NSUserNotification"];
+    [skin registerLuaObjectHelper:toNSUserNotificationFromLua forClass:"NSUserNotification"
+                                                   withUserdataMapping:USERDATA_TAG];
+
+    notification_delegate_setup() ;
+    ourNotificationSpecifics = [NSMutableDictionary dictionary] ;
 
     return 1;
 }
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
Addresses #2593 

Long term we need to move to UNUserNotification but it's only 10.14+ (which is probably ok at this point) and fundamentally different so will require an entirely new module and approach.

This rewrite sticks with NSUserNotification but with the following changes under the hood (it *should* be syntacticly the same with maybe a little more argument type checking)
* userdata is now just the NSUserNotification object itself. No C-structure with bridged pointers anymore and state info is held in proxy object stored in module level mutable dictionary
* after sending/scheduling a notification, no changes are made to the notification itself (not even to its userInfo dictionary) to ensure that locally saved userdata and delivered userdata returned by hs.notify.deliveredNotifications/scheduledNotifications refer to the same macOS object
* no memory leaks -- registry no longer used to "save" userdata. Instead using selfRefCount via proxy object stored in module level mutable dictionary
* better checking for availability of private API methods

It needs testing, and I haven't really tested it that much against notifications that use the app's initial delegate (I think only `hs.showError` uses this, but need to check a little deeper) other than to verify that hs.notify.deliveredNotifications *does* report them... accessing details of these *may* cause crashes atm as it makes assumptions that aren't true for these specific notifications. I'll confirm and fix if necessary tomorrow (well later today).

@Pancia I have some ideas for tests I intend to run on this tomorrow, but honestly I haven't used hs.notify within my own configuration in quite a while, so if you're comfortable/able to build a local version of Hammerspoon against this pull I'd be interested in your feedback as well.