### PR TITLE
Add getCurrentTrackArtworkURL() to spotify extension

### DIFF
--- a/extensions/spotify/spotify.lua
+++ b/extensions/spotify/spotify.lua
@@ -166,6 +166,20 @@ end
 function spotify.getCurrentTrack()
   return tell('name of the current track')
 end
+
+--- hs.spotify.getCurrentTrackArtworkURL()
+--- Function
+--- Gets the artwork URL of the current track
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * A string containing the URL of the artwork for the current track, or nil if an error occurred
+function spotify.getCurrentTrackArtworkURL()
+  return tell('artwork url of current track')
+end
+
 --- hs.spotify.getCurrentTrackId()
 --- Function
 --- Gets the id of the current track


### PR DESCRIPTION
### Problem

I would love to be able to use track artwork in notification.

Here is a usage example:
```lua
  local track = hs.spotify.getCurrentTrack()
  local artist = hs.spotify.getCurrentArtist()
  local url = hs.spotify.getCurrentTrackArtworkURL()
  local image = hs.image.imageFromURL(url)
  hs.notify.new({title=track, subTitle=artist, contentImage=image }):send()
```

### Solution

Introduce `getCurrentTrackArtworkURL()` function to spotify extension returning the URL of the artwork for the current track.