### PR TITLE
[READY] Add support for loading dylib libraries from user config directory

### DIFF
--- a/Hammerspoon/setup.lua
+++ b/Hammerspoon/setup.lua
@@ -1,7 +1,7 @@
 local modpath, frameworkspath, prettypath, fullpath, configdir, docstringspath, hasinitfile, autoload_extensions = ...
 
 package.path=configdir.."/?.lua"..";"..configdir.."/?/init.lua"..";"..configdir.."/Spoons/?.spoon/init.lua"..";"..package.path..";"..modpath.."/?.lua"..";"..modpath.."/?/init.lua"
-package.cpath=configdir.."/?.so"..";"..package.cpath..";"..frameworkspath.."/?.dylib"
+package.cpath=configdir.."/?.dylib"..";"..configdir.."/?.so"..";"..package.cpath..";"..frameworkspath.."/?.dylib"
 
 print("-- package.path: "..package.path)
 print("-- package.cpath: "..package.cpath)

--- a/extensions/bonjour/bonjour.lua
+++ b/extensions/bonjour/bonjour.lua
@@ -21,8 +21,6 @@ module.service     = require("hs.libbonjourservice")
 local browserMT = hs.getObjectMetatable(USERDATA_TAG)
 -- local serviceMT = hs.getObjectMetatable(USERDATA_TAG .. ".service")
 
-require "hs.doc".registerJSONFile(hs.processInfo["resourcePath"] .. "/docs.json")
-
 local collectionPrevention = {}
 local task    = require("hs.task")
 local host    = require("hs.host")


### PR DESCRIPTION
This will allow external modules to be built and named in the same manner as they would be if/when they are migrated into the core application.

In addition, I've removed an extra `docs.json` registration in the `hs.bonjour` module (I have left the similar redundancy in `hs.axuielement` because it will be addressed when #3149 lands and I don't want to create a potential merge conflict).