### PR TITLE
hs.task: push the last gasp nil onto the main lua_State

### DIFF
--- a/extensions/task/libtask.m
+++ b/extensions/task/libtask.m
@@ -951,7 +951,7 @@ int luaopen_hs_libtask(lua_State* L) {
             if (notLastGasp) {
                 [_skin pushLuaRef:refTable ref:userData->selfRef];
             } else {
-                lua_pushnil(L) ;
+                lua_pushnil(_L) ;
             }
             [_skin pushNSObject:stdOutArg];
             [_skin pushNSObject:stdErrArg];


### PR DESCRIPTION
Fixes #3883.

`luaopen_hs_libtask` captures the `lua_State` it is called with, and the
`NSFileHandleReadCompletionNotification` observer it installs closes over that state for the
lifetime of the application. Every push inside the observer goes through `_skin` or `_L`, both
resolved from `[LuaSkin sharedWithState:NULL]` and therefore the main state, except the last gasp
branch at `libtask.m:954`, which pushed onto the captured `L`.

Since `hs.<ext>` is required lazily on first access, `L` is whichever state first touched
`hs.task`. If that first touch happens inside a coroutine, `L` is the coroutine's state, so the
`nil` lands there rather than on the main state. `protectedCallAndTraceback:3` then finds three
values where it wants four, and its `lua_insert(self.L, -nargs - 2)` (`Skin.m:412-413`) walks off
the frame. The `lua` target builds with `-DLUA_USE_APICHECK` in all three configurations, so
`index2stack`'s `api_check` at `lapi.c:103` aborts the process. There is no Lua traceback and the
whole app goes down.

I ran into this writing a coroutine based driver for `hs.task`. The issue has a minimal reproducer
and a matched control that differs only in which state loaded the extension.

This is the same defect #3165 fixed in `libhttp.m`, where the delegate's stored `lua_State*` was
removed and its pushes moved to `skin.L`. The #3166 sweep that followed it did not reach
`libtask.m`.

## On tests

CONTRIBUTING.md asks for tests alongside extension changes and I have not added one. My reasoning,
in case you disagree with it:

The state half of the precondition is testable. `HSTestCase`'s `tearDown` calls `MJLuaReplace()`,
so each test method starts on a virgin `lua_State`, and `task_metagc` removes the stale observer
when the old state closes. It would need a new test class with its own Lua file, because
`extensions/task/test_task.lua:1` does `hs.task = require("hs.task")` at file scope, which binds
the observer to the main state before any test body in `HStask` runs.

The other half is the problem. The branch only executes when `userData->selfRef == LUA_NOREF`
(`libtask.m:949`), meaning a read completion notification delivered after the termination handler
has released `selfRef`. That is a race between two main run loop deliveries, and it is the
behaviour documented as "may be invoked one last time" at `libtask.m:197`. I could not find a way
to force it from Lua. A test built on it would pass against the unfixed build whenever the race
went the other way, so I cannot show it reliably failing before the fix, which makes it worse than
no test. And in the runs where it did catch a regression the symptom is `abort()`, so it would
take down the XCTest runner and discard every test after it rather than reporting a failure.

Making this properly testable needs a deterministic way into that branch, something like a debug
only hook that forces `selfRef = LUA_NOREF` and posts a synthetic notification. I am happy to add
that if you want it, but it felt out of proportion to a one line fix and like something to agree
on first.

## Not built locally

I have not compiled this. I have Xcode but not the Cocoapods setup the workspace needs, and I did
not want to imply a build I had not run. `_L` is declared at `libtask.m:931` in the same block, so
the change is in scope, but CI is the real check here.
