### PR TITLE
hs.urlevent: match event names case-insensitively (fixes #3837)

### DIFF
--- a/extensions/urlevent/urlevent.lua
+++ b/extensions/urlevent/urlevent.lua
@@ -71,6 +71,9 @@ local function urlEventCallback(scheme, event, params, fullURL, senderPID)
             log.wf("Something called a " .. hsScheme .. ":// URL without an action")
             return
         end
+        -- Event names are matched case-insensitively (see hs.urlevent.bind()), so
+        -- normalise the incoming event name before looking up its callback
+        event = string.lower(event)
         if not callbacks[event] then
             log.wf("Received hs.urlevent event with no registered callback:"..event)
         else
@@ -103,8 +106,9 @@ urlevent.setCallback(urlEventCallback)
 ---   * senderPID - An integer containing the PID of the sending application, if available (otherwise -1)
 ---   * fullURL - A string containing the full, original URL
 ---  * Given the URL `hammerspoon://doThingA?value=1` The event name is `doThingA` and the callback's `params` argument will be a table containing `{["value"] = "1"}` and `fullURL` will be `hammerspoon://doThingA?value=1`
+---  * Event names are matched case-insensitively (i.e. binding `doThingA` will also match `hammerspoon://dothinga`), because macOS normalises the host portion of a URL to lowercase before it is delivered to Hammerspoon
 function urlevent.bind(eventName, callback)
-    callbacks[eventName] = callback
+    callbacks[string.lower(eventName)] = callback
 end
 
 --- hs.urlevent.openURL(url)


### PR DESCRIPTION
## Summary

Since #3691 (commit `5395f34`), the ObjC layer lowercases `url.host` before delivering it to the Lua callback, so the event name reaching `urlEventCallback` is always lowercase. But `hs.urlevent.bind()` stored the callback under the user's *original-case* event name, so `hs.urlevent.bind("myEvent", …)` could never match the delivered `myevent`, logging *"Received hs.urlevent event with no registered callback"*. This showed up on macOS Tahoe / Hammerspoon 1.1.0, the first release carrying #3691. Matches @cmsj's suggestion in the issue thread to "lowercase the name at binding time too."

## Change

Normalize event names to lowercase in both `bind()` (storage) and the dispatch lookup, so bindings match regardless of the case used in either the config or the URL. Removal via `bind(name, nil)` is normalized the same way. Docstring updated to note the case-insensitive matching.

## Repro (before this PR)

```lua
hs.urlevent.bind("myEvent", function() hs.alert.show("fired") end)
```

`open -g hammerspoon://myEvent` → *"...no registered callback: myevent"*. Lowercasing the bind name was the only workaround.

## Testing

Verified by loading the module (pre- and post-fix) with stubbed dependencies and simulating a delivered (host-lowercased) event: mixed-case binds now fire for both mixed- and lower-case URLs; lowercase binds keep working; `bind(name, nil)` unbinds across cases. A full XCTest for `urlevent` would require new `HSurlevent.m` scaffolding plus URL-event injection (not currently present); happy to add it if desired.

Fixes #3837
