### PR TITLE
Allow passing nil as name to hs.pasteboard.callbackWhenChanged

### DIFF
--- a/extensions/pasteboard/pasteboard.lua
+++ b/extensions/pasteboard/pasteboard.lua
@@ -88,7 +88,9 @@ end
 ---  ~~~
 module.callbackWhenChanged = function(...)
     local name, timeout, callback = nil, 2.0, nil
-    for _, v in ipairs({...}) do
+    local args = {...}
+    for i = 1, #args do
+        local v = args[i]
         if type(v) == "number" then
             timeout = v
         elseif type(v) == "nil" or type(v) == "string" then


### PR DESCRIPTION

The issue was that calling `hs.pasteboard.callbackWhenChanged(nil, 1, function() end)` raised "callback must be a function". This is because ipairs stops iterating the varargs table on the first nil element, so the for-loop body is not executed.