### PR TITLE
The event handler might receive an invalid pid

### DIFF
--- a/extensions/window/window_filter.lua
+++ b/extensions/window/window_filter.lua
@@ -1375,7 +1375,14 @@ local windowWatcherDelayed={}
 
 appWindowEvent=function(win,event,_,pid,retry)
   if not win:isWindow() then return end
-  local appname = application.applicationForPID(pid):name()
+  local app = application.applicationForPID(pid)
+  if not app then
+    -- it is very likely the PID died/terminated before this code
+    -- gets executed
+    -- simply ignore event
+    return
+  end
+  local appname = app:name()
   local role=win.subrole and win:subrole()
   if appname=='Hammerspoon' and (not role or role=='AXUnknown') then return end
   local id = win.id and win:id()


### PR DESCRIPTION
Sometimes an app generates an event just before dying/terminating

thus the event handler tries to retrieve the app of the PID but it is no longer available. This patch avoids a crash due to not finding the app for the given pid