### PR TITLE
Add support for Stream Deck Neo, Module 6, Module 15, and Module 32

### DIFF
--- a/extensions/streamdeck/HSStreamDeckManager.m
+++ b/extensions/streamdeck/HSStreamDeckManager.m
@@ -164,6 +164,14 @@ static void HIDdisconnect(void *context, IOReturn result, void *sender, IOHIDDev
                                           productIDKey: @USB_PID_STREAMDECK_PLUS};
         NSDictionary *matchPedal      = @{vendorIDKey:  @USB_VID_ELGATO,
                                           productIDKey: @USB_PID_STREAMDECK_PEDAL};
+        NSDictionary *matchNeo        = @{vendorIDKey:  @USB_VID_ELGATO,
+                                          productIDKey: @USB_PID_STREAMDECK_NEO};
+        NSDictionary *matchModule6    = @{vendorIDKey:  @USB_VID_ELGATO,
+                                          productIDKey: @USB_PID_STREAMDECK_MODULE_6};
+        NSDictionary *matchModule15   = @{vendorIDKey:  @USB_VID_ELGATO,
+                                          productIDKey: @USB_PID_STREAMDECK_MODULE_15};
+        NSDictionary *matchModule32   = @{vendorIDKey:  @USB_VID_ELGATO,
+                                          productIDKey: @USB_PID_STREAMDECK_MODULE_32};
 
         IOHIDManagerSetDeviceMatchingMultiple((__bridge IOHIDManagerRef)self.ioHIDManager,
                                               (__bridge CFArrayRef)@[matchOriginal,
@@ -174,7 +182,11 @@ static void HIDdisconnect(void *context, IOReturn result, void *sender, IOHIDDev
                                                                      matchXLV2,
                                                                      matchMk2,
                                                                      matchPlus,
-                                                                     matchPedal]);
+                                                                     matchPedal,
+                                                                     matchNeo,
+                                                                     matchModule6,
+                                                                     matchModule15,
+                                                                     matchModule32]);
 
         // Add our callbacks for relevant events
         IOHIDManagerRegisterDeviceMatchingCallback((__bridge IOHIDManagerRef)self.ioHIDManager,
@@ -288,7 +300,27 @@ static void HIDdisconnect(void *context, IOReturn result, void *sender, IOHIDDev
         case USB_PID_STREAMDECK_PEDAL:
             deck = [[HSStreamDeckDevicePedal alloc] initWithDevice:device manager:self];
             break;
-            
+
+        case USB_PID_STREAMDECK_NEO:
+            // Neo has 8 keys (4x2) - using Mini class as closest match
+            deck = [[HSStreamDeckDeviceMini alloc] initWithDevice:device manager:self];
+            break;
+
+        case USB_PID_STREAMDECK_MODULE_6:
+            // Module 6 has 6 keys (3x2), same layout as Mini
+            deck = [[HSStreamDeckDeviceMini alloc] initWithDevice:device manager:self];
+            break;
+
+        case USB_PID_STREAMDECK_MODULE_15:
+            // Module 15 has 15 keys (5x3), same as MK2
+            deck = [[HSStreamDeckDeviceMk2 alloc] initWithDevice:device manager:self];
+            break;
+
+        case USB_PID_STREAMDECK_MODULE_32:
+            // Module 32 has 32 keys (8x4), same as XL
+            deck = [[HSStreamDeckDeviceXL alloc] initWithDevice:device manager:self];
+            break;
+
         default:
             NSLog(@"deviceDidConnect from unknown device: %d", productID.intValue);
             break;

--- a/extensions/streamdeck/streamdeck.h
+++ b/extensions/streamdeck/streamdeck.h
@@ -24,5 +24,9 @@ static const char *USERDATA_TAG = "hs.streamdeck";
 #define USB_PID_STREAMDECK_MK2         0x0080
 #define USB_PID_STREAMDECK_PLUS        0x0084
 #define USB_PID_STREAMDECK_PEDAL       0x0086
+#define USB_PID_STREAMDECK_NEO         0x009A
+#define USB_PID_STREAMDECK_MODULE_6    0x00B8
+#define USB_PID_STREAMDECK_MODULE_15   0x00B9
+#define USB_PID_STREAMDECK_MODULE_32   0x00BA
 
 #endif /* streamdeck_h */


### PR DESCRIPTION
Add USB Product IDs and device matching for newer Elgato Stream Deck devices:
- Stream Deck Neo (0x009A) - 8 keys (4x2), uses Mini class
- Stream Deck Module 6 (0x00B8) - 6 keys (3x2), uses Mini class
- Stream Deck Module 15 (0x00B9) - 15 keys (5x3), uses MK2 class
- Stream Deck Module 32 (0x00BA) - 32 keys (8x4), uses XL class

Device PIDs from official Elgato HID documentation: https://docs.elgato.com/streamdeck/hid/