### PR TITLE
Added support for Stream Deck Plus

### DIFF
--- a/Hammerspoon.xcodeproj/project.pbxproj
+++ b/Hammerspoon.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		22C9154E27A1095200E650A2 /* librazer.dylib in Copy Extension Dylibs */ = {isa = PBXBuildFile; fileRef = 22C9154327A108F000E650A2 /* librazer.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		22C9154F27A1097A00E650A2 /* razer.lua in Resources */ = {isa = PBXBuildFile; fileRef = 2213842A27A105DD0085CA24 /* razer.lua */; };
 		22C9155027A1099700E650A2 /* razer.lua in Copy Extension Lua files */ = {isa = PBXBuildFile; fileRef = 2213842A27A105DD0085CA24 /* razer.lua */; };
+		22DC4FA8299E140100065BE1 /* HSStreamDeckDevicePlus.m in Sources */ = {isa = PBXBuildFile; fileRef = 22DC4FA6299E140100065BE1 /* HSStreamDeckDevicePlus.m */; };
+		22DC4FA9299E140100065BE1 /* HSStreamDeckDevicePlus.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DC4FA7299E140100065BE1 /* HSStreamDeckDevicePlus.h */; };
 		22DF5D2823B9A9EA00C41AE6 /* libpasteboard_watcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 22DF5D1A23B99C4D00C41AE6 /* libpasteboard_watcher.m */; };
 		22E4D8031FA748AC00C8CF5C /* libmidi.m in Sources */ = {isa = PBXBuildFile; fileRef = 22E4D7F71FA7485A00C8CF5C /* libmidi.m */; };
 		22EEC62424926E6E00BAE4DA /* libserial.m in Sources */ = {isa = PBXBuildFile; fileRef = 22EEC61724926E2100BAE4DA /* libserial.m */; };
@@ -1596,6 +1598,8 @@
 		22A6625F25FC07F700AA329E /* test_serial.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = test_serial.lua; path = extensions/serial/test_serial.lua; sourceTree = "<group>"; };
 		22A6626125FC087000AA329E /* HSserial.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HSserial.m; sourceTree = "<group>"; };
 		22C9154327A108F000E650A2 /* librazer.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = librazer.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		22DC4FA6299E140100065BE1 /* HSStreamDeckDevicePlus.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = HSStreamDeckDevicePlus.m; path = extensions/streamdeck/HSStreamDeckDevicePlus.m; sourceTree = "<group>"; };
+		22DC4FA7299E140100065BE1 /* HSStreamDeckDevicePlus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HSStreamDeckDevicePlus.h; path = extensions/streamdeck/HSStreamDeckDevicePlus.h; sourceTree = "<group>"; };
 		22DF5D1A23B99C4D00C41AE6 /* libpasteboard_watcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = libpasteboard_watcher.m; path = extensions/pasteboard/libpasteboard_watcher.m; sourceTree = "<group>"; };
 		22DF5D2723B9A9D300C41AE6 /* libpasteboardwatcher.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libpasteboardwatcher.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		22E4D7F71FA7485A00C8CF5C /* libmidi.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = libmidi.m; path = extensions/midi/libmidi.m; sourceTree = SOURCE_ROOT; };
@@ -3022,6 +3026,8 @@
 				4F2DF3DE1F6046AD00742D08 /* libstreamdeck.m */,
 				4F2DF3F21F605A9B00742D08 /* HSStreamDeckDevice.h */,
 				4F2DF3F31F605A9B00742D08 /* HSStreamDeckDevice.m */,
+				22DC4FA7299E140100065BE1 /* HSStreamDeckDevicePlus.h */,
+				22DC4FA6299E140100065BE1 /* HSStreamDeckDevicePlus.m */,
 				4F6653E8238C6B6600DEE120 /* HSStreamDeckDeviceMini.h */,
 				4F6653E9238C6B6600DEE120 /* HSStreamDeckDeviceMini.m */,
 				4F6653E4238C36F100DEE120 /* HSStreamDeckDeviceOriginal.h */,
@@ -4446,6 +4452,7 @@
 				4F6653F62390351100DEE120 /* NSImage+JPEG.h in Headers */,
 				4F6653E6238C36F100DEE120 /* HSStreamDeckDeviceOriginal.h in Headers */,
 				4F5560A1279F6A0300B91FD8 /* HSStreamDeckDeviceMk2.h in Headers */,
+				22DC4FA9299E140100065BE1 /* HSStreamDeckDevicePlus.h in Headers */,
 				4F2DF3F81F6170BE00742D08 /* NSImage+BMP.h in Headers */,
 				4F2DF3F01F605A4900742D08 /* HSStreamDeckManager.h in Headers */,
 				4FFB210023CD14A500811E77 /* HSStreamDeckDeviceOriginalV2.h in Headers */,
@@ -7225,6 +7232,7 @@
 				4F2DF3EB1F60471400742D08 /* libstreamdeck.m in Sources */,
 				4FFB210123CD14A500811E77 /* HSStreamDeckDeviceOriginalV2.m in Sources */,
 				4FFB20FD23C5E01300811E77 /* HSStreamDeckDeviceXL.m in Sources */,
+				22DC4FA8299E140100065BE1 /* HSStreamDeckDevicePlus.m in Sources */,
 				4F2DF3F51F605A9B00742D08 /* HSStreamDeckDevice.m in Sources */,
 				4F5560A2279F6A0300B91FD8 /* HSStreamDeckDeviceMk2.m in Sources */,
 				4F6653EB238C6B6600DEE120 /* HSStreamDeckDeviceMini.m in Sources */,

--- a/extensions/streamdeck/HSStreamDeckDevice.h
+++ b/extensions/streamdeck/HSStreamDeckDevice.h
@@ -33,6 +33,7 @@ typedef enum : NSUInteger {
 @property (nonatomic) id manager;
 @property (nonatomic) int selfRefCount;
 @property (nonatomic) int buttonCallbackRef;
+@property (nonatomic) int encoderCallbackRef;
 @property (nonatomic) BOOL isValid;
 @property (nonatomic) LSGCCanary lsCanary;
 
@@ -42,6 +43,14 @@ typedef enum : NSUInteger {
 @property (nonatomic) int keyRows;
 @property (nonatomic) int imageWidth;
 @property (nonatomic) int imageHeight;
+
+@property (nonatomic, readonly, getter=getEncoderCount) int encoderCount;
+@property (nonatomic) int encoderColumns;
+@property (nonatomic) int encoderRows;
+
+@property (nonatomic) int lcdStripWidth;
+@property (nonatomic) int lcdStripHeight;
+
 @property (nonatomic) HSStreamDeckImageCodec imageCodec;
 @property (nonatomic) BOOL imageFlipX;
 @property (nonatomic) BOOL imageFlipY;
@@ -50,6 +59,7 @@ typedef enum : NSUInteger {
 @property (nonatomic) int reportLength;
 @property (nonatomic) int reportHeaderLength;
 @property (nonatomic) int dataKeyOffset;
+@property (nonatomic) int dataEncoderOffset;
 @property (nonatomic) NSUInteger firmwareReadOffset;
 @property (nonatomic) NSUInteger serialNumberReadOffset;
 @property (nonatomic) NSData *resetCommand;
@@ -58,6 +68,8 @@ typedef enum : NSUInteger {
 @property (nonatomic) NSUInteger firmwareVersionCommand;
 
 @property (nonatomic) NSMutableArray *buttonStateCache;
+@property (nonatomic) NSMutableArray *encoderButtonStateCache;
+
 @property (nonatomic, readonly, getter=getSerialNumber) NSString *serialNumber;
 
 
@@ -72,7 +84,11 @@ typedef enum : NSUInteger {
 - (NSData *)deviceRead:(int)resultLength reportID:(CFIndex)reportID readOffset:(NSUInteger)readOffset;
 
 - (int)transformKeyIndex:(int)sourceKey;
+
 - (void)deviceDidSendInput:(NSArray*)newButtonStates;
+- (void)deviceDidSendEncoderInput:(NSArray*)newEncoderButtonStates;
+- (void)deviceDidSendEncoderTurnWithButton:(NSNumber*)button turningLeft:(BOOL)turningLeft;
+
 - (BOOL)setBrightness:(int)brightness;
 - (void)reset;
 

--- a/extensions/streamdeck/HSStreamDeckDevice.h
+++ b/extensions/streamdeck/HSStreamDeckDevice.h
@@ -107,7 +107,7 @@ typedef enum : NSUInteger {
 - (void)setColor:(NSColor*)color forButton:(int)button;
 - (void)setImage:(NSImage*)image forButton:(int)button;
 
-- (void)setLCDImage:(NSImage*)image forEncoder:(int)encoder;;
+- (void)setLCDImage:(NSImage*)image forEncoder:(int)encoder;
 
 - (void)deviceDidSendScreenTouch:(NSString*)eventType startX:(int)startX startY:(int)startY endX:(int)endX endY:(int)endY;
 

--- a/extensions/streamdeck/HSStreamDeckDevice.h
+++ b/extensions/streamdeck/HSStreamDeckDevice.h
@@ -32,8 +32,11 @@ typedef enum : NSUInteger {
 @property (nonatomic) IOHIDDeviceRef device;
 @property (nonatomic) id manager;
 @property (nonatomic) int selfRefCount;
+
 @property (nonatomic) int buttonCallbackRef;
 @property (nonatomic) int encoderCallbackRef;
+@property (nonatomic) int screenCallbackRef;
+
 @property (nonatomic) BOOL isValid;
 @property (nonatomic) LSGCCanary lsCanary;
 
@@ -105,5 +108,7 @@ typedef enum : NSUInteger {
 - (void)setImage:(NSImage*)image forButton:(int)button;
 
 - (void)setLCDImage:(NSImage*)image forEncoder:(int)encoder;;
+
+- (void)deviceDidSendScreenTouch:(NSString*)eventType startX:(int)startX startY:(int)startY endX:(int)endX endY:(int)endY;
 
 @end

--- a/extensions/streamdeck/HSStreamDeckDevice.h
+++ b/extensions/streamdeck/HSStreamDeckDevice.h
@@ -58,6 +58,10 @@ typedef enum : NSUInteger {
 @property (nonatomic) int simpleReportLength;
 @property (nonatomic) int reportLength;
 @property (nonatomic) int reportHeaderLength;
+
+@property (nonatomic) int lcdReportLength;
+@property (nonatomic) int lcdReportHeaderLength;
+
 @property (nonatomic) int dataKeyOffset;
 @property (nonatomic) int dataEncoderOffset;
 @property (nonatomic) NSUInteger firmwareReadOffset;
@@ -99,5 +103,7 @@ typedef enum : NSUInteger {
 - (void)clearImage:(int)button;
 - (void)setColor:(NSColor*)color forButton:(int)button;
 - (void)setImage:(NSImage*)image forButton:(int)button;
+
+- (void)setLCDImage:(NSImage*)image forEncoder:(int)encoder;;
 
 @end

--- a/extensions/streamdeck/HSStreamDeckDevice.m
+++ b/extensions/streamdeck/HSStreamDeckDevice.m
@@ -501,8 +501,8 @@
 
     // Unconditionally resize the image
     NSImage *sourceImage = [image copy];
-    //NSSize newSize = NSMakeSize(self.lcdStripWidth, self.lcdStripHeight);
-    NSSize newSize = NSMakeSize(200, 100);
+    int encoderWidth = self.lcdStripWidth / self.encoderColumns;
+    NSSize newSize = NSMakeSize(encoderWidth, self.lcdStripHeight);
     renderImage = [[NSImage alloc] initWithSize: newSize];
     [renderImage lockFocus];
     [sourceImage setSize: newSize];

--- a/extensions/streamdeck/HSStreamDeckDevicePlus.h
+++ b/extensions/streamdeck/HSStreamDeckDevicePlus.h
@@ -1,0 +1,17 @@
+//
+//  HSStreamDeckDevicePlus.h
+//  streamdeck
+//
+//  Created by Chris Hocking on 16/02/2023.
+//  Copyright © 2023 Hammerspoon. All rights reserved.
+//
+
+#import "HSStreamDeckDevice.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HSStreamDeckDevicePlus : HSStreamDeckDevice
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/extensions/streamdeck/HSStreamDeckDevicePlus.m
+++ b/extensions/streamdeck/HSStreamDeckDevicePlus.m
@@ -1,0 +1,49 @@
+//
+//  HSStreamDeckDeviceMk2.m
+//  streamdeck
+//
+//  Created by Chris Hocking on 16/02/2023.
+//  Copyright © 2023 Hammerspoon. All rights reserved.
+//
+
+#import "HSStreamDeckDevicePlus.h"
+
+@implementation HSStreamDeckDevicePlus
+
+- (id)initWithDevice:(IOHIDDeviceRef)device manager:(id)manager {
+    self = [super initWithDevice:device manager:manager];
+    if (self) {
+        self.deckType = @"Elgato Stream Deck Plus";
+        self.keyRows = 2;
+        self.keyColumns = 4;
+        self.imageWidth = 120;
+        self.imageHeight = 120;
+        self.imageCodec = STREAMDECK_CODEC_JPEG;
+        self.imageFlipX = NO;
+        self.imageFlipY = NO;
+        self.imageAngle = 0;
+        self.simpleReportLength = 32;
+        self.reportLength = 1024;
+        self.reportHeaderLength = 8;
+        self.dataKeyOffset = 4;
+
+        uint8_t resetHeader[] = {0x03, 0x02};
+        self.resetCommand = [NSData dataWithBytes:resetHeader length:2];
+
+        uint8_t brightnessHeader[] = {0x03, 0x08, 0xFF};
+        self.setBrightnessCommand = [NSData dataWithBytes:brightnessHeader length:3];
+
+        self.serialNumberCommand = 0x06;
+        self.firmwareVersionCommand = 0x05;
+
+        self.serialNumberReadOffset = 2;
+        self.firmwareReadOffset = 6;
+    }
+    return self;
+}
+
+- (void)deviceWriteImage:(NSData *)data button:(int)button {
+    [self deviceV2WriteImage:data button:button];
+}
+
+@end

--- a/extensions/streamdeck/HSStreamDeckDevicePlus.m
+++ b/extensions/streamdeck/HSStreamDeckDevicePlus.m
@@ -34,6 +34,9 @@
         
         self.lcdStripWidth = 800;
         self.lcdStripHeight = 100;
+        
+        self.lcdReportLength = 1024;        
+        self.lcdReportHeaderLength = 16;
 
         uint8_t resetHeader[] = {0x03, 0x02};
         self.resetCommand = [NSData dataWithBytes:resetHeader length:2];

--- a/extensions/streamdeck/HSStreamDeckDevicePlus.m
+++ b/extensions/streamdeck/HSStreamDeckDevicePlus.m
@@ -25,7 +25,15 @@
         self.simpleReportLength = 32;
         self.reportLength = 1024;
         self.reportHeaderLength = 8;
+        
         self.dataKeyOffset = 4;
+        self.dataEncoderOffset = 5;
+        
+        self.encoderColumns = 4;
+        self.encoderRows = 1;
+        
+        self.lcdStripWidth = 800;
+        self.lcdStripHeight = 100;
 
         uint8_t resetHeader[] = {0x03, 0x02};
         self.resetCommand = [NSData dataWithBytes:resetHeader length:2];

--- a/extensions/streamdeck/HSStreamDeckDevicePlus.m
+++ b/extensions/streamdeck/HSStreamDeckDevicePlus.m
@@ -1,5 +1,5 @@
 //
-//  HSStreamDeckDeviceMk2.m
+//  HSStreamDeckDevicePlus.m
 //  streamdeck
 //
 //  Created by Chris Hocking on 16/02/2023.

--- a/extensions/streamdeck/HSStreamDeckManager.h
+++ b/extensions/streamdeck/HSStreamDeckManager.h
@@ -18,6 +18,7 @@
 #import "HSStreamDeckDeviceMini.h"
 #import "HSStreamDeckDeviceXL.h"
 #import "HSStreamDeckDeviceMk2.h"
+#import "HSStreamDeckDevicePlus.h"
 #import "streamdeck.h"
 
 @interface HSStreamDeckManager : NSObject

--- a/extensions/streamdeck/HSStreamDeckManager.m
+++ b/extensions/streamdeck/HSStreamDeckManager.m
@@ -73,12 +73,14 @@ static void HIDdisconnect(void *context, IOReturn result, void *sender, IOHIDDev
                                           productIDKey: @USB_PID_STREAMDECK_ORIGINAL_V2};
         NSDictionary *matchMini       = @{vendorIDKey:  @USB_VID_ELGATO,
                                           productIDKey: @USB_PID_STREAMDECK_MINI};
-        NSDictionary *matchMiniV2       = @{vendorIDKey:  @USB_VID_ELGATO,
+        NSDictionary *matchMiniV2     = @{vendorIDKey:  @USB_VID_ELGATO,
                                           productIDKey: @USB_PID_STREAMDECK_MINI_V2};
         NSDictionary *matchXL         = @{vendorIDKey:  @USB_VID_ELGATO,
                                           productIDKey: @USB_PID_STREAMDECK_XL};
         NSDictionary *matchMk2        = @{vendorIDKey:  @USB_VID_ELGATO,
                                           productIDKey: @USB_PID_STREAMDECK_MK2};
+        NSDictionary *matchPlus       = @{vendorIDKey:  @USB_VID_ELGATO,
+                                          productIDKey: @USB_PID_STREAMDECK_PLUS};
 
         IOHIDManagerSetDeviceMatchingMultiple((__bridge IOHIDManagerRef)self.ioHIDManager,
                                               (__bridge CFArrayRef)@[matchOriginal,
@@ -86,7 +88,8 @@ static void HIDdisconnect(void *context, IOReturn result, void *sender, IOHIDDev
                                                                      matchMini,
                                                                      matchMiniV2,
                                                                      matchXL,
-                                                                     matchMk2]);
+                                                                     matchMk2,
+                                                                     matchPlus]);
 
         // Add our callbacks for relevant events
         IOHIDManagerRegisterDeviceMatchingCallback((__bridge IOHIDManagerRef)self.ioHIDManager,
@@ -189,6 +192,10 @@ static void HIDdisconnect(void *context, IOReturn result, void *sender, IOHIDDev
             deck = [[HSStreamDeckDeviceMk2 alloc] initWithDevice:device manager:self];
             break;
 
+        case USB_PID_STREAMDECK_PLUS:
+            deck = [[HSStreamDeckDevicePlus alloc] initWithDevice:device manager:self];
+            break;
+            
         default:
             NSLog(@"deviceDidConnect from unknown device: %d", productID.intValue);
             break;

--- a/extensions/streamdeck/HSStreamDeckManager.m
+++ b/extensions/streamdeck/HSStreamDeckManager.m
@@ -40,23 +40,37 @@ static void HIDReport(void* deviceRef, IOReturn result, void* sender, IOHIDRepor
         // ----------
         // LCD EVENT:
         // ----------
-        NSLog(@"[HSStreamDeckManager] It's a LCD Event!");
+        NSString *eventTypeString = @"Unknown";
+        uint16_t startX = ((uint16_t)report[6]) | (((uint16_t)report[7]) << 8);
+        uint16_t startY = ((uint16_t)report[8]) | (((uint16_t)report[9]) << 8);
+        uint16_t endX = 0;
+        uint16_t endY = 0;
         
         uint8_t eventType = report[4];
         if (eventType == 0x01) {
-            NSLog(@"[HSStreamDeckManager] LCD Short Press");
+            // ------------
+            // SHORT PRESS:
+            // ------------
+            eventTypeString = @"shortPress";
         } else if (eventType == 0x02) {
-            NSLog(@"[HSStreamDeckManager] LCD Long Press");
+            // -----------
+            // LONG PRESS:
+            // -----------
+            eventTypeString = @"longPress";
         } else if (eventType == 0x03) {
-            NSLog(@"[HSStreamDeckManager] LCD Swipe");
+            // ------
+            // SWIPE:
+            // ------
+            eventTypeString = @"swipe";
+            endX = ((uint16_t)report[10]) | (((uint16_t)report[11]) << 8);
+            endY = ((uint16_t)report[12]) | (((uint16_t)report[13]) << 8);
         }
         
+        [device deviceDidSendScreenTouch:eventTypeString startX:startX startY:startY endX:endX endY:endY];
     } else if (inputType == 0x03) {
         // --------------
         // ENCODER EVENT:
         // --------------
-        //NSLog(@"[HSStreamDeckManager] It's an Encoder Event!");
-        
         uint8_t eventType = report[4];
         if (eventType == 0x00) {
             // ----------------------

--- a/extensions/streamdeck/libstreamdeck.m
+++ b/extensions/streamdeck/libstreamdeck.m
@@ -284,6 +284,28 @@ static int streamdeck_setButtonImage(lua_State *L) {
     return 1;
 }
 
+/// hs.streamdeck:setLCDImage(encoder, image)
+/// Method
+/// Sets the image of the LCD on the deck
+///
+/// Parameters:
+///  * encoder - A number (from 1 to 4) describing which encoder to set the image for
+///  * image - An hs.image object
+///
+/// Returns:
+///  * The hs.streamdeck object
+static int streamdeck_setLCDImage(lua_State *L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TNUMBER, LS_TUSERDATA, "hs.image", LS_TBREAK];
+
+    HSStreamDeckDevice *device = [skin luaObjectAtIndex:1 toClass:"HSStreamDeckDevice"];
+    
+    [device setLCDImage:[skin luaObjectAtIndex:3 toClass:"NSImage"] forEncoder:(int)lua_tointeger(skin.L, 2)];
+    
+    lua_pushvalue(skin.L, 1);
+    return 1;
+}
+
 /// hs.streamdeck:setButtonColor(button, color)
 /// Method
 /// Sets a button on the deck to the specified color
@@ -382,6 +404,7 @@ static const luaL_Reg userdata_metaLib[] = {
     {"buttonCallback", streamdeck_buttonCallback},
     {"encoderCallback", streamdeck_encoderCallback},
     {"setButtonImage", streamdeck_setButtonImage},
+    {"setLCDImage", streamdeck_setLCDImage},
     {"setButtonColor", streamdeck_setButtonColor},
     {"setBrightness", streamdeck_setBrightness},
     {"reset", streamdeck_reset},

--- a/extensions/streamdeck/libstreamdeck.m
+++ b/extensions/streamdeck/libstreamdeck.m
@@ -27,7 +27,7 @@ static int streamdeck_gc(lua_State *L) {
 /// Initialises the Stream Deck driver and sets a discovery callback
 ///
 /// Parameters:
-///  * fn - A function that will be called when a Streaming Deck is connected or disconnected. It should take the following arguments:
+///  * fn - A function that will be called when a Stream Deck is connected or disconnected. It should take the following arguments:
 ///   * A boolean, true if a device was connected, false if a device was disconnected
 ///   * An hs.streamdeck object, being the device that was connected/disconnected
 ///
@@ -53,7 +53,7 @@ static int streamdeck_init(lua_State *L) {
 /// Sets/clears a callback for reacting to device discovery events
 ///
 /// Parameters:
-///  * fn - A function that will be called when a Streaming Deck is connected or disconnected. It should take the following arguments:
+///  * fn - A function that will be called when a Stream Deck is connected or disconnected. It should take the following arguments:
 ///   * A boolean, true if a device was connected, false if a device was disconnected
 ///   * An hs.streamdeck object, being the device that was connected/disconnected
 ///
@@ -135,10 +135,10 @@ static int streamdeck_buttonCallback(lua_State *L) {
 
 /// hs.streamdeck:encoderCallback(fn)
 /// Method
-/// Sets/clears the encoder button callback function for a Stream Deck device
+/// Sets/clears the knob/encoder callback function for a Stream Deck Plus.
 ///
 /// Parameters:
-///  * fn - A function to be called when an encoder button is pressed/released on the Stream Deck. It should receive five arguments:
+///  * fn - A function to be called when an encoder button is pressed/released/rotated on a Stream Deck Plus. It should receive five arguments:
 ///   * The hs.streamdeck userdata object
 ///   * A number containing the button that was pressed/released/rotated
 ///   * A boolean indicating whether the button was pressed (true) or released (false)
@@ -164,10 +164,10 @@ static int streamdeck_encoderCallback(lua_State *L) {
 
 /// hs.streamdeck:screenCallback(fn)
 /// Method
-/// Sets/clears the screen callback function for a Stream Deck device
+/// Sets/clears the screen callback function for a Stream Deck Plus's touch screen (above the encoder knobs).
 ///
 /// Parameters:
-///  * fn - A function to be called when an screen is pressed/released/swiped on the Stream Deck. It should receive six arguments:
+///  * fn - A function to be called when a screen is pressed/released/swiped on a Stream Deck Plus. It should receive six arguments:
 ///   * The hs.streamdeck userdata object
 ///   * A string either containing "shortPress", "longPress" or "swipe"
 ///   * The X position of where the screen was first touched
@@ -194,7 +194,7 @@ static int streamdeck_screenCallback(lua_State *L) {
 
 /// hs.streamdeck:setBrightness(brightness)
 /// Method
-/// Sets the brightness of a deck
+/// Sets the brightness of a Stream Deck device
 ///
 /// Parameters:
 ///  * brightness - A whole number between 0 and 100 indicating the percentage brightness level to set
@@ -215,7 +215,7 @@ static int streamdeck_setBrightness(lua_State *L) {
 
 /// hs.streamdeck:reset()
 /// Method
-/// Resets a deck
+/// Resets a Stream Deck device
 ///
 /// Parameters:
 ///  * None
@@ -235,7 +235,7 @@ static int streamdeck_reset(lua_State *L) {
 
 /// hs.streamdeck:serialNumber()
 /// Method
-/// Gets the serial number of a deck
+/// Gets the serial number of a Stream Deck device
 ///
 /// Parameters:
 ///  * None
@@ -254,7 +254,7 @@ static int streamdeck_serialNumber(lua_State *L) {
 
 /// hs.streamdeck:firmwareVersion()
 /// Method
-/// Gets the firmware version of a deck
+/// Gets the firmware version of a Stream Deck device
 ///
 /// Parameters:
 ///  * None
@@ -273,7 +273,7 @@ static int streamdeck_firmwareVersion(lua_State *L) {
 
 /// hs.streamdeck:buttonLayout()
 /// Method
-/// Gets the layout of buttons the device has
+/// Gets the layout of buttons a Stream Deck device has
 ///
 /// Parameters:
 ///  * None
@@ -294,7 +294,7 @@ static int streamdeck_buttonLayout(lua_State *L) {
 
 /// hs.streamdeck:setButtonImage(button, image)
 /// Method
-/// Sets the image of a button on the deck
+/// Sets the image of a button on the Stream Deck device
 ///
 /// Parameters:
 ///  * button - A number (from 1 to 15) describing which button to set the image for
@@ -316,7 +316,7 @@ static int streamdeck_setButtonImage(lua_State *L) {
 
 /// hs.streamdeck:setScreenImage(encoder, image)
 /// Method
-/// Sets the image of the screen on the Stream Deck
+/// Sets the image of the screen on the Stream Deck device
 ///
 /// Parameters:
 ///  * encoder - A number (from 1 to 4) describing which encoder to set the image for
@@ -338,7 +338,7 @@ static int streamdeck_setScreenImage(lua_State *L) {
 
 /// hs.streamdeck:setButtonColor(button, color)
 /// Method
-/// Sets a button on the deck to the specified color
+/// Sets a button on the Stream Deck device to the specified color
 ///
 /// Parameters:
 ///  * button - A number (from 1 to 15) describing which button to set the color on

--- a/extensions/streamdeck/libstreamdeck.m
+++ b/extensions/streamdeck/libstreamdeck.m
@@ -133,6 +133,35 @@ static int streamdeck_buttonCallback(lua_State *L) {
     return 1;
 }
 
+/// hs.streamdeck:encoderCallback(fn)
+/// Method
+/// Sets/clears the encoder button callback function for a deck
+///
+/// Parameters:
+///  * fn - A function to be called when an encoder button is pressed/released on the stream deck. It should receive three arguments:
+///   * The hs.streamdeck userdata object
+///   * A number containing the button that was pressed/released/rotated
+///   * A boolean indicating whether the button was pressed (true) or released (false)
+///   * A boolean indicating that the button was turned left
+///   * A boolean indicating that the button was turned right
+///
+/// Returns:
+///  * The hs.streamdeck device
+static int streamdeck_encoderCallback(lua_State *L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TUSERDATA, USERDATA_TAG, LS_TFUNCTION | LS_TNIL, LS_TBREAK];
+
+    HSStreamDeckDevice *device = [skin luaObjectAtIndex:1 toClass:"HSStreamDeckDevice"];
+    device.encoderCallbackRef = [skin luaUnref:streamDeckRefTable ref:device.encoderCallbackRef];
+
+    if (lua_type(skin.L, 2) == LUA_TFUNCTION) {
+        device.encoderCallbackRef = [skin luaRef:streamDeckRefTable atIndex:2];
+    }
+
+    lua_pushvalue(skin.L, 1);
+    return 1;
+}
+
 /// hs.streamdeck:setBrightness(brightness)
 /// Method
 /// Sets the brightness of a deck
@@ -334,6 +363,7 @@ static int streamdeck_object_gc(lua_State* L) {
         theDevice.selfRefCount-- ;
         if (theDevice.selfRefCount == 0) {
             theDevice.buttonCallbackRef = [skin luaUnref:streamDeckRefTable ref:theDevice.buttonCallbackRef] ;
+            theDevice.encoderCallbackRef = [skin luaUnref:streamDeckRefTable ref:theDevice.encoderCallbackRef] ;
             theDevice = nil ;
         }
     }
@@ -350,6 +380,7 @@ static const luaL_Reg userdata_metaLib[] = {
     {"firmwareVersion", streamdeck_firmwareVersion},
     {"buttonLayout", streamdeck_buttonLayout},
     {"buttonCallback", streamdeck_buttonCallback},
+    {"encoderCallback", streamdeck_encoderCallback},
     {"setButtonImage", streamdeck_setButtonImage},
     {"setButtonColor", streamdeck_setButtonColor},
     {"setBrightness", streamdeck_setBrightness},

--- a/extensions/streamdeck/streamdeck.h
+++ b/extensions/streamdeck/streamdeck.h
@@ -21,5 +21,6 @@ static const char *USERDATA_TAG = "hs.streamdeck";
 #define USB_PID_STREAMDECK_MINI_V2     0x0090
 #define USB_PID_STREAMDECK_XL          0x006c
 #define USB_PID_STREAMDECK_MK2         0x0080
+#define USB_PID_STREAMDECK_PLUS        0x0084
 
 #endif /* streamdeck_h */

--- a/extensions/streamdeck/streamdeck.lua
+++ b/extensions/streamdeck/streamdeck.lua
@@ -1,8 +1,17 @@
 --- === hs.streamdeck ===
 ---
---- Configure/control an Elgato Stream Deck
+--- Configure/control an Elgato Stream Deck.
 ---
---- Please note that in order for this module to work, the official Elgato Stream Deck app should not be running
+--- Please note that in order for this module to work, the official Elgato Stream Deck app should not be running.
+---
+--- This extension supports the following devices:
+---  * Stream Deck (Original)
+---  * Stream Deck (Original V2)
+---  * Stream Deck Plus
+---  * Stream Deck Mini
+---  * Stream Deck Mini (V2)
+---  * Stream Deck XL
+---  * Stream Deck XL (Mk2)
 ---
 --- This module would not have been possible without standing on the shoulders of others:
 ---  * https://github.com/OpenStreamDeck/StreamDeckSharp


### PR DESCRIPTION
- Added `hs.streamdeck:screenCallback(fn)` 
- Added `hs.streamdeck:encoderCallback(fn)`
- Added `hs.streamdeck:setScreenImage(encoder, image)`
- Closes #3342

**TEST CODE:**
```lua
local logger = require("hs.logger")
logger.defaultLogLevel = 'debug'
local log = logger.new("streamDeck")
local streamdeck = require("hs.streamdeck")

obj = nil

local function discoveryCallback(connected, object)
    log.df("Stream Deck Callback. Connected: %s, Object: %s", connected, object)

    if connected and object then    
        --------------------------------------------------------------------------------
        -- Button Callback:
        --------------------------------------------------------------------------------
        object:buttonCallback(function(object, buttonID, pressed)
            log.df("[BUTTON] object: %s, buttonID: %s, pressed: %s", object, buttonID, pressed)
        end)
        
        --------------------------------------------------------------------------------
        -- Encoder Callback:
        --------------------------------------------------------------------------------
        object:encoderCallback(function(object, buttonID, pressed, turningLeft, turningRight)
            if turningLeft then
                log.df("[ENCODER] object: %s, buttonID: %s, turned: LEFT", object, buttonID)
            elseif turningRight then
                log.df("[ENCODER] object: %s, buttonID: %s, turned: RIGHT", object, buttonID)
            else
                log.df("[ENCODER] object: %s, buttonID: %s, pressed: %s", object, buttonID, pressed)
            end
        end)
        
        --------------------------------------------------------------------------------
        -- Screen Callback:
        --------------------------------------------------------------------------------
        object:screenCallback(function(object, eventType, startX, startY, endX, endY)        
            log.df("[SCREEN] object: %s, eventType: %s, startX: %s, startY: %s, endX: %s, endY: %s", object, eventType, startX, startY, endX, endY)        
        end)
        
        --------------------------------------------------------------------------------
        -- Set Image Buttons:
        --------------------------------------------------------------------------------
        for i=1, 8 do
            object:setButtonImage(i, hs.image.imageFromAppBundle("com.apple.finder"))
        end
    
        --------------------------------------------------------------------------------
        -- Set LCD Images:
        --------------------------------------------------------------------------------
        for i=1, 4 do
            object:setScreenImage(i, hs.image.imageFromAppBundle("com.apple.finder"))
        end
    
        --------------------------------------------------------------------------------
        -- Save to global `obj` object for testing:
        --------------------------------------------------------------------------------
        obj = object
    end    

end

streamdeck.init(discoveryCallback)
```