### PR TITLE
Add NSCalendarsFullAccessUsageDescription to Info.plist

### DIFF
--- a/Hammerspoon/Hammerspoon-Info.plist
+++ b/Hammerspoon/Hammerspoon-Info.plist
@@ -214,6 +214,10 @@
 	<string>Hammerspoon needs to send events to automate applications.</string>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Some Hammerspoon extensions (such as hs.calendar) require full access to your calendars.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Some Hammerspoon extensions (such as hs.calendar) require access to your calendars.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Some Hammerspoon extensions require access to the camera.</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
## Problem

Without `NSCalendarsFullAccessUsageDescription` in `Info.plist`, macOS silently refuses to prompt the user for Calendar access. Hammerspoon never appears in System Settings → Privacy & Security → Calendars, and all calendar-data reads (via AppleScript or EventKit) fail silently.

This was reported in #3803.

## Fix

Add the two missing privacy usage description keys, following the same wording pattern as the existing `NSCameraUsageDescription`, `NSMicrophoneUsageDescription`, etc. entries:

- `NSCalendarsFullAccessUsageDescription` — required on macOS 14+ for full EventKit access
- `NSCalendarsUsageDescription` — legacy key, honoured on macOS ≤ 13

## Testing

1. Apply the patch and build
2. Launch Hammerspoon
3. Run in the console:
   ```lua
   hs.osascript.applescript('tell application "Calendar" to get name of every calendar')
   ```
4. macOS should now show the Calendar permission dialog for Hammerspoon

Closes #3803