### PR TITLE
documentation fixes

### DIFF
--- a/extensions/dialog/internal.m
+++ b/extensions/dialog/internal.m
@@ -679,10 +679,10 @@ static int blockAlert(lua_State *L) {
 ///  * `buttonOne` defaults to "OK" if no value is supplied.
 ///  * `buttonOne` will also be triggered by pressing `ENTER`, whereas `buttonTwo` will be triggered by pressing `ESC`.
 ///  * Examples:
-///      `hs.dialog.textPrompt("Main message.", "Please enter something:")`
-///      `hs.dialog.textPrompt("Main message.", "Please enter something:", "Default Value", "OK")`
-///      `hs.dialog.textPrompt("Main message.", "Please enter something:", "Default Value", "OK", "Cancel")`
-///      `hs.dialog.textPrompt("Main message.", "Please enter something:", "", "OK", "Cancel", true)`
+///     * `hs.dialog.textPrompt("Main message.", "Please enter something:")`
+///     * `hs.dialog.textPrompt("Main message.", "Please enter something:", "Default Value", "OK")`
+///     * `hs.dialog.textPrompt("Main message.", "Please enter something:", "Default Value", "OK", "Cancel")`
+///     * `hs.dialog.textPrompt("Main message.", "Please enter something:", "", "OK", "Cancel", true)`
 static int textPrompt(lua_State *L) {
     NSString* defaultButton = @"OK";
 

--- a/scripts/docs/bin/build_docs.py
+++ b/scripts/docs/bin/build_docs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Hammerspoon API Documentation Builder"""
 


### PR DESCRIPTION
This PR contains:
1. a commit that makes build_docs.py more portabl2
2. a formatting fix for hs.dialog.textPrompt

Many other bits of doc are broken like (2) fixes - please let me know if this fix is good or if you'd like some other format, then maybe I can go through more of the docs to fix this.