### PR TITLE
fix typo

### DIFF
--- a/extensions/drawing/color/drawing_color.lua
+++ b/extensions/drawing/color/drawing_color.lua
@@ -2,7 +2,7 @@ local module = require("hs.libdrawing_color")
 
 --- === hs.drawing.color ===
 ---
---- Provides ccess to the system color lists and a wider variety of ways to represent color within Hammerspoon.
+--- Provides access to the system color lists and a wider variety of ways to represent color within Hammerspoon.
 ---
 --- Color is represented within Hammerspoon as a table containing keys which tell Hammerspoon how the color is specified.  You can specify a color in one of the following ways, depending upon the keys you supply within the table:
 ---


### PR DESCRIPTION
`ccess` => `access`

https://github.com/Hammerspoon/hammerspoon/blob/b03d628f792eb88188962643c32a490f1174c10d/extensions/drawing/color/drawing_color.lua#L5