### PR TITLE
[Ready] hs.watchable -- added alwaysNotify to watcher

### DIFF
--- a/extensions/watchable/watchable.lua
+++ b/extensions/watchable/watchable.lua
@@ -159,7 +159,7 @@ mt_watcher = {
 --- Method
 --- Get or set whether this watcher should be notified even when the new value is identical to the current value
 ---
---- Paramters:
+--- Parameters:
 ---  * `notify` - an optional boolean specifying whether or not the watchableObject should trigger a callback when the value of the watched path is set to its current value (i.e. it is set, but doesn't actually change value)
 ---
 --- Returns:


### PR DESCRIPTION
Should address #3437 

Also: callbacks can now be objects with __call metamethod
clarified some documentation
fixed useless debug metamethod on module

There were some changes to the watch constructor and callback method, so should be tested a bit more before merging, but initial tests look good and hasn't broken anything of mine yet...