### PR TITLE
Bugfix for allowing a table argument to be optional.

### DIFF
--- a/LuaSkin/LuaSkin/Skin.m
+++ b/LuaSkin/LuaSkin/Skin.m
@@ -734,7 +734,7 @@ catastrophe:
                 break;
         }
 
-        if (!(spec & LS_TANY) && !(spec & lsType) && !(spec & LS_TWRAPPEDOBJECT)) {
+        if (!(spec & LS_TANY) && !((lsType == LS_TNIL) && spec & LS_TOPTIONAL) && !(spec & lsType) && !(spec & LS_TWRAPPEDOBJECT)) {
             luaL_error(self.L, "ERROR: incorrect type '%s' for argument %d (expected %s)", luaL_typename(self.L, idx), idx, specMaskToString(spec).UTF8String);
         }
 nextarg:


### PR DESCRIPTION
I'm writing a mixed extension where I'd like to pass some data from a config file to a lua function
that passes it to an Objective-C function (that middle step might be eliminated).

The function accepts two strings and two optional tables. I'm checking arguments in Objective-C like that.
```
[skin checkArgs:LS_TSTRING, LS_TSTRING, LS_TTABLE|LS_TOPTIONAL, LS_TTABLE|LS_TOPTIONAL, LS_TBREAK];
```

However when calling the function as `f("hello", "world")`, the following error message is shown,
indicating that `LS_TTABLE|LS_TOPTIONAL` might not work as expected:

```
...Contents/Resources/extensions/hs/myext/init.lua:12: ERROR: incorrect type 'nil' for argument 3 (expected table)
stack traceback:
    [C]: in function 'hs.myext._openWithAppAndConfig'
    ...Contents/Resources/extensions/hs/myext/init.lua:12: in function 'hs.myext.openWithAppAndConfig'
    /Users/cklein/.hammerspoon/init.lua:55: in function </Users/cklein/.hammerspoon/init.lua:48>
2021-04-11 01:12:28.243733+0200 Hammerspoon[33519:3082278] BREADCRUMB: (ERROR) hs.chooser:completionCallback: ...Contents/Resources/extensions/hs/myext/init.lua:12: ERROR: incorrect type 'nil' for argument 3 (expected table)
stack traceback:
    [C]: in function 'hs.myext._openWithAppAndConfig'
    ...Contents/Resources/extensions/hs/myext/init.lua:12: in function 'hs.myext.openWithAppAndConfig'
    /Users/cklein/.hammerspoon/init.lua:55: in function </Users/cklein/.hammerspoon/init.lua:48>
```

`!(spec & lsType)` also looks suspicious, or at least I don't understand it,
the two value sets don't seem to have anything to do with each other:

`lsType` is one of the following values:

```
#define LUA_TNONE       (-1)
#define LUA_TNIL        0
#define LUA_TBOOLEAN        1
#define LUA_TLIGHTUSERDATA  2
#define LUA_TNUMBER     3
#define LUA_TSTRING     4
#define LUA_TTABLE      5
#define LUA_TFUNCTION       6
#define LUA_TUSERDATA       7
#define LUA_TTHREAD     8
#define LUA_NUMTYPES        9
```

`spec` is a combination of the following values:

```
#define LS_TBREAK         1 << 0
#define LS_TOPTIONAL      1 << 1
#define LS_TNIL           1 << 2
#define LS_TBOOLEAN       1 << 3
#define LS_TNUMBER        1 << 4
#define LS_TSTRING        1 << 5
#define LS_TTABLE         1 << 6
#define LS_TFUNCTION      1 << 7
#define LS_TUSERDATA      1 << 8
#define LS_TNONE          1 << 9
#define LS_TANY           1 << 10
#define LS_TINTEGER       1 << 11
#define LS_TVARARG        1 << 12
#define LS_TTYPEDTABLE    1 << 13
#define LS_TWRAPPEDOBJECT 1 << 14
```

So it seems that only `lsType` divisible by 2 were allowed to be optional.
Note that I didn't remove that condition.
