### PR TITLE
small fix for hs.window.highlight

### DIFF
--- a/extensions/window/highlight.lua
+++ b/extensions/window/highlight.lua
@@ -78,7 +78,7 @@ local function getColor(t) if type(t)~='table' or t.red or not t[1] then return 
 local function getScreens()
   local screens=screen.allScreens()
   if #screens==0 then log.w('Cannot get current screens') return end
-  sf=screens[1]:frame()
+  sf=screens[1]:fullFrame()
   for i=2,#screens do
     local fr=screens[i]:frame()
     if fr.x<sf.x then sf.x=fr.x end
@@ -170,7 +170,11 @@ local isolatesubs={
 
 local function setUiPrefs()
   local prevOverlay,prevFlash=hasOverlay,hasFlash
-  if frame then frame:delete() rt:delete() rl:delete() rb:delete() rr:delete() rflash:delete() end
+  if frame then
+    if next(frame) ~= nil then
+      frame:delete() rt:delete() rl:delete() rb:delete() rr:delete() rflash:delete()
+    end
+  end
   local ui=highlight.ui
   local f={x=-5,y=0,w=1,h=1}
   frame=drrect(f):setFill(false):setStroke(true):setStrokeWidth(ui.frameWidth):setBehavior(BEHAVIOR)


### PR DESCRIPTION
I ran into 2 small problems while working on a window highlight function.

### Bug 1

After toggling the highlight via `hs.window.highlight.start()` and then `:stop()` trying to turn it on again results in an error:
```
ERROR:   LuaSkin: hs.hotkey callback: ...pp/Contents/Resources/extensions/hs/window/highlight.lua:178: attempt to call a nil value (method 'delete')
stack traceback:
	...pp/Contents/Resources/extensions/hs/window/highlight.lua:178: in upvalue 'setUiPrefs'
	...pp/Contents/Resources/extensions/hs/window/highlight.lua:194: in metamethod 'newindex'
```

**Fix:** seems frame is not set to `nil` but rather just an empty table `{}`, so check for empty `frame` table before calling the `:delete()` method:

https://github.com/luckman212/hammerspoon/blob/9132767945e4e3ccc66d370633e594ffe9dda9bf/extensions/window/highlight.lua#L173-L177

### Bug 2

The background overlay rect is not positioned correctly - it calculates the dock area as if it were on the right side even if the user has it on the left. The better fix (for multi mon setups) would be to canvas each screen independently, accounting for dock/menubar/etc if the goal is to not obscure the Dock. But the poor man's fix is to just use `screen:fullFrame` instead of `:frame` :

https://github.com/luckman212/hammerspoon/blob/9132767945e4e3ccc66d370633e594ffe9dda9bf/extensions/window/highlight.lua#L81

