### PR TITLE
Add NSBluetoothAlwaysUsageDescription to Info.plist

### DIFF
--- a/Hammerspoon/Hammerspoon-Info.plist
+++ b/Hammerspoon/Hammerspoon-Info.plist
@@ -214,6 +214,8 @@
 	<string>Hammerspoon needs to send events to automate applications.</string>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Some Hammerspoon configurations require access to Bluetooth (for example, to connect and disconnect Bluetooth devices).</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Some Hammerspoon extensions require access to the camera.</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
macOS requires a usage description string before an app may touch the Bluetooth APIs. Without one the system does not prompt for consent — it terminates the offending process outright, so Hammerspoon can never appear in System Settings → Privacy & Security → Bluetooth and can never be granted access.

This shows up two ways:

- Hammerspoon crashing on launch with `Termination Reason: Namespace TCC, Code 0`, whose crash report names this exact key (#3684).
- Configs that shell out to Bluetooth tools such as `blueutil`, where the child process is killed with SIGABRT. TCC attributes the access to the responsible process, so the spawned tool inherits Hammerspoon's inability to be granted Bluetooth.

Verified on macOS 26.5.2: a `blueutil` invocation from `hs.task` dies with exit 134 and no consent prompt, and `tccutil reset BluetoothAlways org.hammerspoon.Hammerspoon` does not help because there is nothing to prompt with. The same binary launched from a bundle that *does* declare the key prompts normally and works.

Adding the key does not grant access or trigger a prompt on its own — it only makes consent possible when something actually uses Bluetooth. This is deliberately not a proposal for an `hs.bluetooth` module (#793); it is just the one string that lets users grant the permission themselves.

Refs #3684

🤖 Generated with [Claude Code](https://claude.com/claude-code)