### PR TITLE
Fix stale frames on retained screen objects

### DIFF
--- a/Hammerspoon Tests/HSscreen.m
+++ b/Hammerspoon Tests/HSscreen.m
@@ -67,6 +67,18 @@
     RUN_LUA_TEST()
 }
 
+- (void)testRetainedScreenFrameAfterDockChange {
+    RUN_LUA_TEST()
+}
+
+- (void)testRetainedScreenFramesAfterDisplayChange {
+    RUN_LUA_TEST()
+}
+
+- (void)testRetainedScreenFramesAfterDisconnect {
+    RUN_LUA_TEST()
+}
+
 - (void)testFromUnitRect {
     RUN_LUA_TEST()
 }

--- a/extensions/screen/screen.lua
+++ b/extensions/screen/screen.lua
@@ -179,6 +179,9 @@ function screenObject:position()
     if s:id()==id then return p.x,p.y end
   end
 end
+
+local getScreenFrame
+
 --- hs.screen:fullFrame() -> hs.geometry rect
 --- Method
 --- Returns the screen frame, including the dock and menu.
@@ -189,10 +192,7 @@ end
 --- Returns:
 ---  * an hs.geometry rect describing this screen's frame in absolute coordinates
 function screenObject:fullFrame()
-  local primary_screen = screen.allScreens()[1]
-  local f = self:_frame()
-  f.y = primary_screen:_frame().h - f.h - f.y
-  return geometry(f)
+  return getScreenFrame(self, "_frame")
 end
 
 --- hs.screen:frame() -> hs.geometry rect
@@ -205,8 +205,22 @@ end
 --- Returns:
 ---  * an hs.geometry rect describing this screen's "usable" frame (i.e. without the dock and menu bar) in absolute coordinates
 function screenObject:frame()
-  local primary_screen = screen.allScreens()[1]
-  local f = self:_visibleframe()
+  return getScreenFrame(self, "_visibleframe")
+end
+
+getScreenFrame = function(self, method)
+  local screens = screen.allScreens()
+  local primary_screen = screens[1]
+  local id = self:id()
+  -- Retained NSScreen objects can have stale bounds after the configuration changes.
+  -- Keep the stored bounds if the display is no longer connected.
+  for _, current in ipairs(screens) do
+    if current:id() == id then
+      self = current
+      break
+    end
+  end
+  local f = self[method](self)
   f.y = primary_screen:_frame().h - f.h - f.y
   return geometry(f)
 end

--- a/extensions/screen/test_screen.lua
+++ b/extensions/screen/test_screen.lua
@@ -1,6 +1,8 @@
 hs.screen = require("hs.screen")
 hs.geometry = require("hs.geometry")
 
+local createTestContext
+
 function testMainScreen()
   local screen = hs.screen.mainScreen()
   assertIsUserdataOfType("hs.screen", screen)
@@ -120,6 +122,77 @@ function testFromUnitRect()
   local unitFrame = primary:fromUnitRect(hs.geometry.unitrect(0, 0, 1, 1))
 
   assertIsEqual(frame, unitFrame)
+
+  return success()
+end
+
+function testRetainedScreenFrameAfterDockChange()
+  -- Arrange
+  local context = createTestContext()
+  local savedScreen = context.laptop
+
+  context.withScreens(function()
+    assertIsEqual(hs.geometry(0, 33, 1728, 1084), savedScreen:frame())
+
+    -- Act
+    context.screens = {
+      context.createScreen(1, {0, 0, 1728, 1117}, {0, 116, 1728, 968}),
+      context.external,
+    }
+    local frame = savedScreen:frame()
+
+    -- Assert
+    assertIsEqual(hs.geometry(0, 33, 1728, 968), frame)
+    assertIsEqual(frame, savedScreen:fromUnitRect(hs.geometry.unitrect(0, 0, 1, 1)))
+  end)
+
+  return success()
+end
+
+function testRetainedScreenFramesAfterDisplayChange()
+  -- Arrange
+  local context = createTestContext()
+  local savedLaptop = context.laptop
+  local savedExternal = context.external
+
+  context.withScreens(function()
+    assertIsEqual(hs.geometry(1728, 37, 1920, 1080), savedExternal:fullFrame())
+
+    -- Act: change the primary display, resolution, and layout.
+    context.screens = {
+      context.createScreen(2, {0, 0, 2560, 1440}, {0, 80, 2560, 1336}),
+      context.createScreen(1, {-1728, 1440, 1728, 1117}, {-1728, 1440, 1728, 1084}),
+    }
+    local externalFrame = savedExternal:fullFrame()
+    local laptopFrame = savedLaptop:fullFrame()
+    local externalVisibleFrame = savedExternal:frame()
+    local laptopVisibleFrame = savedLaptop:frame()
+
+    -- Assert
+    assertIsEqual(hs.geometry(0, 0, 2560, 1440), externalFrame)
+    assertIsEqual(hs.geometry(-1728, -1117, 1728, 1117), laptopFrame)
+    assertIsEqual(hs.geometry(0, 24, 2560, 1336), externalVisibleFrame)
+    assertIsEqual(hs.geometry(-1728, -1084, 1728, 1084), laptopVisibleFrame)
+  end)
+
+  return success()
+end
+
+function testRetainedScreenFramesAfterDisconnect()
+  -- Arrange
+  local context = createTestContext()
+  local savedScreen = context.external
+
+  context.withScreens(function()
+    -- Act
+    context.screens = {context.laptop}
+    local frame = savedScreen:fullFrame()
+    local visibleFrame = savedScreen:frame()
+
+    -- Assert: preserve the saved bounds when the display is unavailable.
+    assertIsEqual(hs.geometry(1728, 37, 1920, 1080), frame)
+    assertIsEqual(hs.geometry(1728, 61, 1920, 1056), visibleFrame)
+  end)
 
   return success()
 end
@@ -338,4 +411,33 @@ function testToUnitRect()
   assertIsEqual(unitRect.h, 1.0)
 
   return success()
+end
+
+createTestContext = function()
+  local context = {}
+
+  context.createScreen = function(id, frame, visibleFrame)
+    return setmetatable({
+      id = function() return id end,
+      _frame = function()
+        return {x = frame[1], y = frame[2], w = frame[3], h = frame[4]}
+      end,
+      _visibleframe = function()
+        return {x = visibleFrame[1], y = visibleFrame[2], w = visibleFrame[3], h = visibleFrame[4]}
+      end,
+    }, {__index = hs.getObjectMetatable("hs.screen")})
+  end
+
+  context.withScreens = function(callback)
+    local allScreens = hs.screen.allScreens
+    hs.screen.allScreens = function() return context.screens end
+    local ok, err = xpcall(callback, debug.traceback)
+    hs.screen.allScreens = allScreens
+    if not ok then error(err, 0) end
+  end
+
+  context.laptop = context.createScreen(1, {0, 0, 1728, 1117}, {0, 0, 1728, 1084})
+  context.external = context.createScreen(2, {1728, 0, 1920, 1080}, {1728, 0, 1920, 1056})
+  context.screens = {context.laptop, context.external}
+  return context
 end


### PR DESCRIPTION
Saving an `hs.screen` object and changing the Dock can leave `frame()` returning the old usable area. `fullFrame()` can also keep old bounds after display changes. The saved object retains an old `NSScreen` instance.

Both methods now resolve the current screen by display ID before reading its bounds. They preserve the existing fallback for disconnected displays.

The regression tests cover Dock changes, display resolution and layout changes, and disconnected screens.
