### PR TITLE
hints: accept numeric keypad keys when hint chars are digits

### DIFF
--- a/extensions/hints/hints.lua
+++ b/extensions/hints/hints.lua
@@ -11,6 +11,7 @@ local modal_hotkey = hotkey.modal
 --- Variable
 --- This controls the set of characters that will be used for window hints. They must be characters found in hs.keycodes.map
 --- The default is the letters A-Z. Note that if `hs.hints.style` is set to "vimperator", this variable will be ignored.
+--- If any of these characters are digits, the equivalent numeric keypad keys (`pad0`-`pad9`) will also select those hints.
 hints.hintChars = {"A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z"}
 
 -- vimperator mode requires to use full set of alphabet to represent applications.
@@ -194,6 +195,10 @@ function hints.setupModal()
 
   for _, c in ipairs(hintChars) do
     k:bind({}, c, function() hints.processChar(c) end)
+    -- Also accept the numeric keypad equivalent when a hint char is a digit
+    if c:match("^%d$") then
+      k:bind({}, "pad"..c, function() hints.processChar(c) end)
+    end
   end
   return k
 end


### PR DESCRIPTION
When `hs.hints.hintChars` is configured with digits, only the number-row keycodes get bound, so the numeric keypad keys (`pad0`-`pad9`) do nothing.

I hit this on a split keyboard where the number row lives on a layer that emits keypad keycodes--so the keypad is how I actually type a digit, and the hints modal was ignoring it.

This binds the matching `padN` keycode alongside each digit hint character. I can work around it by overriding `hints.setupModal()` in my own config, but selecting a digit hint with the digit key (wherever that digit happens to live on the keyboard) seems like it should just be the default.
