### PR TITLE
Add hs.audiodevice:thru() and hs.audiodevice:setThru(thru)

### DIFF
--- a/Hammerspoon Tests/HSaudiodevice.m
+++ b/Hammerspoon Tests/HSaudiodevice.m
@@ -144,6 +144,10 @@
     RUN_LUA_TEST()
 }
 
+- (void)testThru {
+    RUN_LUA_TEST()
+}
+
 - (void)testVolume {
     SKIP_IN_TRAVIS()
     RUN_LUA_TEST()

--- a/extensions/audiodevice/test_audiodevice.lua
+++ b/extensions/audiodevice/test_audiodevice.lua
@@ -158,6 +158,21 @@ function testMute()
   return success()
 end
 
+function testThru()
+  local device = hs.audiodevice.defaultInputDevice()
+  local wasThru = device:thru()
+  if (type(wasThru) ~= "boolean") then
+    -- This device does not support thru. Not much we can do about it, so log it and move on
+    print("Audiodevice does not support thru, unable to test thru functionality. Skipping test due to lack of hardware")
+    return success()
+  end
+  device:setThru(not wasThru)
+  assertIsEqual(not wasThru, device:thru())
+  -- Be nice to whoever is running the test and restore the original state
+  device:setThru(wasThru)
+  return success()
+end
+
 function testJackConnected()
   local jackConnected = hs.audiodevice.defaultOutputDevice():jackConnected()
   if (type(jackConnected) ~= "boolean") then


### PR DESCRIPTION
```
hs.audiodevice:thru() -> bool or nil
hs.audiodevice:setThru(thru) -> bool
```

Get or set the play through (low-latency/direct monitoring) state of the the audio device via `kAudioDevicePropertyPlayThru`. This is the feature of some microphones where they can play their input directly to their output (e.g. headphone jack) so you can get low-latency feedback while recording.

* This only works on devices that have hardware support (often microphones with a built-in headphone jack)
* This setting corresponds to the "Thru" setting in Audio MIDI Setup
* I only have one device to test with, it's a combo input/output device. I'm unsure if they're ever split into multiple devices? I decompiled Audio MIDI Setup (before I got around to installing Xcode) and it does seem to do a conditional check, supporting both input and output devices, before setting thru.
   * I don't think we need separate `hs.audiodevice:setInputThru(state)` and `hs.audiodevice:setOutputThru(state)`?

(I have a USB microphone that annoyingly enables this every time is reconnected or I reboot, I want to script disabling it. This could also be useful for other users who like this setting, but perhaps want do something like assign it a keyboard shortcut.)

