### PR TITLE
fix incorrect link address

### DIFF
--- a/extensions/canvas/canvas.lua
+++ b/extensions/canvas/canvas.lua
@@ -402,7 +402,7 @@ end
 ---  * The center of the object is determined by getting the element's bounds with [hs.canvas:elementBounds](#elementBounds).
 ---  * If the third argument is a boolean value, the `point` argument is assumed to be the element's center and the boolean value is used as the `append` argument.
 ---
----  * This method uses [hs.canvas.matrix](MATRIX.md) to generate the rotation transformation and provides a wrapper for `hs.canvas.matrix.translate(x, y):rotate(angle):translate(-x, -y)` which is then assigned or appended to the element's existing `transformation` attribute.
+---  * This method uses [hs.canvas.matrix](./hs.canvas.matrix.html) to generate the rotation transformation and provides a wrapper for `hs.canvas.matrix.translate(x, y):rotate(angle):translate(-x, -y)` which is then assigned or appended to the element's existing `transformation` attribute.
 canvasMT.rotateElement = function(obj, index, angle, point, append)
     if type(point) == "boolean" then
         append, point = point, nil

--- a/extensions/canvas/libcanvas.m
+++ b/extensions/canvas/libcanvas.m
@@ -2590,7 +2590,7 @@ static int canvas_getTextElementSize(lua_State *L) {
 /// Get or set the matrix transformation which is applied to every element in the canvas before being individually processed and added to the canvas.
 ///
 /// Parameters:
-///  * `matrix` - an optional table specifying the matrix table, as defined by the [hs.canvas.matrix](MATRIX.md) module, to be applied to every element of the canvas, or an explicit `nil` to reset the transformation to the identity matrix.
+///  * `matrix` - an optional table specifying the matrix table, as defined by the [hs.canvas.matrix](./hs.canvas.matrix.html) module, to be applied to every element of the canvas, or an explicit `nil` to reset the transformation to the identity matrix.
 ///
 /// Returns:
 ///  * if an argument is provided, returns the canvasObject, otherwise returns the current value


### PR DESCRIPTION
The links to `MATRIX.md` don't lead anywhere. Noticed this when feeding the docs to https://devdocs.io/ which created some empty pages for the `MATRIX.md` file.

Could also remove the .html from the link and would still work, I copied the style from https://github.com/Hammerspoon/hammerspoon/blob/56b5835dc1bf7bb430dfea3f1662379cccec0c82/extensions/applescript/applescript.lua#L5