### PR TITLE
Handle VOX not running in isRunning() - fixes #2906

### DIFF
--- a/extensions/vox/init.lua
+++ b/extensions/vox/init.lua
@@ -306,7 +306,8 @@ end
 --- Returns:
 ---  * A boolean value indicating whether the vox application is running
 function vox.isRunning()
-  return app.get("VOX"):isRunning() ~= nil
+  local app = app.get("VOX")
+  return app and app:isRunning() ~= nil
 end
 
 return vox

--- a/extensions/vox/init.lua
+++ b/extensions/vox/init.lua
@@ -306,8 +306,8 @@ end
 --- Returns:
 ---  * A boolean value indicating whether the vox application is running
 function vox.isRunning()
-  local app = app.get("VOX")
-  return app and app:isRunning() ~= nil
+  local a = app.get("VOX")
+  return a and a:isRunning() ~= nil
 end
 
 return vox


### PR DESCRIPTION
Handle isRunning() throwing an error if VOX is not running. Fixes #2906.