### PR TITLE
Prevent recursion in print() replacement: don't call log.w()

### DIFF
--- a/extensions/ipc/ipc.lua
+++ b/extensions/ipc/ipc.lua
@@ -68,7 +68,7 @@ local printReplacement = function(...)
     for id,v in pairs(module.__registeredCLIInstances) do
         if v._cli.console and v.print and not v._cli.quietMode then
           if module.print_inside(id) then
-            log.w(string.format("Instance of [%s] already recursing, refusing request.", id))
+            originalPrint(string.format("Instance of [%s] already recursing, refusing request.", id))
           else
             module.print_enter(id)
             --            v.print(...)


### PR DESCRIPTION
log.w() calls print() which causes a recursion, so don't call it in print() replacement.

See https://github.com/Hammerspoon/hammerspoon/issues/3872