### PR TITLE
[REVIEW] Bring brightness control back to Silicon

### DIFF
--- a/extensions/brightness/init.lua
+++ b/extensions/brightness/init.lua
@@ -5,7 +5,15 @@
 --- Home: https://github.com/asmagill/mjolnir_asm.sys
 ---
 --- This module is based primarily on code from the previous incarnation of Mjolnir by [Steven Degutis](https://github.com/sdegutis/).
---- Note: This module is mostly useless on Macs with Apple Silicon processors until newer APIs are discovered or published by Apple.
+
+-- try to load private framework for brightness controls
+local state, msg = package.loadlib(
+    "/System/Library/PrivateFrameworks/DisplayServices.framework/Versions/Current/DisplayServices",
+    "*"
+)
+if not state then
+    hs.printf("-- unable to load DisplayServices framework; may impact brightness control: %s", msg)
+end
 
 local module = require("hs.brightness.internal")
 

--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -6,6 +6,15 @@
 --- System Preferences->Displays->Arrangement). The origin `0,0` is at the top left corner of the *primary screen*.
 --- (Screens to the left of the primary screen, or above it, and windows on these screens, will have negative coordinates)
 
+-- try to load private framework for brightness controls
+local state, msg = package.loadlib(
+    "/System/Library/PrivateFrameworks/DisplayServices.framework/Versions/Current/DisplayServices",
+    "*"
+)
+if not state then
+    hs.printf("-- unable to load DisplayServices framework; may impact brightness control: %s", msg)
+end
+
 local screen = require "hs.screen.internal"
 local geometry = require "hs.geometry"
 require "hs.image"


### PR DESCRIPTION
Addresses #2668 further

Fixes `hs.brightness.get`, `hs.brightness.set`, `hs.screen:getBrightness`, and `hs.screen:setBrightness`.

Tested on built in displays for:
* M1 Powerbook running Big Sur 11.2
* Intel Powerbook running Big Sur 11.1
* Intel iMac running Catalina 10.15.7

I'd like to hear feedback from anyone with an external display that supports brightness adjustments (mine don't and never have).

- - -

Still investigating whether or not we can easily address `hs.brightness.ambient` as well.

(For those who've been following the discussion in #2668, once I realized what the first argument to the new functions was, it suddenly made sense why it had been failing on Intel macs before -- they don't start their display IDs at 1.)