### PR TITLE
hs.ipc: stop the print re-entrancy guard from recursing into itself

### DIFF
--- a/extensions/ipc/ipc.lua
+++ b/extensions/ipc/ipc.lua
@@ -66,9 +66,13 @@ local originalPrint = print
 local printReplacement = function(...)
     originalPrint(...)
     for id,v in pairs(module.__registeredCLIInstances) do
-        if v._cli.console and v.print and not v._cli.quietMode then
+        if v._cli.console and v._cli.console ~= "none" and v.print and not v._cli.quietMode then
           if module.print_inside(id) then
-            log.w(string.format("Instance of [%s] already recursing, refusing request.", id))
+            -- Do not use log.w() here: hs.logger formats its output with hs.printf,
+            -- which calls the *global* print -- i.e. this function. The warning would
+            -- re-enter printReplacement with the recursion counter still raised, trip
+            -- this guard again, and loop until Hammerspoon dies. Print directly.
+            originalPrint(string.format("%s: Instance of [%s] already recursing, refusing request.", USERDATA_TAG, id))
           else
             module.print_enter(id)
             --            v.print(...)


### PR DESCRIPTION
This diagnosis and patch were written by Claude Fable 5.1, an Anthropic model, on behalf of @NightMachinery.

Fixes #3872.

## What you see

A flood of `Instance of [...] already recursing, refusing request.` — tens of thousands of lines in seconds — a hung `hs` client, and sometimes a Hammerspoon crash.

## The guard is the loop

`extensions/ipc/ipc.lua:66-86` replaces the global `print` to mirror console output to registered CLI instances, with a re-entrancy guard:

```lua
if module.print_inside(id) then
    log.w(string.format("Instance of [%s] already recursing, refusing request.", id))
```

`log.w` goes through `hs.logger`, which formats with `hs.printf`, and `hs.printf` (`extensions/_coresetup/_coresetup.lua:26`) is:

```lua
function hs.printf(fmt,...) return print(sformat(fmt,...)) end
```

It resolves the global `print` at call time — which is `printReplacement`. So when a print nests inside the mirroring path, the guard trips, its own warning re-enters `printReplacement` with the counter still raised, trips the guard again, and recurses without bound. The guard suppresses the payload but not its own diagnostic.

## Why an ordinary `hs -c` reaches it

`ipc.lua:374` defaults an instance's console mode to the string `"none"`, which is truthy in Lua, so `if v._cli.console` (line 69) is true for *every* instance. Console mirroring is therefore on for a plain `hs -c` even without `-C`, which is what makes the loop reachable from a command whose first use of an extension prints `-- Loading extension: ...`.

## The change

- Emit the guard's warning via the saved `originalPrint`, so it can reach the console but never the mirror. Wording is unchanged, prefixed with the module tag since it no longer goes through the logger.
- Test `v._cli.console ~= "none"` rather than changing the default to `nil`. Defaulting to `nil` is *not* safe here: the per-instance `print` at `ipc.lua:410` does `if type(parent.console) == "nil" then originalPrint(...) end`, a branch that is currently dead because `console` is always one of `"none"`/`"mirror"`/`"legacy"`. A `nil` default would resurrect it and echo all `hs -c` output into the Hammerspoon console. The explicit comparison keeps `-C` (`"mirror"`) and `-P` (`"legacy"`) behaving exactly as before.

Nothing else is touched.

## Reproducing

With mirroring reachable (before this patch, any `hs -c`; after it, `hs -C -c`), run a command in which a print nests inside another print:

```
hs -c 'local p=print; print=function(...) p("nested",...) p(...) end; print("outer"); print=p'
```

Before: an unbounded flood of `already recursing` and a client timeout. After: the nested print is refused once per print, with a single line each, and the client returns.

## Checks

`luac5.4 -p extensions/ipc/ipc.lua` passes. `luacheck` was not available in this environment. Hammerspoon itself was not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
