### PR TITLE
Fix blockAlert documentation

### DIFF
--- a/extensions/dialog/libdialog.m
+++ b/extensions/dialog/libdialog.m
@@ -577,9 +577,9 @@ static int webviewAlert(lua_State *L) {
 ///
 /// Notes:
 ///  * The optional values must be entered in order (i.e. you can't supply `style` without also supplying `buttonOne` and `buttonTwo`).
-///  * [style] can be "warning", "informational" or "critical". If something other than these string values is given, it will use "informational".
+///  * [style] can be "warning", "informational" or "critical". If something other than these string values is given, it will use "warning".
 ///  * Example:
-///      `hs.dialog.blockAlert("Message", "Informative Text", "Button One", "Button Two", "NSCriticalAlertStyle")`
+///      `hs.dialog.blockAlert("Message", "Informative Text", "Button One", "Button Two", "critical")`
 static int blockAlert(lua_State *L) {
 
 	NSString* defaultButton = @"OK";


### PR DESCRIPTION
Change the style parameter in the example from "NSCriticalAlertStyle" to "critical". Also, according to the implementation (line 636), the default style will be "warning", not "informational".