### PR TITLE
[REVIEW] Add docktile support to hs.dockicon

### DIFF
--- a/extensions/canvas/internal.m
+++ b/extensions/canvas/internal.m
@@ -3951,6 +3951,10 @@ static int userdata_gc(lua_State* L) {
 
         theView.selfRef          = [skin luaUnref:refTable ref:theView.selfRef] ;
 
+        NSDockTile *tile     = [[NSApplication sharedApplication] dockTile];
+        NSView     *tileView = tile.contentView ;
+        if (tileView && [theView isEqualTo:tileView]) tile.contentView = nil ;
+
         HSCanvasWindow *theWindow = theView.wrapperWindow ;
         if (theWindow) [theWindow close];
         theView.wrapperWindow    = nil ;

--- a/extensions/dockicon/init.lua
+++ b/extensions/dockicon/init.lua
@@ -5,6 +5,7 @@
 --- This module is based primarily on code from the previous incarnation of Mjolnir by [Steven Degutis](https://github.com/sdegutis/).
 
 local module = require("hs.dockicon.internal")
+require("hs.canvas") -- loads canvas class support for docktile support
 
 local realSetBadge = module.setBadge
 module.setBadge = function(arg)

--- a/extensions/dockicon/internal.m
+++ b/extensions/dockicon/internal.m
@@ -1,6 +1,5 @@
-#import <Cocoa/Cocoa.h>
-#import <LuaSkin/LuaSkin.h>
-
+@import Cocoa ;
+@import LuaSkin ;
 
 extern BOOL MJDockIconVisible(void) ;
 extern void MJDockIconSetVisible(BOOL visible) ;
@@ -72,12 +71,95 @@ static int icon_setBadge(lua_State* L) {
     return 0;
 }
 
+@interface NSView (HSCanvasView)
+-(NSWindow *)wrapperWindow ;
+@end
+/// hs.dockicon.tileCanvas([canvas]) -> canvasObject | nil
+/// Function
+/// Get or set a canvas object to be displayed as the Hamemrspoon dock icon
+///
+/// Parameters:
+///  * `canvas` - an optional `hs.canvas` object specifying the canvas to be displayed as the dock icon for Hammerspoon. If an explicit `nil` is specified, the dock icon will revert to the Hammerspoon application icon.
+///
+/// Returns:
+///  * If the dock icon is assigned a canvas object, that canvas object will be returned, otherwise returns nil.
+///
+/// Notes:
+///  * If you update the canvas object by changing any of its components, it will not be reflected in the dock icon until you invoke [hs.dockicon.tileUpdate](#tileUpdate).
+static int icon_docktileCanvas(lua_State *L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    [skin checkArgs:LS_TANY | LS_TOPTIONAL, LS_TBREAK] ;
+    NSDockTile *tile = [[NSApplication sharedApplication] dockTile];
+
+    if (lua_gettop(L) != 0) {
+        NSView *oldView = tile.contentView ;
+        if (lua_type(L, 1) == LUA_TNIL) {
+            tile.contentView = nil ;
+        } else {
+            [skin checkArgs:LS_TUSERDATA, "hs.canvas", LS_TBREAK] ;
+            tile.contentView = [skin toNSObjectAtIndex:1] ;
+        }
+        [tile display] ;
+        // if canvas removed from tile, reattach it so it can be displayed as a canvas again
+        if (![oldView isEqualTo:tile.contentView] && [oldView isKindOfClass:NSClassFromString(@"HSCanvasView")]) {
+            [oldView.wrapperWindow setContentView:oldView] ;
+        }
+    }
+    [skin pushNSObject:tile.contentView] ;
+    return 1 ;
+}
+
+/// hs.dockicon.tileSize() -> size table
+/// Function
+/// Returns a table containing the size of the tile representing the dock icon.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * a table containing the size of the tile representing the dock icon for Hammerspoon. This table will contain `h` and `w` keys specifying the tile height and width as numbers.
+///
+/// Notes:
+///  * the size returned specifies the display size of the dock icon tile. If your canvas item is larger than this, then only the top left portion corresponding to the size returned will be displayed.
+static int icon_docktileSize(lua_State *L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    [skin checkArgs:LS_TBREAK] ;
+    NSDockTile *tile = [[NSApplication sharedApplication] dockTile];
+
+    [skin pushNSSize:tile.size] ;
+    return 1 ;
+}
+
+/// hs.dockicon.tileUpdate() -> none
+/// Function
+/// Force an update of the dock icon.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * None
+///
+/// Notes:
+///  * Changes made to a canvas object are not reflected automatically like they are when a canvas is being displayed on the screen; you must invoke this method after making changes to the canvas for the updates to be reflected in the dock icon.
+static int icon_docktileUpdate(lua_State *L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    [skin checkArgs:LS_TBREAK] ;
+    NSDockTile *tile = [[NSApplication sharedApplication] dockTile];
+
+    [tile display] ;
+    return 0 ;
+}
+
 static luaL_Reg icon_lib[] = {
     {"visible", icon_visible},
     {"show", icon_show},
     {"hide", icon_hide},
     {"bounce", icon_bounce},
     {"setBadge", icon_setBadge},
+    {"tileCanvas", icon_docktileCanvas},
+    {"tileSize", icon_docktileSize},
+    {"tileUpdate", icon_docktileUpdate},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
Ok, I needed a break from `hs.notify` (though i'm almost ready to say it's ready, probably tomorrow) and this was fairly easy to add.

Addresses #2701 

This update allows assigning a canvas object to the Hammerspoon dock icon.

~~~lua
a = hs.canvas.new{ x = 100, y = 100, h = 128, w = 128 } 
a[#a + 1] = { type = "text", text = "placeholder" } 
hs.dockicon.tileCanvas(a)
t = hs.timer.doEvery(1, function() a[1].text = os.date("%R:%S\n%D") ; hs.dockicon.tileUpdate() end)
~~~