### PR TITLE
hs.window.desktop() now returns nil if Finder is not running

### DIFF
--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -38,7 +38,7 @@ window.animationDuration = 0.2
 ---  * None
 ---
 --- Returns:
----  * An `hs.window` object representing the desktop
+---  * An `hs.window` object representing the desktop, or nil if Finder is not running
 ---
 --- Notes:
 ---  * The desktop belongs to Finder.app: when Finder is the active application, you can focus the desktop by cycling
@@ -47,7 +47,7 @@ window.animationDuration = 0.2
 ---  * The desktop is filtered out from `hs.window.allWindows()` (and downstream uses)
 function window.desktop()
   local finder = application.get('com.apple.finder')
-  if not finder then return false end
+  if not finder then return nil end
   for _,w in ipairs(finder:allWindows()) do if w:role()=='AXScrollArea' then return w end end
 end
 

--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -47,6 +47,7 @@ window.animationDuration = 0.2
 ---  * The desktop is filtered out from `hs.window.allWindows()` (and downstream uses)
 function window.desktop()
   local finder = application.get('com.apple.finder')
+  if not finder then return false end
   for _,w in ipairs(finder:allWindows()) do if w:role()=='AXScrollArea' then return w end end
 end
 


### PR DESCRIPTION
Found a small issue in `hs.window` where, if you have a function that depends on the special Desktop window— `hs.window.desktop()` it will fail when Finder.app is not running (either you quit it manually, or via AppleScript, or it crashed, etc.)

repro:
1. quit Finder
2. from hs console:
```lua
hs.window.desktop()
```

Error:
```
> hs.window.desktop()
...oon.app/Contents/Resources/extensions/hs/window/init.lua:51: attempt to index a nil value (local 'finder')
stack traceback:
	...oon.app/Contents/Resources/extensions/hs/window/init.lua:51: in function 'hs.window.desktop'
	(...tail calls...)
	[C]: in function 'xpcall'
	...app/Contents/Resources/extensions/hs/_coresetup/init.lua:514: in function <...app/Contents/Resources/extensions/hs/_coresetup/init.lua:494>
```

fix is in `extensions/hs/window/init.lua` - to check for nil before the iter:
```lua
if not finder then return false end
```
