### PR TITLE
Fix `package.path`s under `userruntime` w/ unexpanded tilde

### DIFF
--- a/Hammerspoon/setup.lua
+++ b/Hammerspoon/setup.lua
@@ -1,6 +1,6 @@
 local modpath, frameworkspath, prettypath, fullpath, configdir, docstringspath, hasinitfile, autoload_extensions = ...
 
-local userruntime = "~/.local/share/hammerspoon/site"
+local userruntime = os.getenv("HOME") .. "/.local/share/hammerspoon/site"
 
 local paths = {
   configdir .. "/?.lua",


### PR DESCRIPTION
Lua doesn't automatically expand tildes to `$HOME`, as this code seems to assume.

Fix #3518

I didn't mean to close #3702.