### PR TITLE
Add hs.screen example for finding Built-in Retina Display

### DIFF
--- a/extensions/screen/init.lua
+++ b/extensions/screen/init.lua
@@ -64,6 +64,7 @@ end
 --- ```lua
 --- hs.screen(724562417) --> Color LCD - by id
 --- hs.screen'Dell'      --> DELL U2414M - by name
+--- hs.screen'Built%-in' --> Built-in Retina Display, note the % to escape the hyphen repetition character
 --- hs.screen'0,0'       --> PHL BDM4065 - by position, same as hs.screen.primaryScreen()
 --- hs.screen{x=-1,y=0}  --> DELL U2414M - by position, screen to the immediate left of the primary screen
 --- hs.screen'3840x2160' --> PHL BDM4065 - by screen resolution


### PR DESCRIPTION
As noted in #2793 finding "Built-in" display requires escaping the `-` character because it is a repetition character in `string.match`.

This adds an example to the docs because I feel like it's a fairly common task and those unfamiliar with Lua will get tripped up.