### PR TITLE
hs.window:isVisible() will now return false even if the underlying hs.application object is invalid

### DIFF
--- a/extensions/window/init.lua
+++ b/extensions/window/init.lua
@@ -252,6 +252,7 @@ end
 --- Notes:
 ---  * This does not mean the user can see the window - it may be obscured by other windows, or it may be off the edge of the screen
 function objectMT.isVisible(self)
+  if not self:application() then return false end
   return not self:application():isHidden() and not self:isMinimized()
 end
 


### PR DESCRIPTION
I have a simple module that logs app launches (activations) to the console with the PID, app name etc.

I noticed that I get log spew (stack trace) sometimes about `loginwindow` when the screen saver activates. You can test this by pasting this code into the console:

```lua
function tryThing()
  a = hs.application'loginwindow'
  print(a:name())
end
t = hs.timer.doEvery(1, tryThing)
```

Now, activate the screensaver (use a hot corner)
You should get something like

```
2021-03-05 14:22:22: loginwindow
2021-03-05 14:22:23: loginwindow
2021-03-05 14:22:23: 14:22:23 ERROR:   LuaSkin: Unable to fetch NSRunningApplication for pid: 169
2021-03-05 14:22:23: 14:22:23 ERROR:   LuaSkin: ...oon.app/Contents/Resources/extensions/hs/window/init.lua:256: attempt to index a nil value
stack traceback:
	...oon.app/Contents/Resources/extensions/hs/window/init.lua:257: in method 'isVisible'
	...n.app/Contents/Resources/extensions/hs/window/filter.lua:1018: in field 'new'
	...n.app/Contents/Resources/extensions/hs/window/filter.lua:1027: in field 'created'
	...n.app/Contents/Resources/extensions/hs/window/filter.lua:1397: in function <...n.app/Contents/Resources/extensions/hs/window/filter.lua:1371>
```

Some kind of permission issue maybe? not sure. The bug seems to be in LuaSkin but I tried to grep the code for that error message and came up empty. I added a nil check to `hs.window` @ L256 :

```lua
function objectMT.isVisible(self)
+ if not self:application() then return false end
  return not self:application():isHidden() and not self:isMinimized()
end
```

Really not sure if there's a better fix but, this works for me and eliminates the hard fault, reducing it to a 1-line warning:

```
2021-03-05 14:23:07: loginwindow
2021-03-05 14:23:08: loginwindow
2021-03-05 14:23:09: 14:23:09 ERROR:   LuaSkin: Unable to fetch NSRunningApplication for pid: 169
2021-03-05 14:23:09: loginwindow
2021-03-05 14:23:10: loginwindow
```
