### PR TITLE
[pr-change] Canvas objects now respond to lua garbage collection

### DIFF
--- a/extensions/canvas/Canvas.h
+++ b/extensions/canvas/Canvas.h
@@ -6,7 +6,8 @@
 @end
 
 @interface HSCanvasView : NSView <NSDraggingDestination>
-@property int                 selfRef ;
+@property int                 selfRef ; // used during fadeOut to make sure collection doesn't interrupt
+@property int                 selfRefCount ;
 @property HSCanvasWindow     *wrapperWindow ;
 @property int                 mouseCallbackRef ;
 @property int                 draggingCallbackRef ;


### PR DESCRIPTION
Will resolve #2730

This is currently being tested by me but I'm putting it up in case others want to test it as well. I *think* I've accounted for all combinations of fade and hide, but will contrive more tests tonight.

The delete method now prints a deprecation warning (for the first 10 calls -- I figure this makes it likely that it will show up at least once in the console after a user's `init.lua` is done but doesn't spam the console forever) and then falls through to `hide`.