### PR TITLE
Fix window animations overshooting on mixed-scale displays (#3852)

### DIFF
--- a/extensions/window/window.lua
+++ b/extensions/window/window.lua
@@ -275,16 +275,20 @@ local function animate()
   local time = timer.secondsSinceEpoch()
   for id,anim in pairs(animations) do
     local r = quadOut(time,anim.time,anim.duration)
-    local f = {}
+    local win = anim.window
     if r>=1 then
-      f=anim.endFrame
       animations[id] = nil
+      -- final frame: use the AXEnhancedUserInterface-managed _setFrame() for pixel-correct placement
+      win:_setFrame(anim.endFrame)
     else
+      local f = {}
       for _,k in pairs{'x','y','w','h'} do
         f[k] = anim.startFrame[k] + (anim.endFrame[k]-anim.startFrame[k])*r
       end
+      -- intermediate frames: plain size,position,size resize *without* toggling AXEnhancedUserInterface;
+      -- toggling it on every animation tick corrupts the window geometry on mixed-scale displays (#3852)
+      win:_setSize(f) win:_setTopLeft(f) win:_setSize(f)
     end
-    anim.window:_setFrame(f)
   end
   if not next(animations) then animTimer:setNextTrigger(DISTANT_FUTURE) end
 end


### PR DESCRIPTION
Fixes #3852.

On multi-display setups where the displays have different scale factors, an animated `window:moveToScreen()` / `setFrame()` overshoots the right and bottom edges of the target screen. The window renders larger than requested even though `:size()` reports the correct value. Passing `duration = 0` (no animation) always lands correctly.

Cause: 04b4c3b and 540faee (both 2025-12-17) replaced the old side-effect-free Lua `_setFrame` (`setSize; setTopLeft; setSize`) with a C `_setFrame` that disables and re-enables `AXEnhancedUserInterface` around the move. The animation loop in `extensions/window/window.lua` calls `_setFrame` on every 17 ms tick, so a single animated move now toggles `AXEnhancedUserInterface` roughly a dozen times while the window crosses a scale boundary. That per-tick churn re-applies the enhanced-UI scale transform to intermediate frames and leaves the window rendered too large. The `duration = 0` path toggles it once, which is why it works.

Fix: intermediate animation frames now use the lightweight three-step resize without touching `AXEnhancedUserInterface` (the pre-December behavior, fine for throwaway interpolation frames), and only the final frame uses the EUI-managed `_setFrame`, identical to the `duration = 0` path. Side benefit: far fewer AX round-trips per animation.

Testing: verified by code trace and the reporter's measurements (their target-frame math is provably correct, so the fault is isolated to the animated apply step). I only have a single display here, so confirmation from someone with differently-scaled displays would be appreciated; the reporter's recipe reproduces it.

An alternative would be disabling EUI once at animation start and restoring at the end, but that needs state tracking across ticks and stopAnimation interruptions; this version is self-contained.