### PR TITLE
chooser: optimize performance

### DIFF
--- a/extensions/chooser/HSChooser.h
+++ b/extensions/chooser/HSChooser.h
@@ -36,6 +36,7 @@
 @property(nonatomic) NSColor *subTextColor;
 
 @property(nonatomic, retain) NSFont *font;
+@property(nonatomic, retain) NSImage *defaultImage;
 
 // Size information we calculate for ourselves
 @property(nonatomic) NSRect winRect;

--- a/extensions/chooser/HSChooser.m
+++ b/extensions/chooser/HSChooser.m
@@ -58,6 +58,9 @@
             self.font = [NSFont fontWithName:self.fontName size:self.fontSize];
         }
 
+        // Cache the default placeholder image
+        self.defaultImage = [NSImage imageNamed:NSImageNameFollowLinkFreestandingTemplate];
+
         [self calculateRects];
 
         if (![self setupWindow]) {
@@ -360,7 +363,7 @@
     }
 
     cellView.shortcutText.stringValue = shortcutText ? shortcutText : @"??";
-    cellView.image.image = image ? image : [NSImage imageNamed:NSImageNameFollowLinkFreestandingTemplate];
+    cellView.image.image = image ? image : self.defaultImage;
 
     if (self.fgColor) {
         cellView.text.textColor = self.fgColor;
@@ -464,18 +467,19 @@
         // We do not have a query callback set, so we are doing the filtering
         if (queryString.length > 0) {
             NSMutableArray *filteredChoices = [[NSMutableArray alloc] init];
+            NSString *lowercaseQuery = [queryString lowercaseString];
 
             for (NSDictionary *choice in [self getChoicesWithOptions:NO]) {
                 NSString *text = [choice objectForKey:@"text"];
-                if (text && ![text isKindOfClass:[NSString class]]) text = [NSString stringWithFormat:@"%@", text] ;
-                if (!text) text = @"" ;
-                if ([[text lowercaseString] containsString:[queryString lowercaseString]]) {
-                    [filteredChoices addObject: choice];
+                if (text && ![text isKindOfClass:[NSString class]]) text = [NSString stringWithFormat:@"%@", text];
+                if (!text) text = @"";
+                if ([[text lowercaseString] containsString:lowercaseQuery]) {
+                    [filteredChoices addObject:choice];
                 } else if (self.searchSubText) {
                     NSString *subText = [choice objectForKey:@"subText"];
-                    if (subText && ![subText isKindOfClass:[NSString class]]) subText = [NSString stringWithFormat:@"%@", subText] ;
-                    if (!subText) subText = @"" ;
-                    if ([[subText lowercaseString] containsString:[queryString lowercaseString]]) {
+                    if (subText && ![subText isKindOfClass:[NSString class]]) subText = [NSString stringWithFormat:@"%@", subText];
+                    if (!subText) subText = @"";
+                    if ([[subText lowercaseString] containsString:lowercaseQuery]) {
                         [filteredChoices addObject:choice];
                     }
                 }
@@ -622,23 +626,23 @@
     _fgColor = fgColor;
     self.queryField.textColor = _fgColor;
 
-    for (int x = 0; x < [self.choicesTableView numberOfRows]; x++) {
-        NSTableCellView *cellView = [self.choicesTableView viewAtColumn:0 row:x makeIfNecessary:NO];
+    [self.choicesTableView enumerateAvailableRowViewsUsingBlock:^(__kindof NSTableRowView *rowView, NSInteger row) {
+        NSTableCellView *cellView = [rowView viewAtColumn:0];
         NSTextField *text = [cellView viewWithTag:1];
         NSTextField *shortcutText = [cellView viewWithTag:2];
         text.textColor = _fgColor;
         shortcutText.textColor = _fgColor;
-    }
+    }];
 }
 
 - (void)setSubTextColor:(NSColor *)subTextColor {
     _subTextColor = subTextColor;
 
-    for (int x = 0; x < [self.choicesTableView numberOfRows]; x++) {
-        NSTableCellView *cellView = [self.choicesTableView viewAtColumn:0 row:x makeIfNecessary:NO];
+    [self.choicesTableView enumerateAvailableRowViewsUsingBlock:^(__kindof NSTableRowView *rowView, NSInteger row) {
+        NSTableCellView *cellView = [rowView viewAtColumn:0];
         NSTextField *subText = [cellView viewWithTag:3];
         subText.textColor = _subTextColor;
-    }
+    }];
 }
 
 - (void)applyDarkSetting:(BOOL)beDark {

--- a/extensions/chooser/HSChooserTableView.h
+++ b/extensions/chooser/HSChooserTableView.h
@@ -21,5 +21,6 @@
 
 @property (nonatomic, weak) id<HSChooserTableViewDelegate> extendedDelegate;
 @property (nonatomic, strong) NSTrackingArea *trackingArea;
+@property (nonatomic, assign) NSInteger lastHoveredRow;
 
 @end

--- a/extensions/chooser/HSChooserTableView.m
+++ b/extensions/chooser/HSChooserTableView.m
@@ -15,6 +15,7 @@
     if (self) {
         self.trackingArea = [[NSTrackingArea alloc] initWithRect:self.frame options:(NSTrackingActiveInKeyWindow|NSTrackingMouseMoved) owner:self userInfo:nil];
         [self addTrackingArea:self.trackingArea];
+        self.lastHoveredRow = -1;
     }
     return self;
 }
@@ -44,7 +45,8 @@
 
     [super mouseMoved:theEvent];
 
-    if (row != -1) {
+    if (row != -1 && row != self.lastHoveredRow) {
+        self.lastHoveredRow = row;
         [self selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
         [self scrollRowToVisible:row];
     }


### PR DESCRIPTION
## Summary
- Pre-lowercase query string once per filter instead of per-row (eliminates O(n) string allocations)
- Track last hovered row to avoid redundant selection updates on mouse move
- Use `enumerateAvailableRowViewsUsingBlock:` for color updates (only iterates visible rows)
- Cache default placeholder image at init instead of per-cell lookup

## Test plan
- [ ] Open chooser with large number of items
- [ ] Type quickly and verify smooth filtering
- [ ] Move mouse over rows and verify smooth selection
- [ ] Change fg/subText colors and verify updates work