### PR TITLE
[READY] hs.battery -- Fix for systems that report an empty array for powerSources

### DIFF
--- a/extensions/battery/battery.lua
+++ b/extensions/battery/battery.lua
@@ -9,6 +9,15 @@
 local module = require("hs.libbattery")
 local fnutils = require("hs.fnutils")
 
+local original_powerSources = module._powerSources
+module._powerSources = function(...)
+    local temp = original_powerSources(...)
+    if type(temp) == "table" and #temp == 0 then
+        temp = { {} }
+    end
+    return temp
+end
+
 -- private variables and methods -----------------------------------------
 
 local check_list = {


### PR DESCRIPTION
Wraps _powerSources internal function so that rather than return an empty array on non laptops without a UPS, it returns an array with an empty item (which the module functions expect)

Initial testing against a non-laptop was on an iMac that has a UPS attached -- I honestly don't recall if I ever tested it against the system without the UPS USB port cable attached, so this issue may have just been hidden for a while or may be a change in the way the OS returns empty results (the existing code would have caught a `nil`, but not the empty table as reported in #3448)
