### PR TITLE
Fix lua-objc mapping to handle high/low surrogate pairs in hs.styledtext

### DIFF
--- a/extensions/styledtext/styledtext.lua
+++ b/extensions/styledtext/styledtext.lua
@@ -508,6 +508,9 @@ module = setmetatable(module, {
         else
             return rawget(self, _)
         end
+    end,
+    __call = function(self, ...)
+        return module.new(...)
     end
 })
 

--- a/extensions/styledtext/styledtext.lua
+++ b/extensions/styledtext/styledtext.lua
@@ -509,7 +509,7 @@ module = setmetatable(module, {
             return rawget(self, _)
         end
     end,
-    __call = function(self, ...)
+    __call = function(self, ...) -- luacheck: ignore
         return module.new(...)
     end
 })


### PR DESCRIPTION
Addresses issues in #3219 

Completely rewrites lua-objc index mapping to properly handle UTF16 High/Low surrogate pairs

UTF8 (which Lua uses) can have Unicode characters of 1-4 bytes
UTF16 (which Objective-C/Swift use) are always 2 bytes, but for Unicode characters above U+10000 inclusive, 2 UTF16 characters (i.e. 4 bytes) are used.

This code assumes that no 1-byte UTF8 character can be a surrogate member... as far as I can tell this is a safe assumption, but I haven't found an explicit statement to that effect, so if anyone knows otherwise, please chime in.
