### PR TITLE
Reformat documentation for hs.socket and hs.socket.udp

### DIFF
--- a/extensions/socket/libsocket.m
+++ b/extensions/socket/libsocket.m
@@ -153,13 +153,13 @@ static void readCallback(HSAsyncTcpSocket *asyncSocket, NSData *data, long tag) 
 
 /// hs.socket.new([fn]) -> hs.socket object
 /// Constructor
-/// Creates an unconnected asynchronous TCP socket object
+/// Creates an unconnected asynchronous TCP socket object.
 ///
 /// Parameters:
-///  * fn - An optional [callback function](#setCallback) for reading data from the socket, settable here for convenience
+///  * `fn` - An optional [callback function](#setCallback) for reading data from the socket, settable here for convenience.
 ///
 /// Returns:
-///  * An [`hs.socket`](#new) object
+///  * An [`hs.socket`](#new) object.
 ///
 static int socket_new(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -186,16 +186,16 @@ static int socket_new(lua_State *L) {
 
 /// hs.socket.parseAddress(sockaddr) -> table or nil
 /// Function
-/// Parses a binary socket address structure into a readable table
+/// Parses a binary socket address structure into a readable table.
 ///
 /// Parameters:
-///  * sockaddr - A binary socket address structure, usually obtained from the [`info`](#info) method or in [`hs.socket.udp`](./hs.socket.udp.html)'s [read callback](./hs.socket.udp.html#setCallback)
+///  * `sockaddr` - A binary socket address structure, usually obtained from the [`info`](#info) method or in [`hs.socket.udp`](./hs.socket.udp.html)'s [read callback](./hs.socket.udp.html#setCallback).
 ///
 /// Returns:
 ///  * A table describing the address with the following keys or `nil`:
-///   * host - A string containing the host IP
-///   * port - A number containing the port
-///   * addressFamily - A number containing the address family
+///   * host - A string containing the host IP.
+///   * port - A number containing the port.
+///   * addressFamily - A number containing the address family.
 ///
 /// Notes:
 ///  * Some address family definitions from `<sys/socket.h>`:
@@ -231,21 +231,21 @@ static int socket_parseAddress(lua_State *L) {
     return 1;
 }
 
-/// hs.socket:connect({host, port}|path[, fn]) -> self or nil
+/// hs.socket:connect(host, port | path [, fn]) -> self or nil
 /// Method
-/// Connects an unconnected [`hs.socket`](#new) instance
+/// Connects an unconnected socket.
 ///
 /// Parameters:
-///  * host - A string containing the hostname or IP address
-///  * port - A port number [1-65535]
-///  * path - A string containing the path to the Unix domain socket
-///  * fn - An optional single-use callback function to execute after establishing the connection. Receives no parameters
+///  * `host` - A string containing the hostname or IP address.
+///  * `port` - A port number [1-65535].
+///  * `path` - A string containing the path to the Unix domain socket.
+///  * `fn` - An optional single-use callback function to execute after establishing the connection. The callback receives no parameters.
 ///
 /// Returns:
-///  * The [`hs.socket`](#new) object or `nil` if an error occurred
+///  * The [`hs.socket`](#new) object, or `nil` if an error occurred.
 ///
 /// Notes:
-///  * Either a host/port pair OR a Unix domain socket path must be supplied. If no port is passed, the first param is assumed to be a path to the socket file
+///  * Either a host/port pair OR a Unix domain socket path must be supplied. If no port is passed, the first parameter is assumed to be a path to the socket file.
 ///
 static int socket_connect(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -296,14 +296,14 @@ static int socket_connect(lua_State *L) {
 
 /// hs.socket:listen(port|path) -> self or nil
 /// Method
-/// Binds an unconnected [`hs.socket`](#new) instance to a port or path (Unix domain socket) for listening
+/// Binds an unconnected socket to either a port or path (Unix domain socket) for listening.
 ///
 /// Parameters:
-///  * port - A port number [0-65535]. Ports [1-1023] are privileged. Port 0 allows the OS to select any available port
-///  * path - A string containing the path to the Unix domain socket
+///  * `port` - A port number [0-65535]. Ports [1-1023] are privileged. Port 0 allows the OS to select any available port.
+///  * `path` - A string containing the path to the Unix domain socket.
 ///
 /// Returns:
-///  * The [`hs.socket`](#new) object or `nil` if an error occurred
+///  * The [`hs.socket`](#new) object, or `nil` if an error occurred.
 ///
 static int socket_listen(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -344,16 +344,16 @@ static int socket_listen(lua_State *L) {
 
 /// hs.socket:disconnect() -> self
 /// Method
-/// Disconnects the [`hs.socket`](#new) instance, freeing it for reuse
+/// Disconnects the socket, freeing it for reuse.
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
-///  * The [`hs.socket`](#new) object
+///  * The [`hs.socket`](#new) object.
 ///
 /// Notes:
-///  * If called on a listening socket with multiple connections, each client is disconnected
+///  * If called on a listening socket with multiple connections, each client is disconnected.
 ///
 static int socket_disconnect(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -368,17 +368,18 @@ static int socket_disconnect(lua_State *L) {
 
 /// hs.socket:read(delimiter[, tag]) -> self or nil
 /// Method
-/// Read data from the socket. Results are passed to the [callback function](#setCallback), which must be set to use this method
+/// Read data from the socket.
 ///
 /// Parameters:
-///  * delimiter - Either a number of bytes to read, or a string delimiter such as "&#92;n" or "&#92;r&#92;n". Data is read up to and including the delimiter
-///  * tag - An optional integer to assist with labeling reads. It is passed to the callback to assist with implementing [state machines](https://github.com/robbiehanson/CocoaAsyncSocket/wiki/Intro_GCDAsyncSocket#reading--writing) for processing complex protocols
+///  * `delimiter` - Either a number of bytes to read, or a string delimiter such as "\n" or "\r\n". Data is read up to and including the delimiter.
+///  * `tag` - An optional integer to assist with labeling reads. It is passed to the callback to assist with implementing [state machines](https://github.com/robbiehanson/CocoaAsyncSocket/wiki/Intro_GCDAsyncSocket#reading--writing) for processing complex protocols.
 ///
 /// Returns:
-///  * The [`hs.socket`](#new) object or `nil` if an error occured
+///  * The [`hs.socket`](#new) object, or `nil` if an error occured.
 ///
 /// Notes:
-///  * If called on a listening socket with multiple connections, data is read from each of them
+///  * Results are passed to the socket's [callback function](#setCallback), which must be set to use this method.
+///  * If called on a listening socket with multiple connections, data is read from each of them.
 ///
 static int socket_read(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -425,20 +426,20 @@ static int socket_read(lua_State *L) {
     return 1;
 }
 
-/// hs.socket:write(message[, tag][, fn]) -> self
+/// hs.socket:write(message[, tag, fn]) -> self
 /// Method
-/// Write data to the socket
+/// Write data to the socket.
 ///
 /// Parameters:
-///  * message - A string containing data to be sent on the socket
-///  * tag - An optional integer to assist with labeling writes
-///  * fn - An optional single-use callback function to execute after writing data to the socket. Receives the tag parameter
+///  * `message` - A string containing data to be sent on the socket.
+///  * `tag` - An optional integer to assist with labeling writes.
+///  * `fn` - An optional single-use callback function to execute after writing data to the socket. The callback receives the tag parameter provided here.
 ///
 /// Returns:
-///  * The [`hs.socket`](#new) object
+///  * The [`hs.socket`](#new) object.
 ///
 /// Notes:
-///  * If called on a listening socket with multiple connections, data is broadcasted to all connected sockets
+///  * If called on a listening socket with multiple connections, data is broadcast to all connected sockets.
 ///
 static int socket_write(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -471,15 +472,18 @@ static int socket_write(lua_State *L) {
 
 /// hs.socket:setCallback([fn]) -> self
 /// Method
-/// Sets the read callback for the [`hs.socket`](#new) instance. Must be set to read data from the socket
+/// Sets the read callback for the socket.
 ///
 /// Parameters:
-///  * fn - An optional callback function to process data read from the socket. `nil` or no argument clears the callback. The callback receives 2 parameters:
-///    * data - The data read from the socket as a string
-///    * tag - The integer tag associated with the read call, which defaults to -1
+///  * `fn` - An optional callback function to process data read from the socket. `nil` or no argument clears the callback. The callback receives 2 parameters:
+///    * `data` - The data read from the socket as a string.
+///    * `tag` - The integer tag associated with the read call, which defaults to `-1`.
 ///
 /// Returns:
-///  * The [`hs.socket`](#new) object
+///  * The [`hs.socket`](#new) object.
+///
+/// Notes:
+///  * A callback must be set in order to read data from the socket.
 ///
 static int socket_setCallback(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -498,13 +502,16 @@ static int socket_setCallback(lua_State *L) {
 
 /// hs.socket:setTimeout(timeout) -> self
 /// Method
-/// Sets the timeout for the socket operations. If the timeout value is negative, the operations will not use a timeout, which is the default
+/// Sets the timeout for the socket operations.
 ///
 /// Parameters:
-///  * timeout - A number containing the timeout duration, in seconds
+///  * `timeout` - A number containing the timeout duration, in seconds.
 ///
 /// Returns:
-///  * The [`hs.socket`](#new) object
+///  * The [`hs.socket`](#new) object.
+///
+/// Notes:
+///  *  If the timeout value is negative, the operations will not use a timeout, which is the default.
 ///
 static int socket_setTimeout(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -519,28 +526,18 @@ static int socket_setTimeout(lua_State *L) {
 
 /// hs.socket:startTLS([verify][, peerName]) -> self
 /// Method
-/// Secures the socket with TLS. The socket will disconnect immediately if TLS negotiation fails
+/// Secures the socket with TLS.
 ///
 /// Parameters:
-///  * verify - An optional boolean that, if `false`, allows TLS handshaking with servers with self-signed certificates and does not evaluate the chain of trust. Defaults to `true` and omitted if `peerName` is supplied
-///  * peerName - An optional string containing the fully qualified domain name of the peer to validate against — for example, `store.apple.com`. It should match the name in the X.509 certificate given by the remote party. See notes below
+///  * `verify` - An optional boolean that, if `false`, allows TLS handshaking with servers with self-signed certificates and does not evaluate the chain of trust. Defaults to `true` and omitted if `peerName` is supplied
+///  * `peerName` - An optional string containing the fully qualified domain name of the peer to validate against — for example, `store.apple.com`. It should match the name in the X.509 certificate given by the remote party. See the important security note below.
 ///
 /// Returns:
-///  * The [`hs.socket`](#new) object
+///  * The [`hs.socket`](#new) object.
 ///
 /// Notes:
-/// * IMPORTANT SECURITY NOTE:
-/// The default settings will check to make sure the remote party's certificate is signed by a
-/// trusted 3rd party certificate agency (e.g. verisign) and that the certificate is not expired.
-/// However it will not verify the name on the certificate unless you
-/// give it a name to verify against via `peerName`.
-/// The security implications of this are important to understand.
-/// Imagine you are attempting to create a secure connection to MySecureServer.com,
-/// but your socket gets directed to MaliciousServer.com because of a hacked DNS server.
-/// If you simply use the default settings, and MaliciousServer.com has a valid certificate,
-/// the default settings will not detect any problems since the certificate is valid.
-/// To properly secure your connection in this particular scenario you
-/// should set `peerName` to "MySecureServer.com".
+///  * The socket will disconnect immediately if TLS negotiation fails. 
+///  * **IMPORTANT SECURITY NOTE**: The default settings will check to make sure the remote party's certificate is signed by a trusted 3rd party certificate agency (e.g. verisign) and that the certificate is not expired.  However it will not verify the name on the certificate unless you give it a name to verify against via `peerName`.  The security implications of this are important to understand.  Imagine you are attempting to create a secure connection to MySecureServer.com, but your socket gets directed to MaliciousServer.com because of a hacked DNS server.  If you simply use the default settings, and MaliciousServer.com has a valid certificate, the default settings will not detect any problems since the certificate is valid.  To properly secure your connection in this particular scenario you should set `peerName` to "MySecureServer.com".
 ///
 static int socket_startTLS(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -574,13 +571,16 @@ static NSInteger get_socket_connections(HSAsyncTcpSocket* asyncSocket) {
 
 /// hs.socket:connected() -> bool
 /// Method
-/// Returns the connection status of the [`hs.socket`](#new) instance
+/// Returns the connection status of the socket.
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
-///  * `true` if connected, otherwise `false`
+///  * `true` if the socket is connected, otherwise `false`.
+///
+/// Notes:
+///  * If the socket is bound for listening, this method returns `true` if there is at least one connection.
 ///
 static int socket_connected(lua_State *L) {
     [[LuaSkin sharedWithState:L] checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
@@ -592,13 +592,16 @@ static int socket_connected(lua_State *L) {
 
 /// hs.socket:connections() -> number
 /// Method
-/// Returns the number of connections to the socket, which is at most 1 for default (non-listening) sockets
+/// Returns the number of connections to the socket.
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
-///  * The number of connections to the socket
+///  * The number of connections to the socket.
+///
+/// Notes:
+///  * This method returns at most 1 for default (non-listening) sockets.
 ///
 static int socket_connections(lua_State *L) {
     [[LuaSkin sharedWithState:L] checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBREAK];
@@ -610,32 +613,32 @@ static int socket_connections(lua_State *L) {
 
 /// hs.socket:info() -> table
 /// Method
-/// Returns information on the [`hs.socket`](#new) instance
+/// Returns information about the socket.
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
 ///  * A table containing the following keys:
-///   * connectedAddress - `string` (`sockaddr` struct)
-///   * connectedHost - `string`
-///   * connectedPort - `number`
-///   * connectedURL - `string`
-///   * connections - `number`
-///   * isConnected - `boolean`
-///   * isDisconnected - `boolean`
-///   * isIPv4 - `boolean`
-///   * isIPv4Enabled - `boolean`
-///   * isIPv4PreferredOverIPv6 - `boolean`
-///   * isIPv6 - `boolean`
-///   * isIPv6Enabled - `boolean`
-///   * isSecure - `boolean`
-///   * localAddress - `string` (`sockaddr` struct)
-///   * localHost - `string`
-///   * localPort - `number`
-///   * timeout - `number`
-///   * unixSocketPath - `string`
-///   * userData - `string`
+///    * connectedAddress - `string` (`sockaddr` struct)
+///    * connectedHost - `string`
+///    * connectedPort - `number`
+///    * connectedURL - `string`
+///    * connections - `number`
+///    * isConnected - `boolean`
+///    * isDisconnected - `boolean`
+///    * isIPv4 - `boolean`
+///    * isIPv4Enabled - `boolean`
+///    * isIPv4PreferredOverIPv6 - `boolean`
+///    * isIPv6 - `boolean`
+///    * isIPv6Enabled - `boolean`
+///    * isSecure - `boolean`
+///    * localAddress - `string` (`sockaddr` struct)
+///    * localHost - `string`
+///    * localPort - `number`
+///    * timeout - `number`
+///    * unixSocketPath - `string`
+///    * userData - `string`
 ///
 static int socket_info(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];

--- a/extensions/socket/libsocket_udp.m
+++ b/extensions/socket/libsocket_udp.m
@@ -110,13 +110,13 @@ static void readCallback(HSAsyncUdpSocket *asyncUdpSocket, NSData *data, NSData 
 
 /// hs.socket.udp.new([fn]) -> hs.socket.udp object
 /// Constructor
-/// Creates an unconnected asynchronous UDP socket object
+/// Creates an unconnected asynchronous UDP socket object.
 ///
 /// Parameters:
-///  * fn - An optional [callback function](#setCallback) for reading data from the socket, settable here for convenience
+///  * `fn` - An optional [callback function](#setCallback) for reading data from the socket, settable here for convenience.
 ///
 /// Returns:
-///  * An [`hs.socket.udp`](#new) object
+///  * An [`hs.socket.udp`](#new) object.
 ///
 static int socketudp_new(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -144,25 +144,25 @@ static int socketudp_new(lua_State *L) {
 
 /// hs.socket.udp:connect(host, port[, fn]) -> self or nil
 /// Method
-/// Connects an unconnected [`hs.socket.udp`](#new) instance
+/// Connects an unconnected socket.
 ///
 /// Parameters:
-///  * host - A string containing the hostname or IP address
-///  * port - A port number [1-65535]
-///  * fn - An optional single-use callback function to execute after establishing the connection. Receives no parameters
+///  * `host` - A string containing the hostname or IP address.
+///  * `port` - A port number [1-65535].
+///  * `fn` - An optional single-use callback function to execute after establishing the connection. The callback receives no parameters.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object or `nil` if an error occured
+///  * The [`hs.socket.udp`](#new) object, or `nil` if an error occured.
 ///
 /// Notes:
-/// * By design, UDP is a connectionless protocol, and connecting is not needed
+/// * By design, UDP is a connectionless protocol, and connecting is not needed.
 /// * Choosing to connect to a specific host/port has the following effect:
-///  * You will only be able to send data to the connected host/port
-///  * You will only be able to receive data from the connected host/port
-///  * You will receive ICMP messages that come from the connected host/port, such as "connection refused"
-/// * The actual process of connecting a UDP socket does not result in any communication on the socket. It simply changes the internal state of the socket
-/// * You cannot bind a socket after it has been connected
-/// * You can only connect a socket once
+///   * You will only be able to send data to the connected host/port;
+///   * You will only be able to receive data from the connected host/port;
+///   * You will receive ICMP messages that come from the connected host/port, such as "connection refused".
+/// * The actual process of connecting a UDP socket does not result in any communication on the socket, it simply changes the internal state of the socket.
+/// * You cannot bind a socket for listening after it has been connected.
+/// * You can only connect a socket once.
 ///
 static int socketudp_connect(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -191,13 +191,13 @@ static int socketudp_connect(lua_State *L) {
 
 /// hs.socket.udp:listen(port) -> self or nil
 /// Method
-/// Binds an unconnected [`hs.socket.udp`](#new) instance to a port for listening
+/// Binds an unconnected socket to a port for listening.
 ///
 /// Parameters:
-///  * port - A port number [0-65535]. Ports [1-1023] are privileged. Port 0 allows the OS to select any available port
+///  * `port` - A port number [0-65535]. Ports [1-1023] are privileged. Port 0 allows the OS to select any available port.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object or `nil` if an error occured
+///  * The [`hs.socket.udp`](#new) object, or `nil` if an error occured.
 ///
 static int socketudp_listen(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -221,13 +221,13 @@ static int socketudp_listen(lua_State *L) {
 
 /// hs.socket.udp:close() -> self
 /// Method
-/// Immediately closes the underlying socket, freeing the [`hs.socket.udp`](#new) instance for reuse. Any pending send operations are discarded
+/// Immediately closes the socket, freeing it for reuse. Any pending send operations are discarded.
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object
+///  * The [`hs.socket.udp`](#new) object.
 ///
 static int socketudp_close(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -242,13 +242,16 @@ static int socketudp_close(lua_State *L) {
 
 /// hs.socket.udp:pause() -> self
 /// Method
-/// Suspends reading of packets from the socket. Call one of the receive methods to resume
+/// Suspends reading of packets from the socket.
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
 ///  * The [`hs.socket.udp`](#new) object
+///
+/// Notes:
+///  * Call one of the receive methods to resume.
 ///
 static int socketudp_pause(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -291,22 +294,23 @@ static BOOL socketudp_receiveContinuous(lua_State *L, BOOL readContinuous) {
 
 /// hs.socket.udp:receive([fn]) -> self or nil
 /// Method
-/// Reads packets from the socket as they arrive. Results are passed to the [callback function](#setCallback), which must be set to use this method
+/// Reads packets from the socket as they arrive.
 ///
 /// Parameters:
-///  * fn - Optionally supply the [read callback](#setCallback) here
+///  * `fn` - Optionally supply the [read callback](#setCallback) here.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object or `nil` if an error occured
+///  * The [`hs.socket.udp`](#new) object, or `nil` if an error occured.
 ///
 /// Notes:
-///  * There are two modes of operation for receiving packets: one-at-a-time & continuous
-///  * In one-at-a-time mode, you call receiveOne every time you are ready process an incoming UDP packet
-///  * Receiving packets one-at-a-time may be better suited for implementing certain state machine code where your state machine may not always be ready to process incoming packets
-///  * In continuous mode, the callback is invoked immediately every time incoming udp packets are received
-///  * Receiving packets continuously is better suited to real-time streaming applications
-///  * You may switch back and forth between one-at-a-time mode and continuous mode
-///  * If the socket is currently in one-at-a-time mode, calling this method will switch it to continuous mode
+///  * Results are passed to the [callback function](#setCallback), which must be set to use this method.
+///  * There are two modes of operation for receiving packets: one-at-a-time & continuous.
+///  * In one-at-a-time mode, you call receiveOne every time you are ready process an incoming UDP packet.
+///  * Receiving packets one-at-a-time may be better suited for implementing certain state machine code where your state machine may not always be ready to process incoming packets.
+///  * In continuous mode, the callback is invoked immediately every time incoming udp packets are received.
+///  * Receiving packets continuously is better suited to real-time streaming applications.
+///  * You may switch back and forth between one-at-a-time mode and continuous mode.
+///  * If the socket is currently in one-at-a-time mode, calling this method will switch it to continuous mode.
 ///
 static int socketudp_receive(lua_State *L) {
     socketudp_receiveContinuous(L, true) ? lua_pushvalue(L, 1) : lua_pushnil(L);
@@ -316,21 +320,22 @@ static int socketudp_receive(lua_State *L) {
 
 /// hs.socket.udp:receiveOne([fn]) -> self or nil
 /// Method
-/// Reads a single packet from the socket. Results are passed to the [callback function](#setCallback), which must be set to use this method
+/// Reads a single packet from the socket.
 ///
 /// Parameters:
-///  * fn - Optionally supply the [read callback](#setCallback) here
+///  * `fn` - Optionally supply the [read callback](#setCallback) here.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object or `nil` if an error occured
+///  * The [`hs.socket.udp`](#new) object, or `nil` if an error occured.
 ///
 /// Notes:
-///  * There are two modes of operation for receiving packets: one-at-a-time & continuous
-///  * In one-at-a-time mode, you call receiveOne every time you are ready process an incoming UDP packet
-///  * Receiving packets one-at-a-time may be better suited for implementing certain state machine code where your state machine may not always be ready to process incoming packets
-///  * In continuous mode, the callback is invoked immediately every time incoming udp packets are received
-///  * Receiving packets continuously is better suited to real-time streaming applications
-///  * You may switch back and forth between one-at-a-time mode and continuous mode
+///  * Results are passed to the [callback function](#setCallback), which must be set to use this method.
+///  * There are two modes of operation for receiving packets: one-at-a-time & continuous.
+///  * In one-at-a-time mode, you call receiveOne every time you are ready process an incoming UDP packet.
+///  * Receiving packets one-at-a-time may be better suited for implementing certain state machine code where your state machine may not always be ready to process incoming packets.
+///  * In continuous mode, the callback is invoked immediately every time incoming udp packets are received.
+///  * Receiving packets continuously is better suited to real-time streaming applications.
+///  * You may switch back and forth between one-at-a-time mode and continuous mode.
 ///  * If the socket is currently in continuous mode, calling this method will switch it to one-at-a-time mode
 ///
 static int socketudp_receiveOne(lua_State *L) {
@@ -339,25 +344,25 @@ static int socketudp_receiveOne(lua_State *L) {
     return 1;
 }
 
-/// hs.socket.udp:send(message, host, port[, tag][, fn]) -> self
+/// hs.socket.udp:send(message[, host, port][, tag, fn]) -> self
 /// Method
-/// Sends a packet to the destination address
+/// Sends a packet to the destination address.
 ///
 /// Parameters:
-///  * message - A string containing data to be sent on the socket
-///  * host - A string containing the hostname or IP address
-///  * port - A port number [1-65535]
-///  * tag - An optional integer to assist with labeling writes
-///  * fn - An optional single-use callback function to execute after sending the packet. Receives the tag parameter
+///  * `message` - A string containing data to be sent on the socket.
+///  * `host` - A string containing the hostname or IP address.
+///  * `port` - A port number [1-65535].
+///  * `tag` - An optional integer to assist with labeling writes.
+///  * `fn` - An optional single-use callback function to execute after sending the packet. The callback receives the tag parameter provided here.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object
+///  * The [`hs.socket.udp`](#new) object.
 ///
 /// Notes:
-///  * For non-connected sockets, the remote destination is specified for each packet
-///  * If the socket has been explicitly connected with [`connect`](#connect), only the message parameter and an optional tag and/or write callback can be supplied
-///  * Recall that connecting is optional for a UDP socket
-///  * For connected sockets, data can only be sent to the connected address
+///  * For non-connected sockets, the remote destination is specified for each packet.
+///  * If the socket has been explicitly connected with [`connect`](#connect), only the message parameter and an optional tag and/or write callback can be supplied.
+///  * Recall that connecting is optional for a UDP socket.
+///  * For connected sockets, data can only be sent to the connected address.
 ///
 static int socketudp_send(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -412,17 +417,17 @@ static int socketudp_send(lua_State *L) {
 
 /// hs.socket.udp:broadcast([flag]) -> self or nil
 /// Method
-/// Enables broadcasting on the underlying socket
+/// Enables broadcasting on the underlying socket.
 ///
 /// Parameters:
-///  * flag - An optional boolean: `true` to enable broadcasting, `false` to disable it. Defaults to `true`
+///  * `flag` - An optional boolean: `true` to enable broadcasting, `false` to disable it. Defaults to `true`.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object or `nil` if an error occurred
+///  * The [`hs.socket.udp`](#new) object, or `nil` if an error occurred.
 ///
 /// Notes:
-///  * By default, the underlying socket in the OS will not allow you to send broadcast messages
-///  * In order to send broadcast messages, you need to enable this functionality in the socket
+///  * By default, the underlying socket in the OS will not allow you to send broadcast messages.
+///  * In order to send broadcast messages, you need to enable this functionality in the socket.
 ///  * A broadcast is a UDP message to addresses like "192.168.255.255" or "255.255.255.255" that is delivered to every host on the network.
 ///  * The reason this is generally disabled by default (by the OS) is to prevent accidental broadcast messages from flooding the network.
 ///
@@ -446,19 +451,19 @@ static int socketudp_enableBroadcast(lua_State *L) {
 
 /// hs.socket.udp:reusePort([flag]) -> self or nil
 /// Method
-/// Enables port reuse on the underlying socket
+/// Enables port reuse on the socket.
 ///
 /// Parameters:
-///  * flag - An optional boolean: `true` to enable port reuse, `false` to disable it. Defaults to `true`
+///  * `flag` - An optional boolean: `true` to enable port reuse, `false` to disable it. Defaults to `true`.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object or `nil` if an error occurred
+///  * The [`hs.socket.udp`](#new) object, or `nil` if an error occurred.
 ///
 /// Notes:
-///  * By default, only one socket can be bound to a given IP address+port at a time
-///  * To enable multiple processes to simultaneously bind to the same address+port, you need to enable this functionality in the socket
-///  * All processes that wish to use the address+port simultaneously must all enable reuse port on the socket bound to that port
-///  * Must be called before binding the socket
+///  * By default, only one socket can be bound to a given IP address & port at a time.
+///  * To enable multiple processes to simultaneously bind to the same address & port, you need to enable this functionality in the socket.
+///  * All processes that wish to use the address & port simultaneously must all enable reuse port on the socket bound to that port.
+///  * Must be called before binding the socket.
 ///
 static int socketudp_enableReusePort(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -480,19 +485,19 @@ static int socketudp_enableReusePort(lua_State *L) {
 
 /// hs.socket.udp:enableIPv(version[, flag]) -> self or nil
 /// Method
-/// Enables or disables IPv4 or IPv6 on the underlying socket. By default, both are enabled
+/// Enables or disables IPv4 or IPv6 on the underlying socket. By default, both are enabled.
 ///
 /// Parameters:
-///  * version - A number containing the IP version (4 or 6) to enable or disable
-///  * flag - A boolean: `true` to enable the chosen IP version, `false` to disable it. Defaults to `true`
+///  * `version` - A number containing the IP version (4 or 6) to enable or disable.
+///  * `flag` - A boolean: `true` to enable the chosen IP version, `false` to disable it. Defaults to `true`.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object or `nil` if an error occurred
+///  * The [`hs.socket.udp`](#new) object, or `nil` if an error occurred.
 ///
 /// Notes:
 ///  * Must be called before binding the socket. If you want to create an IPv6-only server, do something like:
-///   * `hs.socket.udp.new(callback):enableIPv(4, false):listen(port):receive()`
-///  * The convenience constructor [`hs.socket.server`](#server) will automatically bind the socket and requires closing and relistening to use this method
+///    * `hs.socket.udp.new(callback):enableIPv(4, false):listen(port):receive()`
+///  * The convenience constructor [`hs.socket.server`](#server) will automatically bind the socket and requires closing and relistening to use this method.
 ///
 static int socketudp_enableIPversion(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -517,18 +522,18 @@ static int socketudp_enableIPversion(lua_State *L) {
 
 /// hs.socket.udp:preferIPv([version]) -> self
 /// Method
-/// Sets the preferred IP version: IPv4, IPv6, or neutral (first to resolve)
+/// Sets the preferred IP version: IPv4, IPv6, or neutral (first to resolve).
 ///
 /// Parameters:
-///  * version - An optional number containing the IP version to prefer. Anything but 4 or 6 else sets the default neutral behavior
+///  * `version` - An optional number containing the IP version to prefer. Anything but 4 or 6 else sets the default neutral behavior.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object
+///  * The [`hs.socket.udp`](#new) object.
 ///
 /// Notes:
-///  * If a DNS lookup returns only IPv4 results, the socket will automatically use IPv4
-///  * If a DNS lookup returns only IPv6 results, the socket will automatically use IPv6
-///  * If a DNS lookup returns both IPv4 and IPv6 results, then the protocol used depends on the configured preference
+///  * If a DNS lookup returns only IPv4 results, the socket will automatically use IPv4.
+///  * If a DNS lookup returns only IPv6 results, the socket will automatically use IPv6.
+///  * If a DNS lookup returns both IPv4 and IPv6 results, then the protocol used depends on the configured preference.
 ///
 static int socketudp_preferIPversion(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -549,22 +554,22 @@ static int socketudp_preferIPversion(lua_State *L) {
 
 /// hs.socket.udp:setBufferSize(size[, version]) -> self
 /// Method
-/// Sets the maximum size of the buffer that will be allocated for receive operations
+/// Sets the maximum size of the buffer that will be allocated for receive operations.
 ///
 /// Parameters:
-///  * size - An number containing the receive buffer size in bytes
-///  * version - An optional number containing the IP version for which to set the buffer size. Anything but 4 or 6 else sets the same size for both
+///  * `size` - An number containing the receive buffer size in bytes.
+///  * `version` - An optional number containing the IP version for which to set the buffer size. Anything but 4 or 6 else sets the same size for both.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object
+///  * The [`hs.socket.udp`](#new) object.
 ///
 /// Notes:
-///  * The default maximum size is 9216 bytes
-///  * The theoretical maximum size of any IPv4 UDP packet is UINT16_MAX = 65535
-///  * The theoretical maximum size of any IPv6 UDP packet is UINT32_MAX = 4294967295
-///  * Since the OS notifies us of the size of each received UDP packet, the actual allocated buffer size for each packet is exact
+///  * The default maximum size is 9216 bytes.
+///  * The theoretical maximum size of any IPv4 UDP packet is `UINT16_MAX = 65535`.
+///  * The theoretical maximum size of any IPv6 UDP packet is `UINT32_MAX = 4294967295`.
+///  * Since the OS notifies us of the size of each received UDP packet, the actual allocated buffer size for each packet is exact.
 ///  * In practice the size of UDP packets is generally much smaller than the max. Most protocols will send and receive packets of only a few bytes, or will set a limit on the size of packets to prevent fragmentation in the IP layer.
-///  * If you set the buffer size too small, the sockets API in the OS will silently discard any extra data
+///  * If you set the buffer size too small, the sockets API in the OS will silently discard any extra data.
 ///
 static int socketudp_setReceiveBufferSize(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -591,15 +596,19 @@ static int socketudp_setReceiveBufferSize(lua_State *L) {
 
 /// hs.socket.udp:setCallback([fn]) -> self
 /// Method
-/// Sets the read callback for the [`hs.socket.udp`](#new) instance. Must be set to read data from the socket
+/// Sets the read callback for the socket.
 ///
 /// Parameters:
-///  * fn - An optional callback function to process data read from the socket. `nil` or no argument clears the callback. The callback receives 2 parameters:
-///    * data - The data read from the socket as a string
-///    * sockaddr - The sending address as a binary socket address structure. See [`parseAddress`](#parseAddress)
+///  * `fn` - An optional callback function to process data read from the socket. `nil` or no argument clears the callback. The callback receives 2 parameters:
+///    * `data` - The data read from the socket as a string.
+///    * `sockaddr` - The sending address as a binary socket address structure. See [`parseAddress`](#parseAddress).
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object
+///  * The [`hs.socket.udp`](#new) object.
+///
+/// Notes:
+///  * A callback must be set in order to read data from the socket.
+///
 static int socketudp_setCallback(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
     [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION|LS_TNIL|LS_TOPTIONAL, LS_TBREAK];
@@ -618,13 +627,16 @@ static int socketudp_setCallback(lua_State *L) {
 
 /// hs.socket.udp:setTimeout(timeout) -> self
 /// Method
-/// Sets the timeout for the socket operations. If the timeout value is negative, the operations will not use a timeout, which is the default
+/// Sets the timeout for the socket operations.
 ///
 /// Parameters:
-///  * timeout - A number containing the timeout duration, in seconds
+///  * `timeout` - A number containing the timeout duration, in seconds.
 ///
 /// Returns:
-///  * The [`hs.socket.udp`](#new) object
+///  * The [`hs.socket.udp`](#new) object.
+///
+/// Notes:
+///  *  If the timeout value is negative, the operations will not use a timeout, which is the default.
 ///
 static int socketudp_setTimeout(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -639,17 +651,17 @@ static int socketudp_setTimeout(lua_State *L) {
 
 /// hs.socket.udp:connected() -> bool
 /// Method
-/// Returns the connection status of the [`hs.socket.udp`](#new) instance
+/// Returns the connection status of the socket.
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
-///  * `true` if connected, otherwise `false`
+///  * `true` if connected, otherwise `false`.
 ///
 /// Notes:
-///  * UDP sockets are typically meant to be connectionless
-///  * This method will only return `true` if the [`connect`](#connect) method has been explicitly called
+///  * UDP sockets are typically meant to be connectionless.
+///  * This method will only return `true` if the [`hs.socket.udp:connect`](#connect) method has been explicitly called.
 ///
 static int socketudp_connected(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -662,18 +674,18 @@ static int socketudp_connected(lua_State *L) {
 
 /// hs.socket.udp:closed() -> bool
 /// Method
-/// Returns the closed status of the [`hs.socket.udp`](#new) instance
+/// Returns the closed status of the socket.
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
-///  * `true` if closed, otherwise `false`
+///  * `true` if the socket is closed, otherwise `false`.
 ///
 /// Notes:
-///  * UDP sockets are typically meant to be connectionless
-///  * Sending a packet anywhere, regardless of whether or not the destination receives it, opens the socket until it is explicitly closed
-///  * An active listening socket will not be closed, but will not be 'connected' unless the [connect](#connect) method has been called
+///  * UDP sockets are typically meant to be connectionless.
+///  * Sending a packet anywhere, regardless of whether or not the destination receives it, opens the socket until it is explicitly closed.
+///  * An active listening socket will not be closed, but will not be 'connected' unless the [`hs.socket.udp:connect`](#connect) method has been called.
 ///
 static int socketudp_closed(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];
@@ -686,38 +698,38 @@ static int socketudp_closed(lua_State *L) {
 
 /// hs.socket.udp:info() -> table
 /// Method
-/// Returns information on the [`hs.socket.udp`](#new) instance
+/// Returns information about the socket.
 ///
 /// Parameters:
 ///  * None
 ///
 /// Returns:
 ///  * A table containing the following keys:
-///   * connectedAddress - `string` (`sockaddr` struct)
-///   * connectedHost - `string`
-///   * connectedPort - `number`
-///   * isClosed - `boolean`
-///   * isConnected - `boolean`
-///   * isIPv4 - `boolean`
-///   * isIPv4Enabled - `boolean`
-///   * isIPv4Preferred - `boolean`
-///   * isIPv6 - `boolean`
-///   * isIPv6Enabled - `boolean`
-///   * isIPv6Preferred - `boolean`
-///   * isIPVersionNeutral - `boolean`
-///   * localAddress - `string` (`sockaddr` struct)
-///   * localAddress_IPv4 - `string` (`sockaddr` struct)
-///   * localAddress_IPv6 - `string` (`sockaddr` struct)
-///   * localHost - `string`
-///   * localHost_IPv4 - `string`
-///   * localHost_IPv6 - `string`
-///   * localPort - `number`
-///   * localPort_IPv4 - `number`
-///   * localPort_IPv6 - `number`
-///   * maxReceiveIPv4BufferSize - `number`
-///   * maxReceiveIPv6BufferSize - `number`
-///   * timeout - `number`
-///   * userData - `string`
+///    * connectedAddress - `string` (`sockaddr` struct)
+///    * connectedHost - `string`
+///    * connectedPort - `number`
+///    * isClosed - `boolean`
+///    * isConnected - `boolean`
+///    * isIPv4 - `boolean`
+///    * isIPv4Enabled - `boolean`
+///    * isIPv4Preferred - `boolean`
+///    * isIPv6 - `boolean`
+///    * isIPv6Enabled - `boolean`
+///    * isIPv6Preferred - `boolean`
+///    * isIPVersionNeutral - `boolean`
+///    * localAddress - `string` (`sockaddr` struct)
+///    * localAddress_IPv4 - `string` (`sockaddr` struct)
+///    * localAddress_IPv6 - `string` (`sockaddr` struct)
+///    * localHost - `string`
+///    * localHost_IPv4 - `string`
+///    * localHost_IPv6 - `string`
+///    * localPort - `number`
+///    * localPort_IPv4 - `number`
+///    * localPort_IPv6 - `number`
+///    * maxReceiveIPv4BufferSize - `number`
+///    * maxReceiveIPv6BufferSize - `number`
+///    * timeout - `number`
+///    * userData - `string`
 ///
 static int socketudp_info(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L];

--- a/extensions/socket/socket.lua
+++ b/extensions/socket/socket.lua
@@ -1,8 +1,8 @@
 --- === hs.socket ===
 ---
---- Talk to custom protocols using asynchronous TCP sockets
+--- Talk to custom protocols using asynchronous TCP sockets.
 ---
---- For UDP sockets see [`hs.socket.udp`](./hs.socket.udp.html)
+--- For UDP sockets see [`hs.socket.udp`](./hs.socket.udp.html).
 ---
 --- `hs.socket` is implemented with [CocoaAsyncSocket](https://github.com/robbiehanson/CocoaAsyncSocket). CocoaAsyncSocket's [tagging features](https://github.com/robbiehanson/CocoaAsyncSocket/wiki/Intro_GCDAsyncSocket#reading--writing) provide a handy way to implement custom protocols.
 ---
@@ -61,9 +61,9 @@
 
 --- === hs.socket.udp ===
 ---
---- Talk to custom protocols using asynchronous UDP sockets
+--- Talk to custom protocols using asynchronous UDP sockets.
 ---
---- For TCP sockets see [`hs.socket`](./hs.socket.html)
+--- For TCP sockets see [`hs.socket`](./hs.socket.html).
 ---
 --- You can do a lot of neat trivial and non-trivial things with these. A simple ping ponger:
 --- ```lua
@@ -161,17 +161,23 @@ module.getLogLevel=log.getLogLevel
 
 --- hs.socket.timeout
 --- Variable
---- Timeout for the socket operations, in seconds. New [`hs.socket`](#new) objects will be created with this timeout value, but can individually change it with the [`setTimeout`](#setTimeout) method
+--- Timeout for the socket operations, in seconds.
 ---
---- If the timeout value is negative, the operations will not use a timeout. The default value is -1
+--- Notes:
+---  * New [`hs.socket`](#new) objects will be created with this timeout value, but can individually change it with the [`hs.socket:setTimeout`](#setTimeout) method.
+---
+---  * If the timeout value is negative, the operations will not use a timeout. The default value is `-1`.
 ---
 module.timeout = -1
 
 --- hs.socket.udp.timeout
 --- Variable
---- Timeout for the socket operations, in seconds. New [`hs.socket.udp`](#new) objects will be created with this timeout value, but can individually change it with the [`setTimeout`](#setTimeout) method
+--- Timeout for the socket operations, in seconds.
 ---
---- If the timeout value is negative, the operations will not use a timeout. The default value is -1
+--- Notes:
+---  * New [`hs.socket.udp`](#new) objects will be created with this timeout value, but can individually change it with the [`hs.socket.udp:setTimeout`](#setTimeout) method.
+---
+---  * If the timeout value is negative, the operations will not use a timeout. The default value is `-1`.
 ---
 module.udp.timeout = -1
 
@@ -181,17 +187,17 @@ module.udp.timeout = -1
 ---
 module.udp.parseAddress = module.parseAddress
 
---- hs.socket.server(port|path[, fn]) -> hs.socket object
+--- hs.socket.server(port | path [, fn]) -> hs.socket object
 --- Constructor
---- Creates and binds an [`hs.socket`](#new) instance to a port or path (Unix domain socket) for listening
+--- Creates a TCP socket, and binds it to either a port or path (Unix domain socket) for listening.
 ---
 --- Parameters:
----  * port - A port number [0-65535]. Ports [1-1023] are privileged. Port 0 allows the OS to select any available port
----  * path - A string containing the path to the Unix domain socket
----  * fn - An optional [callback function](#setCallback) for reading data from the socket, settable here for convenience
+---  * `port` - A port number [0-65535]. Ports [1-1023] are privileged. Port 0 allows the OS to select any available port.
+---  * `path` - A string containing the path to the Unix domain socket.
+---  * `fn` - An optional [callback function](#setCallback) for reading data from the socket, settable here for convenience.
 ---
 --- Returns:
----  * An [`hs.socket`](#new) object
+---  * An [`hs.socket`](#new) object.
 ---
 module.server = function(port, callback)
   local sock = module.new(callback)
@@ -201,14 +207,14 @@ end
 
 --- hs.socket.udp.server(port[, fn]) -> hs.socket.udp object
 --- Constructor
---- Creates and binds an [`hs.socket.udp`](#new) instance to a port for listening
+--- Creates a UDP socket, and binds it to a port for listening.
 ---
 --- Parameters:
----  * port - A port number [0-65535]. Ports [1-1023] are privileged. Port 0 allows the OS to select any available port
----  * fn - An optional [callback function](#setCallback) for reading data from the socket, settable here for convenience
+---  * `port` - A port number [0-65535]. Ports [1-1023] are privileged. Port 0 allows the OS to select any available port.
+---  * `fn` - An optional [callback function](#setCallback) for reading data from the socket, settable here for convenience.
 ---
 --- Returns:
----  * An [`hs.socket.udp`](#new) object
+---  * An [`hs.socket.udp`](#new) object.
 ---
 module.udp.server = function(port, callback)
   local sock = module.udp.new(callback)


### PR DESCRIPTION
I tried to make the formatting of documentation in this extension more consistent and easily readable, without editorialising the actual content. For what it's worth, I haven't used `hs.socket.udp` nearly as much as the TCP module.

Fixes #3201