### PR TITLE
Add NSUserActivityTypeBrowsingWeb handling

### DIFF
--- a/Hammerspoon/Hammerspoon-Info.plist
+++ b/Hammerspoon/Hammerspoon-Info.plist
@@ -262,6 +262,7 @@
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>HSExecuteLuaIntent</string>
+		<string>NSUserActivityTypeBrowsingWeb</string>
 	</array>
 	<key>NSUserNotificationAlertStyle</key>
 	<string>alert</string>

--- a/Hammerspoon/MJAppDelegate.m
+++ b/Hammerspoon/MJAppDelegate.m
@@ -88,6 +88,7 @@
             }
         }
 
+
         success = [[NSFileManager defaultManager] moveItemAtPath:fileAndPath toPath:dstSpoonFullPath error:&fileError];
         if (!success) {
             NSLog(@"Unable to move %@ to %@: %@", fileAndPath, spoonPath, fileError);
@@ -127,6 +128,17 @@
     }
 
     return YES;
+}
+
+- (BOOL)application:(NSApplication *)application
+    continueUserActivity:(NSUserActivity *)userActivity
+      restorationHandler:(nonnull void (^)(NSArray<id<NSUserActivityRestoring>> *_Nullable))restorationHandler
+{
+  //NSLog(@"Open URL in NSUserActivityTypeBrowsingWeb");
+  if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
+    [[NSWorkspace sharedWorkspace] openURL:userActivity.webpageURL];
+  }
+  return YES;
 }
 
 

--- a/Hammerspoon/MJAppDelegate.m
+++ b/Hammerspoon/MJAppDelegate.m
@@ -137,8 +137,9 @@
   //NSLog(@"Open URL in NSUserActivityTypeBrowsingWeb");
   if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
     [[NSWorkspace sharedWorkspace] openURL:userActivity.webpageURL];
+    return YES;
   }
-  return YES;
+  return NO;
 }
 
 


### PR DESCRIPTION
To handle Handoff from a native app to a (default) browser `NSUserActivityTypeBrowsingWeb` needs to be handled. If a default browser supports this, Handoff links that have a `webpageUrl` can be opened by the default browser.

More info: https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/Handoff/AdoptingHandoff/AdoptingHandoff.html