### PR TITLE
Add hs.shortcuts and a Shortcuts action

### DIFF
--- a/extensions/shortcuts/init.lua
+++ b/extensions/shortcuts/init.lua
@@ -1,2 +1,12 @@
+--- === hs.shortcuts ===
+---
+--- List and run shortcuts from the Shortcuts app
+---
+--- Separate from this extension, Hammerspoon provides an action for use in the Shortcuts app.
+--- The action is called "Execute Lua" and if it is passed a text block of valid Lua, it will execute that Lua within Hammerspoon.
+--- You can use this action to call functions defined in your `init.lua` or to just execute chunks of Lua.
+---
+--- Your functions/chunks can return text, which will be returned by the action in Shortcuts.
+
 local module = require("hs.shortcuts.internal")
 return module

--- a/extensions/shortcuts/internal.m
+++ b/extensions/shortcuts/internal.m
@@ -13,6 +13,19 @@
 
 static LSRefTable  refTable = LUA_NOREF ;
 
+/// hs.shortcuts.list() -> []
+/// Function
+/// Returns a list of available shortcuts
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * A table of shortcuts, each being a table with the following keys:
+///   * name - The name of the shortcut
+///   * id - A unique ID for the shortcut
+///   * acceptsInput - A boolean indicating if the shortcut requires input
+///   * actionCount - A number relating to how many actions are in the shortcut
 static int shortcuts_list(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TBREAK];
@@ -34,6 +47,15 @@ static int shortcuts_list(lua_State *L) {
     return 1;
 }
 
+/// hs.shortcuts.run(name)
+/// Function
+/// Runs a shortcut in the Shortcuts app
+///
+/// Parameters:
+///  * name - A string containing the name of a shortcut
+///
+/// Returns:
+///  * None
 static int shortcuts_run(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TSTRING, LS_TBREAK];


### PR DESCRIPTION
- Add hs.shortcuts
- Implement Shortcuts action
- More Shortcuts Intent work
- Add some Shortcuts debugging
- Improvements to Shortcuts Intent execution
- Improvements to Shortcuts Intent execution
- Remove returned message from the stack after fetching it in our Shortcuts Intent handler
- Attempt to allow returning file data to Shortcuts Intent
- Further work on multiple return values
- Expand build scripts so I can do much faster local signed build iterations, but still be able to debug them
- Fix a mistake
- More build system changes and fixing the Shortcuts Intent
- Add documentation for hs.shortcuts
