### PR TITLE
hs.itunes now works correctly on macOS 11

### DIFF
--- a/extensions/itunes/init.lua
+++ b/extensions/itunes/init.lua
@@ -9,7 +9,8 @@ local as = require "hs.applescript"
 local app = require "hs.application"
 
 local applicationName = 'iTunes'
-if hs.host.operatingSystemVersion().minor >= 15 then
+local osVersion = hs.host.operatingSystemVersion()
+if osVersion.major >= 11 or osVersion.minor >= 15 then
   applicationName = 'Music'
 end
 


### PR DESCRIPTION
Long time satisfied Hammerspoon user. Thanks so much for all your work on this project 🙏 

I've noticed that the `hs.itunes` module is no longer working with Music.app since I upgraded to Big Sur. Looks like the OS version checks were not checking the major version number (11) at all, so the applescript commands were going to `iTunes`, which no longer exists. This small change fixes it for me and should still work for 10.x versions as well.