### PR TITLE
libmouse.m: update internal mouse name

### DIFF
--- a/extensions/mouse/libmouse.m
+++ b/extensions/mouse/libmouse.m
@@ -84,7 +84,7 @@ static void enum_callback(void *ctx, IOReturn res, void *sender, IOHIDDeviceRef 
 }
 
 -(BOOL)hasInternalMouse {
-    return [self.names containsObject:@"Apple Internal Keyboard / Trackpad"];
+    return [self.names containsObject:@"Apple Inc.::Apple Internal Keyboard / Trackpad"];
 }
 
 -(int)getCount {


### PR DESCRIPTION
According to `hs.mouse.names()`, this is the name of the internal trackpad on my laptop.

```
> hs.inspect(hs.mouse.names())
2022-02-10 19:37:27: -- Loading extension: inspect
{ "Apple Inc.::Apple Internal Keyboard / Trackpad" }
```

Haven't rebuild hammerspoon to confirm that it works, but the snippet above gave me the confidence to open a PR.

Note that if I knew objective C better I'd suggest that we check if one of the name has `Apple Internal` in it.