### PR TITLE
Added ability to save a hs.menubar position between reloads

### DIFF
--- a/extensions/menubar/libmenubar.m
+++ b/extensions/menubar/libmenubar.m
@@ -465,8 +465,7 @@ static int menubarNew(lua_State *L) {
 
 /// hs.menubar:autosaveName([name]) -> menubaritem | current-value
 /// Method
-/// Get or set the autosave name of the menubar. By defining an autosave name, macOS can restore
-/// the menubar position after reloads.
+/// Get or set the autosave name of the menubar. By defining an autosave name, macOS can restore the menubar position after reloads.
 ///
 /// Parameters:
 ///  * name - An optional string if you want to set the autosave name

--- a/extensions/menubar/menubar.lua
+++ b/extensions/menubar/menubar.lua
@@ -11,7 +11,6 @@ require("hs.styledtext")
 
 -- protects tables of constants
 
-menubar.priorities = ls.makeConstantsTable(menubar.priorities)
 menubar.imagePositions = ls.makeConstantsTable(menubar.imagePositions)
 
 -- This is the wrapper for hs.menubar:setIcon(). It is documented in internal.m


### PR DESCRIPTION
- Added an optional `autosaveName` parameter to `hs.menubar.new()`, which allows you to set a unique identifier for the menubar, allowing it to save and restore it's menubar position across reloads.
- Added a method to get and set the `autosaveName` -`hs.menubar:autosaveName()`.
- Removed `hs.menubar.newWithPriority()` as it no longer works on macOS Catalina (and the minimum system requirements for Hammerspoon are now Catalina & above).
- Closes #2878