### PR TITLE
Allow the query to still be forwarded when no matching string exists

### DIFF
--- a/Hammerspoon.xcodeproj/project.pbxproj
+++ b/Hammerspoon.xcodeproj/project.pbxproj
@@ -8671,7 +8671,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4F7F3B7B272DE98800E05732 /* Hammerspoon-Profile.xcconfig */;
 			buildSettings = {
-				DEVELOPMENT_TEAM = KLV5NKS8A2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -10443,7 +10442,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4F7F3B7A272DE83500E05732 /* Hammerspoon-Debug.xcconfig */;
 			buildSettings = {
-				DEVELOPMENT_TEAM = KLV5NKS8A2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -10455,13 +10453,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4F7F3B7C272DE99200E05732 /* Hammerspoon-Release.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				DEVELOPMENT_TEAM = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};
@@ -10522,7 +10517,6 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = KLV5NKS8A2;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",

--- a/Hammerspoon.xcodeproj/project.pbxproj
+++ b/Hammerspoon.xcodeproj/project.pbxproj
@@ -8671,6 +8671,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4F7F3B7B272DE98800E05732 /* Hammerspoon-Profile.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = KLV5NKS8A2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -10442,6 +10443,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4F7F3B7A272DE83500E05732 /* Hammerspoon-Debug.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = KLV5NKS8A2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -10453,10 +10455,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4F7F3B7C272DE99200E05732 /* Hammerspoon-Release.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEVELOPMENT_TEAM = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};
@@ -10517,6 +10522,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = KLV5NKS8A2;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",

--- a/extensions/chooser/HSChooser.h
+++ b/extensions/chooser/HSChooser.h
@@ -30,6 +30,8 @@
 @property(nonatomic, retain) NSString *fontName;
 @property(nonatomic) CGFloat fontSize;
 @property(nonatomic) BOOL searchSubText;
+@property(nonatomic) BOOL enableDefaultForQuery;
+
 @property(nonatomic) NSColor *fgColor;
 @property(nonatomic) NSColor *subTextColor;
 

--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -396,7 +396,7 @@
         }
 
         _lua_stackguard_exit(skin.L);
-    } else if (self.enableDefaultForQuery != NO) {
+    } else if (self.enableDefaultForQuery != NO && self.completionCallbackRef != LUA_NOREF && self.completionCallbackRef != LUA_REFNIL) {
         // No row remaining in choices, return just query
         self.hasChosen = YES;
         LuaSkin *skin = [LuaSkin sharedWithState:NULL];

--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -38,6 +38,7 @@
         self.currentStaticChoices = nil;
         self.currentCallbackChoices = nil;
         self.filteredChoices = nil;
+        self.enableDefaultForQuery = NO;
 
         self.hideCallbackRef = LUA_NOREF;
         self.showCallbackRef = LUA_NOREF;
@@ -393,7 +394,19 @@
             [skin pushNSObject:choice];
             [skin protectedCallAndError:@"hs.chooser:completionCallback" nargs:1 nresults:0];
         }
-        
+
+        _lua_stackguard_exit(skin.L);
+    } else if (self.enableDefaultForQuery != NO) {
+        // No row remaining in choices, return just query
+        self.hasChosen = YES;
+        LuaSkin *skin = [LuaSkin sharedWithState:NULL];
+        _lua_stackguard_entry(skin.L);
+        NSDictionary<NSString*, NSString*> *choice = @{@"text": self.queryField.stringValue};
+        [self hide];
+        [skin pushLuaRef:self.refTable ref:self.completionCallbackRef];
+        [skin pushNSObject:choice];
+        [skin protectedCallAndError:@"hs.chooser:completionCallback" nargs:1 nresults:0];
+
         _lua_stackguard_exit(skin.L);
     }
 }

--- a/extensions/chooser/libchooser.m
+++ b/extensions/chooser/libchooser.m
@@ -581,6 +581,43 @@ static int chooserSetBgDark(lua_State *L) {
     return 1;
 }
 
+/// hs.chooser:enableDefaultForQuery([]) -> hs.chooser object or boolean
+/// Method
+/// Gets/Sets whether the chooser should run the callback on a query when it does not match any on the list
+///
+/// Parameters:
+///  * enableDefaultForQuery - An optional boolean, true to return query string, false to not. If this parametr is omitted, the current configuration value will be returned
+///
+/// Returns:
+///  * the `hs.chooser` object if a value was set, or a boolean if no parameter was passed
+///
+/// Notes:
+///  * This should be used before a chooser has been displayed
+static int chooserSetEnableDefaultForQuery(lua_State *L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TBOOLEAN | LS_TOPTIONAL, LS_TBREAK];
+
+    HSChooser *chooser = [skin toNSObjectAtIndex:1];
+
+    switch (lua_type(L, 2)) {
+        case LUA_TBOOLEAN:
+            chooser.enableDefaultForQuery = lua_toboolean(L, 2);
+            lua_pushvalue(L, 1);
+            break;
+
+        case LUA_TNONE:
+            lua_pushboolean(L, chooser.enableDefaultForQuery);
+            return 1;
+
+        default:
+            NSLog(@"ERROR: Unknown type passed to hs.chooser:enableDefaultForQuery(). This should not be possible");
+            lua_pushnil(L);
+            break;
+    }
+
+    return 1;
+}
+
 /// hs.chooser:searchSubText([searchSubText]) -> hs.chooser object or boolean
 /// Method
 /// Gets/Sets whether the chooser should search in the sub-text of each item
@@ -894,6 +931,7 @@ static const luaL_Reg userdataLib[] = {
     {"bgDark", chooserSetBgDark},
     {"placeholderText", chooserPlaceholder},
     {"searchSubText", chooserSetSearchSubText},
+    {"enableDefaultForQuery", chooserSetEnableDefaultForQuery},
     {"width", chooserSetWidth},
     {"rows", chooserSetNumRows},
 


### PR DESCRIPTION
This is an example of how to implement this, it works in my local testing.
It adds a method, enableDefaultForQuery which can be passed a bool to allow the query to be returned to the final handler, even when it doesn't match an item on the choices list.