### PR TITLE
Improve package.path/package.cpath on Apple Silicon

### DIFF
--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -22,6 +22,9 @@
 #import <AppKit/AppKit.h>
 #import <libproc.h>
 #import <dlfcn.h>
+#import <sys/utsname.h>
+#import <sys/types.h>
+#import <sys/sysctl.h>
 
 @interface MJPreferencesWindowController ()
 - (void) reflectDefaults ;
@@ -226,6 +229,23 @@ static int core_reload(lua_State* L) {
 /// A table containing read-only information about the Hammerspoon application instance currently running.
 static int push_hammerAppInfo(lua_State* L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
+
+    // Fetch the CPU architecture in use
+    NSString *arch = @"Unknown";
+    struct utsname utsname;
+    if (uname(&utsname) == 0) {
+        arch = [NSString stringWithCString:utsname.machine encoding:NSUTF8StringEncoding];
+    }
+
+    // Determine if we're running under Rosetta
+    int isTranslated = 0;
+    size_t size = sizeof(isTranslated);
+    if (sysctlbyname("sysctl.proctranslated", &isTranslated, &size, NULL, 0) == -1) {
+        if (errno == ENOENT)
+            isTranslated = 0;
+        // Technically to reach here we have an error in the sysctl, but we'll ignore it
+    }
+
     NSDictionary *appInfo = @{
                               @"version": [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"],
                               @"build": [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"],
@@ -235,6 +255,8 @@ static int push_hammerAppInfo(lua_State* L) {
                               @"frameworksPath": @([[[NSBundle mainBundle] privateFrameworksPath] fileSystemRepresentation]),
                               @"processID": @(getpid()),
                               @"bundleID": [[NSBundle mainBundle] bundleIdentifier],
+                              @"arch": arch,
+                              @"isRosetta": [NSNumber numberWithBool: isTranslated],
                               @"buildTime": @(__DATE__ ", " __TIME__),
 #ifdef DEBUG
                               @"debugBuild": @(YES),

--- a/Hammerspoon/MJLua.m
+++ b/Hammerspoon/MJLua.m
@@ -240,10 +240,11 @@ static int push_hammerAppInfo(lua_State* L) {
     // Determine if we're running under Rosetta
     int isTranslated = 0;
     size_t size = sizeof(isTranslated);
-    if (sysctlbyname("sysctl.proctranslated", &isTranslated, &size, NULL, 0) == -1) {
+    if (sysctlbyname("sysctl.proc_translated", &isTranslated, &size, NULL, 0) == -1) {
         if (errno == ENOENT)
             isTranslated = 0;
         // Technically to reach here we have an error in the sysctl, but we'll ignore it
+        // isTranslated = -1;
     }
 
     NSDictionary *appInfo = @{
@@ -256,7 +257,7 @@ static int push_hammerAppInfo(lua_State* L) {
                               @"processID": @(getpid()),
                               @"bundleID": [[NSBundle mainBundle] bundleIdentifier],
                               @"arch": arch,
-                              @"isRosetta": [NSNumber numberWithBool: isTranslated],
+                              @"isRosetta": [NSNumber numberWithBool:isTranslated],
                               @"buildTime": @(__DATE__ ", " __TIME__),
 #ifdef DEBUG
                               @"debugBuild": @(YES),

--- a/LuaSkin/lua-5.4.3/src/luaconf.h
+++ b/LuaSkin/lua-5.4.3/src/luaconf.h
@@ -218,20 +218,57 @@
 
 #else			/* }{ */
 
-#define LUA_ROOT	"/usr/local/"
-#define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
-#define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
+//#define LUA_ROOT	"/usr/local/"
+//#define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
+//#define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
+
+#define LUA_INTEL_ROOT  "/usr/local/"
+#define LUA_INTEL_LDIR  LUA_INTEL_ROOT "share/lua/" LUA_VDIR "/"
+#define LUA_INTEL_CDIR  LUA_INTEL_ROOT "lib/lua/" LUA_VDIR "/"
+
+#define LUA_ARM_ROOT    "/opt/homebrew/"
+#define LUA_ARM_LDIR    LUA_ARM_ROOT "share/lua/" LUA_VDIR "/"
+#define LUA_ARM_CDIR    LUA_ARM_ROOT "lib/lua/" LUA_VDIR "/"
+
 
 #if !defined(LUA_PATH_DEFAULT)
-#define LUA_PATH_DEFAULT  \
-		LUA_LDIR"?.lua;"  LUA_LDIR"?/init.lua;" \
-		LUA_CDIR"?.lua;"  LUA_CDIR"?/init.lua;" \
-		"./?.lua;" "./?/init.lua"
+#define LUA_INTEL_PATH_DEFAULT  \
+		LUA_INTEL_LDIR"?.lua;"  LUA_INTEL_LDIR"?/init.lua;" \
+		LUA_INTEL_CDIR"?.lua;"  LUA_INTEL_CDIR"?/init.lua"
+#define LUA_ARM_PATH_DEFAULT    \
+        LUA_ARM_LDIR"?.lua;"    LUA_ARM_LDIR"?/init.lua;" \
+        LUA_ARM_CDIR"?.lua;"    LUA_ARM_CDIR"?/init.lua"
+#define LUA_PATH_DEFAULT_TAIL   "./?.lua;" "./?/init.lua"
+
+#if defined(__aarch64__)
+    // On Apple Silicon we want to prioritise /opt/homebrew over /usr/local because it's more likely the
+    // user has things there, and also it avoids an error where they have migrated x86 homebrew from an
+    // older Mac, but we still want to include the /usr/local paths because they are still legitimate
+    // install locations on Apple Silicon.
+    #define LUA_PATH_DEFAULT LUA_ARM_PATH_DEFAULT ";" LUA_INTEL_PATH_DEFAULT ";" LUA_PATH_DEFAULT_TAIL
+#else
+    #define LUA_PATH_DEFAULT LUA_INTEL_PATH_DEFAULT ";" LUA_PATH_DEFAULT_TAIL
+#endif
+
 #endif
 
 #if !defined(LUA_CPATH_DEFAULT)
-#define LUA_CPATH_DEFAULT \
-		LUA_CDIR"?.so;" LUA_CDIR"loadall.so;" "./?.so"
+#define LUA_INTEL_CPATH_DEFAULT \
+        LUA_INTEL_CDIR"?.so;" LUA_INTEL_CDIR"loadall.so"
+#define LUA_ARM_CPATH_DEFAULT \
+        LUA_ARM_CDIR"?.so;" LUA_ARM_CDIR"loadall.so"
+#define LUA_CPATH_DEFAULT_TAIL  "./?.so"
+
+#if defined(__aarch64__)
+    // On Apple Silicon we want to prioritise /opt/homebrew over /usr/local because it's more likely the
+    // user has things there, and also it avoids an error where they have migrated x86 homebrew from an
+    // older Mac, but we still want to include the /usr/local paths because they are still legitimate
+    // install locations on Apple Silicon.
+    #define LUA_CPATH_DEFAULT LUA_ARM_CPATH_DEFAULT ";" LUA_INTEL_CPATH_DEFAULT ";" LUA_CPATH_DEFAULT_TAIL
+#else
+    #define LUA_CPATH_DEFAULT LUA_INTEL_CPATH_DEFAULT ";" LUA_CPATH_DEFAULT_TAIL
+#endif
+
 #endif
 
 #endif			/* } */


### PR DESCRIPTION
Rework package.path and package.cpath defaults to attempt to account for Homebrew Lua locations on Apple Silicon machines. Closes #3081
