### PR TITLE
Add `hs.application.hideOtherApplications()` function

### DIFF
--- a/extensions/application/libapplication.m
+++ b/extensions/application/libapplication.m
@@ -436,6 +436,22 @@ static int application_hide(lua_State* L) {
     return 1;
 }
 
+/// hs.application.hideOtherApplications() -> nil
+/// Function
+/// Hides all applications other than the frontmost one.
+///
+/// Parameters:
+///  * None
+///
+/// Returns:
+///  * None
+static int application_hideotherapplications(lua_State* L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L];
+    [skin checkArgs:LS_TBREAK];
+    [[NSWorkspace sharedWorkspace] hideOtherApplications];
+    return 0;
+}
+
 /// hs.application:kill()
 /// Method
 /// Tries to terminate the app gracefully.
@@ -1267,6 +1283,7 @@ static const luaL_Reg moduleLib[] = {
     {"defaultAppForUTI", application_bundleForUTI},
     {"launchOrFocus", application_launchorfocus},
     {"launchOrFocusByBundleID", application_launchorfocusbybundleID},
+    {"hideOtherApplications", application_hideotherapplications},
 
     {NULL, NULL}
 };


### PR DESCRIPTION
## Summary

Adds `hs.application.hideOtherApplications()` — a module-level function that hides all applications other than the frontmost one.

This calls `[[NSWorkspace sharedWorkspace] hideOtherApplications]` directly, providing the programmatic equivalent of **Cmd+Opt+H** (Hide Others).

## Motivation

Currently, hiding all other applications requires either:
- Simulating a keystroke with `hs.eventtap.keyStroke({"cmd", "alt"}, "h")` — works but is indirect
- Iterating `hs.application.runningApplications()` and calling `app:hide()` on each — has race conditions with Safari Web Apps and is slower

A direct API call is cleaner, faster, and avoids edge cases with keystroke simulation.

## Usage

```lua
-- Switch to an app and hide everything else
local app = hs.application.get("com.mitchellh.ghostty")
app:activate(true)
hs.application.hideOtherApplications()
```

## Implementation

- Single function addition to `extensions/application/libapplication.m`
- Registered in the `moduleLib` table (module-level function, not instance method)