### PR TITLE
Replaced `wf.hasWindow` with `not next(wf.windows)` as test to determ…

### DIFF
--- a/extensions/window/window_filter.lua
+++ b/extensions/window/window_filter.lua
@@ -995,7 +995,7 @@ function Window:emitEndChain()
   for wf in pairs(activeInstances) do
     if wf.pending[self] then
       emit(self,wf,windowfilter.windowRejected)
-      if wf.hasWindow then
+      if not next(wf.windows) then
         emit(self,wf,windowfilter.hasNoWindows) -- emit pseudo-event
         wf.hasWindow=nil
       end


### PR DESCRIPTION
Replaced `wf.hasWindow` with `not next(wf.windows)` as test to determine whether or not to emit `hasNoWindows`

Now hasNoWindows will only emit when the last window in the window filter has been rejected.

Fix for [hs.window.filter.hasNoWindows triggers inappropriately](https://github.com/Hammerspoon/hammerspoon/issues/3868)