### PR TITLE
Remove warnings from canvas and toolbar

### DIFF
--- a/extensions/canvas/libcanvas.m
+++ b/extensions/canvas/libcanvas.m
@@ -6,7 +6,7 @@ static const char *USERDATA_TAG = "hs.canvas" ;
 static LSRefTable refTable = LUA_NOREF;
 static BOOL defaultCustomSubRole = YES ;
 
-static int warnedAboutDelete = 0 ;
+// static int warnedAboutDelete = 0 ;
 
 // Can't have "static" or "constant" dynamic NSObjects like NSArray, so define in lua_open
 static NSDictionary *languageDictionary ;
@@ -3187,10 +3187,10 @@ static int canvas_delete(lua_State *L) {
 
  //   HSCanvasView   *canvasView   = [skin luaObjectAtIndex:1 toClass:"HSCanvasView"] ;
 //     HSCanvasWindow *canvasWindow = canvasView.wrapperWindow ;
-    if (warnedAboutDelete < 10) {
-        warnedAboutDelete++ ;
-        [skin logWarn:[NSString stringWithFormat:@"%s:delete - explicit delete is no longer required for canvas objects; garbage collection occurs automatically", USERDATA_TAG]] ;
-    }
+//     if (warnedAboutDelete < 10) {
+//         warnedAboutDelete++ ;
+//         [skin logWarn:[NSString stringWithFormat:@"%s:delete - explicit delete is no longer required for canvas objects; garbage collection occurs automatically", USERDATA_TAG]] ;
+//     }
     canvas_hide(L) ;
     lua_pop(L, 1) ; // remove userdata pushed by hide
 

--- a/extensions/webview/libwebview_toolbar.m
+++ b/extensions/webview/libwebview_toolbar.m
@@ -82,7 +82,7 @@ static NSMenu *createCoreSearchFieldMenu() {
         _itemDefDictionary     = [[NSMutableDictionary alloc] init] ;
         _fnRefDictionary       = [[NSMutableDictionary alloc] init] ;
         _enabledDictionary     = [[NSMutableDictionary alloc] init] ;
-        
+
         if (@available(macOS 11.0, *)) {
             _toolbarStyle      = NSWindowToolbarStyleAutomatic ;
         }
@@ -148,7 +148,7 @@ static NSMenu *createCoreSearchFieldMenu() {
         if (@available(macOS 11.0, *)) {
             _toolbarStyle      = original.toolbarStyle ;
         }
-        
+
         self.allowsUserCustomization = original.allowsUserCustomization ;
         self.allowsExtensionItems    = original.allowsExtensionItems ;
         self.autosavesConfiguration  = original.autosavesConfiguration ;
@@ -695,9 +695,9 @@ static NSMenu *createCoreSearchFieldMenu() {
         }
         toolbarItem.enabled = flag ? [self validateToolbarItem:toolbarItem] : YES ;
         [self fillinNewToolbarItem:toolbarItem] ;
-    } else {
-        // may happen on a reload if toolbar autosave contains id's that were added after the toolbar was created but haven't been created yet since the reload
-        [LuaSkin logInfo:[NSString stringWithFormat:@"%s:toolbar:itemForItemIdentifier:willBeInsertedIntoToolbar: invoked with nonexistent identifier:%@", USERDATA_TB_TAG, identifier]] ;
+//     } else {
+//         // may happen on a reload if toolbar autosave contains id's that were added after the toolbar was created but haven't been created yet since the reload
+//         [LuaSkin logInfo:[NSString stringWithFormat:@"%s:toolbar:itemForItemIdentifier:willBeInsertedIntoToolbar: invoked with nonexistent identifier:%@", USERDATA_TB_TAG, identifier]] ;
     }
     return toolbarItem ;
 }
@@ -962,12 +962,12 @@ static int attachToolbar(lua_State *L) {
             theWindow.toolbar             = newToolbar ;
             newToolbar.windowUsingToolbar = theWindow ;
             newToolbar.visible            = YES ;
-            
+
             // Update the toolbar style if available:
             if (@available(macOS 11.0, *)) {
                 theWindow.toolbarStyle = newToolbar.toolbarStyle;
             }
-            
+
         }
         lua_pushvalue(L, 1) ;
     } else {
@@ -1351,7 +1351,7 @@ static int toolbarStyle(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L] ;
     [skin checkArgs:LS_TUSERDATA, USERDATA_TB_TAG, LS_TSTRING | LS_TOPTIONAL, LS_TBREAK] ;
     HSToolbar *toolbar = [skin toNSObjectAtIndex:1] ;
-        
+
     if (lua_gettop(L) == 2) {
         if (@available(macOS 11.0, *))
         {


### PR DESCRIPTION
This removes the canvas warning about delete (I think most of the remaining concerns are in Spoons that are no longer being actively updated, though they work fine otherwise, so it's not a big problem, just an annoying message)

This also removes the warning when a toolbar references an item id that doesn't exist yet -- in my case this occurs because I make additions to the console toolbar (accessible via `hs.console.toolbar()`) but the new items don't exist until after `init.lua` completes, so I was always getting these messages.