### PR TITLE
Finding screen name with a "-" is broken

### DIFF
--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -82,7 +82,7 @@ function screen.find(p)
         local sname=s:name()
         if s:getUUID() == p then
           r[#r+1]=s
-        elseif sname and sname:lower():find(p:lower()) then
+        elseif sname and sname:lower():find(p:lower(), 1, true) then
           r[#r+1]=s
         end
       end


### PR DESCRIPTION
Somewhere in the switch to 0.9.83 the screen name on my MBP changed from "Color LCD" to "Built-in Retina Display". The screen find command does not like the "-" in the screen name. Adding the true to the find turns off pattern matching. Substrings are still found, just turns off RE pattern matching (as far as I can tell from http://lua-users.org/wiki/StringLibraryTutorial)